### PR TITLE
Languages extension to string

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -25,464 +25,464 @@ ASP:
   lexer: aspx-vb
   search_term: aspx-vb
   aliases:
-  - aspx
-  - aspx-vb
+  - "aspx"
+  - "aspx-vb"
   extensions:
-  - .ascx
-  - .axd
-  - .asax
-  - .asmx
-  - .aspx
-  - .ashx
-  - .asp
+  - ".ascx"
+  - ".axd"
+  - ".asax"
+  - ".asmx"
+  - ".aspx"
+  - ".ashx"
+  - ".asp"
 
 ActionScript:
   major: true
   lexer: ActionScript 3
   search_term: as3
   aliases:
-  - as3
+  - "as3"
   extensions:
-  - .as
+  - ".as"
 
 Ada:
   major: true
   extensions:
-  - .adb
-  - .ads
+  - ".adb"
+  - ".ads"
 
 AppleScript:
   extensions:
-  - .scpt
-  - .applescript
+  - ".scpt"
+  - ".applescript"
 
 Arc:
   major: true
   lexer: Text only
   extensions:
-  - .arc
+  - ".arc"
 
 Assembly:
   major: true
   lexer: NASM
   search_term: nasm
   aliases:
-  - nasm
+  - "nasm"
   extensions:
-  - .asm
+  - ".asm"
 
 Batchfile:
   group: Shell
   search_term: bat
   aliases:
-  - bat
+  - "bat"
   extensions:
-  - .bat
-  - .cmd
+  - ".bat"
+  - ".cmd"
 
 Befunge:
   extensions:
-  - .befunge
+  - ".befunge"
 
 BlitzMax:
   extensions:
-  - .bmx
+  - ".bmx"
 
 Boo:
   major: true
   extensions:
-  - .boo
+  - ".boo"
 
 Brainfuck:
   extensions:
-  - .b
-  - .bf
+  - ".b"
+  - ".bf"
 
 C:
   major: true
   extensions:
-  - .c
-  - .h
+  - ".c"
+  - ".h"
 
 C#:
   major: true
   search_term: csharp
   aliases:
-  - csharp
+  - "csharp"
   extensions:
-  - .cs
+  - ".cs"
 
 C++:
   major: true
   search_term: cpp
   aliases:
-  - cpp
+  - "cpp"
   extensions:
-  - .c++
-  - .cc
-  - .cpp
-  - .cu
-  - .cxx
-  - .h++
-  - .hh
-  - .hpp
-  - .hxx
-  - .tcc
+  - ".c++"
+  - ".cc"
+  - ".cpp"
+  - ".cu"
+  - ".cxx"
+  - ".h++"
+  - ".hh"
+  - ".hpp"
+  - ".hxx"
+  - ".tcc"
 
 C-ObjDump:
   lexer: c-objdump
   extensions:
-  - .c-objdump
+  - ".c-objdump"
 
 CSS:
   extensions:
-  - .css
+  - ".css"
 
 ChucK:
   lexer: Java
   extensions:
-  - .ck
+  - ".ck"
 
 Clojure:
   major: true
   extensions:
-  - .clj
+  - ".clj"
 
 CoffeeScript:
   major: true
   extensions:
-  - .coffee
+  - ".coffee"
   filenames:
-  - Cakefile
+  - "Cakefile"
 
 ColdFusion:
   major: true
   lexer: Coldfusion HTML
   search_term: cfm
   aliases:
-  - cfm
+  - "cfm"
   extensions:
-  - .cfm
-  - .cfc
+  - ".cfm"
+  - ".cfc"
 
 Common Lisp:
   major: true
   aliases:
-  - lisp
+  - "lisp"
   extensions:
-  - .lisp
-  - .ny
+  - ".lisp"
+  - ".ny"
 
 Cpp-ObjDump:
   lexer: cpp-objdump
   extensions:
-  - .cppobjdump
-  - .c++objdump
-  - .cxx-objdump
+  - ".cppobjdump"
+  - ".c++objdump"
+  - ".cxx-objdump"
 
 Cucumber:
   lexer: Gherkin
   extensions:
-  - .feature
+  - ".feature"
 
 Cython:
   group: Python
   extensions:
-  - .pyx
-  - .pxd
-  - .pxi
+  - ".pyx"
+  - ".pxd"
+  - ".pxi"
 
 D:
   major: true
   extensions:
-  - .d
-  - .di
+  - ".d"
+  - ".di"
 
 D-ObjDump:
   lexer: d-objdump
   extensions:
-  - .d-objdump
+  - ".d-objdump"
 
 Darcs Patch:
   search_term: dpatch
   aliases:
-  - dpatch
+  - "dpatch"
   extensions:
-  - .darcspatch
-  - .dpatch
+  - ".darcspatch"
+  - ".dpatch"
 
 Delphi:
   major: true
   extensions:
-  - .pas
+  - ".pas"
 
 Diff:
   extensions:
-  - .diff
-  - .patch
+  - ".diff"
+  - ".patch"
 
 Dylan:
   major: true
   extensions:
-  - .dylan
+  - ".dylan"
 
 Eiffel:
   major: true
   lexer: Text only
   extensions:
-  - .e
+  - ".e"
 
 Emacs Lisp:
   major: true
   lexer: Scheme
   aliases:
-  - elisp
+  - "elisp"
   extensions:
-  - .el
-  - .emacs
+  - ".el"
+  - ".emacs"
 
 Erlang:
   major: true
   extensions:
-  - .hrl
-  - .erl
+  - ".hrl"
+  - ".erl"
 
 F#:
   major: true
   lexer: OCaml
   search_term: ocaml
   extensions:
-  - .fs
-  - .fsi
-  - .fsx
+  - ".fs"
+  - ".fsi"
+  - ".fsx"
 
 FORTRAN:
   major: true
   lexer: Fortran
   extensions:
-  - .f
-  - .f90
-  - .F
-  - .F90
+  - ".f"
+  - ".f90"
+  - ".F"
+  - ".F90"
 
 Factor:
   major: true
   extensions:
-  - .factor
+  - ".factor"
 
 Fancy:
   major: true
   extensions:
-  - .fy
-  - .fancypack
+  - ".fy"
+  - ".fancypack"
 
 GAS:
   group: Assembly
   extensions:
-  - .s
-  - .S
+  - ".s"
+  - ".S"
 
 Genshi:
   extensions:
-  - .kid
+  - ".kid"
 
 Gentoo Ebuild:
   group: Shell
   lexer: Bash
   extensions:
-  - .ebuild
+  - ".ebuild"
 
 Gentoo Eclass:
   group: Shell
   lexer: Bash
   extensions:
-  - .eclass
+  - ".eclass"
 
 Gettext Catalog:
   search_term: pot
   searchable: false
   aliases:
-  - pot
+  - "pot"
   extensions:
-  - .po
-  - .pot
+  - ".po"
+  - ".pot"
 
 Go:
   major: true
   extensions:
-  - .go
+  - ".go"
 
 Groff:
   extensions:
-  - .man
-  - .1
-  - .2
-  - .3
-  - .4
-  - .5
-  - .6
-  - .7
+  - ".man"
+  - ".1"
+  - ".2"
+  - ".3"
+  - ".4"
+  - ".5"
+  - ".6"
+  - ".7"
 
 Groovy:
   major: true
   lexer: Java
   extensions:
-  - .gradle
-  - .groovy
+  - ".gradle"
+  - ".groovy"
 
 HTML:
   extensions:
-  - .html
-  - .xhtml
-  - .htm
-  - .xslt
+  - ".html"
+  - ".xhtml"
+  - ".htm"
+  - ".xslt"
 
 HTML+Django:
   group: HTML
   lexer: HTML+Django/Jinja
   extensions:
-  - .mustache
+  - ".mustache"
 
 HTML+ERB:
   group: HTML
   lexer: RHTML
   extensions:
-  - .erb
-  - .html.erb
+  - ".erb"
+  - ".html.erb"
 
 HTML+PHP:
   group: HTML
   extensions:
-  - .phtml
+  - ".phtml"
 
 HaXe:
   major: true
   lexer: haXe
   extensions:
-  - .hx
-  - .hxml
-  - .mtt
+  - ".hx"
+  - ".hxml"
+  - ".mtt"
 
 Haml:
   extensions:
-  - .haml
+  - ".haml"
 
 Haskell:
   major: true
   extensions:
-  - .hs
-  - .hsc
+  - ".hs"
+  - ".hsc"
 
 INI:
   extensions:
-  - .cfg
-  - .ini
-  - .properties
+  - ".cfg"
+  - ".ini"
+  - ".properties"
   filenames:
-  - .gitconfig
+  - ".gitconfig"
 
 IRC log:
   lexer: IRC logs
   search_term: irc
   aliases:
-  - irc
+  - "irc"
   extensions:
-  - .weechatlog
+  - ".weechatlog"
 
 Io:
   major: true
   extensions:
-  - .io
+  - ".io"
 
 JSON:
   group: JavaScript
   lexer: JavaScript
   search_term: javascript
   extensions:
-  - .json
+  - ".json"
 
 Java:
   major: true
   extensions:
-  - .java
-  - .pde
+  - ".java"
+  - ".pde"
 
 Java Server Pages:
   group: Java
   lexer: Java Server Page
   search_term: jsp
   aliases:
-  - jsp
+  - "jsp"
   extensions:
-  - .jsp
+  - ".jsp"
 
 JavaScript:
   major: true
   aliases:
-  - js
-  - node
+  - "js"
+  - "node"
   extensions:
-  - .js
-  - .sjs
-  - .jss
-  - .ssjs
-  - .jsx
-  - .jake
+  - ".js"
+  - ".sjs"
+  - ".jss"
+  - ".ssjs"
+  - ".jsx"
+  - ".jake"
   filenames:
-  - Jakefile
+  - "Jakefile"
 
 LLVM:
   extensions:
-  - .ll
+  - ".ll"
 
 LilyPond:
   lexer: Text only
   extensions:
-  - .ly
-  - .ily
+  - ".ly"
+  - ".ily"
 
 Literate Haskell:
   group: Haskell
   search_term: lhs
   aliases:
-  - lhs
+  - "lhs"
   extensions:
-  - .lhs
+  - ".lhs"
 
 Lua:
   major: true
   extensions:
-  - .lua
-  - .nse
+  - ".lua"
+  - ".nse"
 
 Makefile:
   extensions:
-  - .mak
+  - ".mak"
   filenames:
-  - Makefile
+  - "Makefile"
 
 Mako:
   extensions:
-  - .mao
+  - ".mao"
 
 Markdown:
   lexer: Text only
   extensions:
-  - .md
-  - .mkd
-  - .mkdown
-  - .markdown
-  - .ron
+  - ".md"
+  - ".mkd"
+  - ".mkdown"
+  - ".markdown"
+  - ".ron"
 
 Matlab:
   extensions:
-  - .matlab
+  - ".matlab"
 
 Max/MSP:
   major: true
   lexer: Text only
   extensions:
-  - .mxt
+  - ".mxt"
 
 MiniD: # Legacy
   searchable: false
@@ -492,374 +492,374 @@ Mirah:
   lexer: Ruby
   search_term: ruby
   extensions:
-  - .duby
-  - .mir
-  - .mirah
+  - ".duby"
+  - ".mir"
+  - ".mirah"
 
 Moocode:
   lexer: MOOCode
   extensions:
-  - .moo
+  - ".moo"
 
 Myghty:
   extensions:
-  - .myt
+  - ".myt"
 
 Nimrod:
   extensions:
-  - .nim
+  - ".nim"
 
 Nu:
   major: true
   lexer: Scheme
   aliases:
-  - nush
+  - "nush"
   extensions:
-  - .nu
+  - ".nu"
   filenames:
-  - Nukefile
+  - "Nukefile"
 
 NumPy:
   group: Python
   extensions:
-  - .numpy
-  - .numsc
-  - .numpyw
+  - ".numpy"
+  - ".numsc"
+  - ".numpyw"
 
 OCaml:
   major: true
   extensions:
-  - .ml
-  - .mly
-  - .mli
-  - .mll
+  - ".ml"
+  - ".mly"
+  - ".mli"
+  - ".mll"
 
 ObjDump:
   lexer: objdump
   extensions:
-  - .objdump
+  - ".objdump"
 
 Objective-C:
   major: true
   extensions:
-  - .m
-  - .mm
+  - ".m"
+  - ".mm"
 
 Objective-J:
   major: true
   extensions:
-  - .j
-  - .sj
+  - ".j"
+  - ".sj"
 
 OpenCL:
   group: C
   lexer: C
   extensions:
-  - .cl
+  - ".cl"
 
 PHP:
   major: true
   extensions:
-  - .php
-  - .aw
-  - .php3
-  - .php4
-  - .php5
-  - .ctp
+  - ".php"
+  - ".aw"
+  - ".php3"
+  - ".php4"
+  - ".php5"
+  - ".ctp"
 
 Parrot Internal Representation:
   lexer: Text only
   search_term: pir
   aliases:
-  - pir
+  - "pir"
   extensions:
-  - .pir
-  - .pbc
-  - .pasm
+  - ".pir"
+  - ".pbc"
+  - ".pasm"
 
 Perl:
   major: true
   extensions:
-  - .pl
-  - .ph
-  - .PL
-  - .pod
-  - .pm
-  - .t
-  - .perl
-  - .psgi
+  - ".pl"
+  - ".ph"
+  - ".PL"
+  - ".pod"
+  - ".pm"
+  - ".t"
+  - ".perl"
+  - ".psgi"
 
 Pure Data:
   major: true
   lexer: Text only
   extensions:
-  - .pd
+  - ".pd"
 
 Python:
   major: true
   extensions:
-  - .py
-  - .pyw
+  - ".py"
+  - ".pyw"
 
 Python traceback:
   group: Python
   lexer: Python Traceback
   search_term: pytb
   aliases:
-  - pytb
+  - "pytb"
   extensions:
-  - .pytb
+  - ".pytb"
 
 R:
   major: true
   lexer: S
   extensions:
-  - .r
-  - .R
+  - ".r"
+  - ".R"
 
 RHTML:
   group: HTML
   extensions:
-  - .rhtml
+  - ".rhtml"
 
 Racket:
   major: true
   lexer: Scheme
   extensions:
-  - .rkt
-  - .rktl
-  - .rktd
-  - .scrbl
+  - ".rkt"
+  - ".rktl"
+  - ".rktd"
+  - ".scrbl"
 
 Raw token data:
   search_term: raw
   aliases:
-  - raw
+  - "raw"
   extensions:
-  - .raw
+  - ".raw"
 
 Rebol:
   lexer: REBOL
   extensions:
-  - .rebol
-  - .r2
-  - .r3
+  - ".rebol"
+  - ".r2"
+  - ".r3"
 
 Redcode:
   extensions:
-  - .cw
+  - ".cw"
 
 Ruby:
   major: true
   aliases:
-  - jruby
-  - macruby
-  - rake
-  - rb
-  - rbx
+  - "jruby"
+  - "macruby"
+  - "rake"
+  - "rb"
+  - "rbx"
   extensions:
-  - .rb
-  - .ru
-  - .builder
-  - .rbw
-  - .rbx
-  - .god
-  - .rake
-  - .gemspec
-  - .irbrc
-  - .thor
-  - .rbuild
+  - ".rb"
+  - ".ru"
+  - ".builder"
+  - ".rbw"
+  - ".rbx"
+  - ".god"
+  - ".rake"
+  - ".gemspec"
+  - ".irbrc"
+  - ".thor"
+  - ".rbuild"
   filenames:
-  - Capfile
-  - Rakefile
-  - Thorfile
-  - Gemfile
+  - "Capfile"
+  - "Rakefile"
+  - "Thorfile"
+  - "Gemfile"
 
 SQL:
   searchable: false
   extensions:
-  - .sql
+  - ".sql"
 
 Sass:
   extensions:
-  - .sass
+  - ".sass"
 
 Scala:
   major: true
   extensions:
-  - .scala
+  - ".scala"
 
 Scheme:
   major: true
   extensions:
-  - .sls
-  - .ss
-  - .sps
-  - .scm
+  - ".sls"
+  - ".ss"
+  - ".sps"
+  - ".scm"
 
 Self:
   major: true
   lexer: Text only
   extensions:
-  - .self
+  - ".self"
 
 Shell:
   major: true
   lexer: Bash
   search_term: bash
   aliases:
-  - sh
-  - bash
-  - zsh
+  - "sh"
+  - "bash"
+  - "zsh"
   extensions:
-  - .bash
-  - .sh
+  - ".bash"
+  - ".sh"
   filenames:
-  - .bash_profile
-  - .bashrc
-  - .profile
-  - .zlogin
-  - .zsh
-  - .zshrc
+  - ".bash_profile"
+  - ".bashrc"
+  - ".profile"
+  - ".zlogin"
+  - ".zsh"
+  - ".zshrc"
 
 Smalltalk:
   major: true
   extensions:
-  - .st
+  - ".st"
 
 Smarty:
   extensions:
-  - .tpl
+  - ".tpl"
 
 Standard ML:
   lexer: OCaml
   aliases:
-  - sml
+  - "sml"
   extensions:
-  - .sig
-  - .sml
+  - ".sig"
+  - ".sml"
 
 SuperCollider:
   major: true
   lexer: Text only
   extensions:
-  - .sc
+  - ".sc"
 
 Tcl:
   major: true
   extensions:
-  - .tcl
+  - ".tcl"
 
 Tcsh:
   group: Shell
   extensions:
-  - .tcsh
-  - .csh
+  - ".tcsh"
+  - ".csh"
 
 TeX:
   extensions:
-  - .tex
-  - .sty
-  - .toc
-  - .cls
-  - .aux
+  - ".tex"
+  - ".sty"
+  - ".toc"
+  - ".cls"
+  - ".aux"
 
 Text:
   lexer: Text only
   extensions:
-  - .txt
+  - ".txt"
 
 Textile:
   lexer: Text only
   extensions:
-  - .textile
+  - ".textile"
 
 VHDL:
   major: true
   lexer: Text only
   extensions:
-  - .vhdl
-  - .vhd
+  - ".vhdl"
+  - ".vhd"
 
 Vala:
   major: true
   extensions:
-  - .vala
+  - ".vala"
 
 Verilog:
   major: true
   lexer: Text only
   extensions:
-  - .v
+  - ".v"
 
 VimL:
   major: true
   search_term: vim
   aliases:
-  - vim
+  - "vim"
   extensions:
-  - .vim
+  - ".vim"
   filenames:
-  - .vimrc
-  - .gvimrc
+  - ".vimrc"
+  - ".gvimrc"
 
 Visual Basic:
   major: true
   lexer: Text only
   extensions:
-  - .bas
-  - .vbs
-  - .frx
-  - .vba
-  - .vb
+  - ".bas"
+  - ".vbs"
+  - ".frx"
+  - ".vba"
+  - ".vb"
 
 XML:
   extensions:
-  - .xml
-  - .rss
-  - .xsl
-  - .wsdl
-  - .xul
-  - .xsd
-  - .plist
-  - .mxml
-  - .rdf
+  - ".xml"
+  - ".rss"
+  - ".xsl"
+  - ".wsdl"
+  - ".xul"
+  - ".xsd"
+  - ".plist"
+  - ".mxml"
+  - ".rdf"
 
 XQuery:
   major: true
   extensions:
-  - .xq
-  - .xqm
-  - .xquery
-  - .xqy
+  - ".xq"
+  - ".xqm"
+  - ".xquery"
+  - ".xqy"
 
 XS:
   lexer: C
   extensions:
-  - .xs
+  - ".xs"
 
 YAML:
   extensions:
-  - .yml
-  - .yaml
+  - ".yml"
+  - ".yaml"
   filenames:
-  - .gemrc
+  - ".gemrc"
 
 mupad:
   lexer: MuPAD
   extensions:
-  - .mu
+  - ".mu"
 
 ooc:
   major: true
   lexer: Ooc
   extensions:
-  - .ooc
+  - ".ooc"
 
 reStructuredText:
   search_term: rst
   aliases:
-  - rst
+  - "rst"
   extensions:
-  - .rst
-  - .rest
+  - ".rst"
+  - ".rest"


### PR DESCRIPTION
This entry

```
Groff:
  extensions:
  - .man
  - .1
  - .2
  - .3
  - .4
  - .5
  - .6
  - .7
```

is causing the error (Extension is missing a '.': 0.1) at https://github.com/christophermanning/linguist/blob/master/lib/linguist/language.rb#L47 since the YAML parser will cast .1, .2, etc. to a float.

I ran a regular expression to quote aliases and extensions by replacing `-\s(.*)\n` with `- "$1"\n` to force the value to be read as a string.
