### PR TITLE
Added support for processing/arduino

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -405,7 +405,6 @@ Java:
   major: true
   extensions:
   - .java
-  - .pde
 
 Java Server Pages:
   group: Java
@@ -588,6 +587,11 @@ Perl:
   - .t
   - .perl
   - .psgi
+
+Processing:
+  lexer: C
+  extensions:
+  - .pde
 
 Pure Data:
   major: true

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -23,6 +23,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Lexer['C'], Language['C'].lexer
     assert_equal Lexer['C'], Language['OpenCL'].lexer
     assert_equal Lexer['C'], Language['XS'].lexer
+    assert_equal Lexer['C'], Language['Processing'].lexer
     assert_equal Lexer['C++'], Language['C++'].lexer
     assert_equal Lexer['CSS'], Language['CSS'].lexer
     assert_equal Lexer['Clojure'], Language['Clojure'].lexer


### PR DESCRIPTION
Added support to identify processing (language used by Arduino) uses C lexer. File extension used is PDE, removed usage from Java. 
From what I could tell it didn't quite work with 2 different language definitions using the same extension. Also the pde extension seems to be used mostly by processing.
