### PR TITLE
Detect .xcworkspacedata and .xcuserstate files as generated

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -178,7 +178,7 @@ module Linguist
     #
     # Return true or false
     def generated?
-      if ['.xib', '.nib', '.pbxproj'].include?(extname)
+      if ['.xib', '.nib', '.pbxproj', '.xcworkspacedata', '.xcuserstate'].include?(extname)
         true
       elsif generated_coffeescript? || minified_javascript?
         true


### PR DESCRIPTION
Xcode 4 generates more XML files than ever: update `generated?` to recognize them as such.
