### PR TITLE
Add TeX language to the set of trackable languages

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -175,7 +175,7 @@ module Linguist
     #
     # Return true or false
     def generated?
-      if ['.xib', '.nib', '.pbxproj'].include?(extname)
+      if ['.xib', '.nib', '.pbxproj', '.toc', '.aux'].include?(extname)
         true
       elsif generated_coffeescript? || minified_javascript?
         true

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -791,6 +791,10 @@ Tcsh:
   - .csh
 
 TeX:
+  type: programming
+  lexer: TeX
+  aliases:
+  - latex
   extensions:
   - .tex
   - .sty

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -204,6 +204,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['Shell'], Language.find_by_alias('shell')
     assert_equal Language['Shell'], Language.find_by_alias('zsh')
     assert_equal Language['TeX'], Language.find_by_alias('tex')
+    assert_equal Language['TeX'], Language.find_by_alias('latex')
     assert_equal Language['Textile'], Language.find_by_alias('textile')
     assert_equal Language['VimL'], Language.find_by_alias('vim')
     assert_equal Language['VimL'], Language.find_by_alias('viml')


### PR DESCRIPTION
TeX was already a language that has syntax highlighting, but I noticed it I was never able to see the percentage of TeX in a repository. So I added TeX as a programming language and made sure that user-made TeX files are counted (by adding some ignore file extensions for the generated files).

Add:
- type, lexer, aliases to TeX in the list of languages
- TeX language test for the latex alias
- Set of generated TeX files to be ignored
