### PR TITLE
Guess if .r is R or REBOL

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -259,6 +259,9 @@ module Linguist
       # If its a header file (.h) try to guess the language
       header_language ||
 
+        # If it's a .r file, try to guess the language
+        r_language ||
+
         # See if there is a Language for the extension
         pathname.language ||
 
@@ -285,6 +288,19 @@ module Linguist
         Language['C++']
       else
         Language['C']
+      end
+    end
+
+    # Internal: Guess language of .r files.
+    #
+    # Returns a Language.
+    def r_language
+      return unless extname == '.r'
+
+      if lines.grep(/(rebol|(:\s+func|make\s+object!|^\s*context)\s*\[)/i).any?
+        Language['Rebol']
+      else
+        Language['R']
       end
     end
 

--- a/test/fixtures/hello-r.R
+++ b/test/fixtures/hello-r.R
@@ -1,0 +1,4 @@
+hello <- function() {
+    print("hello, world!")
+}
+hello()

--- a/test/fixtures/hello-rebol.r
+++ b/test/fixtures/hello-rebol.r
@@ -1,0 +1,5 @@
+REBOL []
+hello: func [] [
+    print "hello, world!"
+]
+hello

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -224,6 +224,10 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Language['Ruby'],        blob("wrong_shebang.rb").language
     assert_nil blob("octocat.png").language
 
+    # .r disambiguation
+    assert_equal Language['R'],           blob("hello-r.R").language
+    assert_equal Language['Rebol'],       blob("hello-rebol.r").language
+
     # ML
     assert_equal Language['OCaml'],       blob("Foo.ml").language
     assert_equal Language['Standard ML'], blob("Foo.sig").language


### PR DESCRIPTION
.r is the default extension used widely for both, R and REBOL. This patch attempts to guess if .r is a REBOL file by looking for the following very common REBOL code fragments:
- `REBOL`
- `: func [`
- `make object! [`
- `context [`

If any of those is found in a .r file, it is identified as a REBOL file. Otherwise the language for a .r file is R.

A few examples of repositories on Github containing REBOL code which are currently incorrectly classified as R:
- https://github.com/carls/R3A110
- https://github.com/dockimbel/Red
- https://github.com/earl/vanilla
- https://github.com/henrikmk/VID-Extension-Kit
- https://github.com/oldes/REBOL-scripts
- https://github.com/rebolsource/rebol-test
