### PR TITLE
adds ClojureScript's new file extension to the Clojure language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -152,6 +152,7 @@ Clojure:
   type: programming
   extensions:
   - .clj
+  - .cljs
 
 CoffeeScript:
   type: programming

--- a/lib/linguist/lexers.yml
+++ b/lib/linguist/lexers.yml
@@ -1376,6 +1376,7 @@ Clojure:
   - 'clj'
   filenames:
   - '*.clj'
+  - '*.cljs'
   mimetypes:
   - 'text/x-clojure'
   - 'application/x-clojure'


### PR DESCRIPTION
This will hopefully enable github to syntax highlight the new ClojureScript project (e.g https://github.com/clojure/clojurescript/blob/master/src/cljs/cljs/core.cljs) which has the same syntax as Clojure.
