### PR TITLE
Add Vagrantfiles to the list of Ruby filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -721,6 +721,7 @@ Ruby:
   - Rakefile
   - Thorfile
   - Gemfile
+  - Vagrantfile
 
 Rust:
   type: programming


### PR DESCRIPTION
Vagrantfiles, used by [Vagrant](http://vagrantup.com) to control virtual machines, are ruby scripts.
