### PR TITLE
Added scribble file extension to Racket.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -615,6 +615,7 @@ Racket:
   - .rkt
   - .rktl
   - .rktd
+  - .scrbl
 
 Raw token data:
   search_term: raw


### PR DESCRIPTION
This is our documentation language, http://docs.racket-lang.org/scribble/,
and the files are still racket files even though the syntax looks completely
different.
