### PR TITLE
Add CMake to list of recognized languages

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -154,6 +154,14 @@ Clojure:
   - .clj
   - .cljs
 
+CMake:
+  type: programming
+  extensions:
+  - .cmake
+  - .cmake.in
+  filenames:
+  - CMakeLists.txt
+
 CoffeeScript:
   type: programming
   extensions:


### PR DESCRIPTION
Add commonly used filenames and extensions for scripts used by the CMake build system.
