### PR TITLE
REBOL is a programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -676,6 +676,7 @@ Raw token data:
   - .raw
 
 Rebol:
+  type: programming
   lexer: REBOL
   extensions:
   - .r


### PR DESCRIPTION
This sets the language type of REBOL in `languages.yml` to `programming`.
