### PR TITLE
Change the name of Rebol to REBOL

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -385,7 +385,7 @@ module Linguist
     # Returns a Language.
     def guess_r_language
       if lines.grep(/(rebol|(:\s+func|make\s+object!|^\s*context)\s*\[)/i).any?
-        Language['Rebol']
+        Language['REBOL']
       else
         Language['R']
       end

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -676,7 +676,7 @@ Raw token data:
   extensions:
   - .raw
 
-Rebol:
+REBOL:
   type: programming
   lexer: REBOL
   extensions:

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -243,7 +243,7 @@ class TestBlob < Test::Unit::TestCase
 
     # .r disambiguation
     assert_equal Language['R'],           blob("hello-r.R").language
-    assert_equal Language['Rebol'],       blob("hello-rebol.r").language
+    assert_equal Language['REBOL'],       blob("hello-rebol.r").language
 
     # ML
     assert_equal Language['OCaml'],       blob("Foo.ml").language

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -45,7 +45,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Lexer['OCaml'], Language['OCaml'].lexer
     assert_equal Lexer['OCaml'], Language['Standard ML'].lexer
     assert_equal Lexer['Ooc'], Language['ooc'].lexer
-    assert_equal Lexer['REBOL'], Language['Rebol'].lexer
+    assert_equal Lexer['REBOL'], Language['REBOL'].lexer
     assert_equal Lexer['RHTML'], Language['HTML+ERB'].lexer
     assert_equal Lexer['RHTML'], Language['RHTML'].lexer
     assert_equal Lexer['Ruby'], Language['Mirah'].lexer


### PR DESCRIPTION
The official spelling of REBOL is in all-caps.

(Sorry for the pull request noise, but I completely missed that previously.)
