### PR TITLE
matlab scripts use .m not .matlab.  

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -475,7 +475,7 @@ Markdown:
 
 Matlab:
   extensions:
-  - .matlab
+  - .m
 
 Max/MSP:
   major: true


### PR DESCRIPTION
matlab scripts use .m not .matlab.  i changed that.  my matlab code is typically incorrectly recognized as objective C
