### PR TITLE
Add .rbuild as Ruby extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -654,6 +654,7 @@ Ruby:
   - .gemspec
   - .irbrc
   - .thor
+  - .rbuild
   filenames:
   - Capfile
   - Rakefile


### PR DESCRIPTION
Hope it's not a problem to add a minor thing in the extensions, rbuilds are build scripts for my package manager written in Ruby, so it would make me happy to have them highlighted in Ruby on github.

Thanks.
