### PR TITLE
Add coffee alias to CoffeeScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -171,6 +171,8 @@ Clojure:
 
 CoffeeScript:
   type: programming
+  aliases:
+  - coffee
   extensions:
   - .coffee
   filenames:


### PR DESCRIPTION
This PR adds support to highlight coffeescript files with the following shebang:

`#!/usr/bin/env coffee`
