### PR TITLE
Grails and Gosu GSP guessing

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -432,6 +432,19 @@ module Linguist
         Language['R']
       end
     end
+    
+    
+    # Internal: Guess language of .gsp files.
+    # 
+    # Returns a Language.
+    def guess_gsp_language
+    	    if lines.grep(/<%|<%@|${|<%|<g:|<meta name="layout"|<r:/).any?
+    	Language['Groovy Server Pages']
+      else
+        Language['Gosu']
+      end
+    end
+    
 
     # Internal: Guess language from the first line.
     #

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -379,6 +379,16 @@ Groovy:
   - .gradle
   - .groovy
 
+Groovy Server Pages:
+  group: Groovy
+  lexer: Java Server Page
+  overrides:
+  - .gsp  
+  aliases:
+  - gsp
+  extensions:
+  - .gsp
+
 HTML:
   type: markup
   primary_extension: .html

--- a/test/fixtures/bar.gsp
+++ b/test/fixtures/bar.gsp
@@ -1,0 +1,10 @@
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Testing with SiteMesh and Resources</title>
+    <meta name="layout" content="blankMain"/>
+    <r:require module="style"/>
+</head>
+<body>
+</body>
+</html>

--- a/test/fixtures/hello-pagedirective.gsp
+++ b/test/fixtures/hello-pagedirective.gsp
@@ -1,0 +1,16 @@
+<%@ page contentType="text/html;charset=UTF-8" %>
+
+<html>
+  <head>
+    <title>Using page directive tag</title>
+  </head>
+  <body>
+        <div class="center">
+            <a href="#" alt="Download" id="downloadButton">Download</a>
+        </div>
+        <div class="center">
+            <a href="#" alt="Print" id="printButton">Print</a>
+        </div>
+  </body>
+</html>
+

--- a/test/fixtures/hello-resources.gsp
+++ b/test/fixtures/hello-resources.gsp
@@ -1,0 +1,9 @@
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Testing with Resources</title>
+    <r:require module="style"/>
+</head>
+<body>
+</body>
+</html>

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -332,6 +332,12 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Language['Gosu'], blob("hello.gsp").language
     assert_equal Language['Gosu'], blob("Hello.gst").language
     assert_equal Language['Gosu'], blob("hello.vark").language
+    
+    #Groovy Server Pages 
+    assert_equal Language['Groovy Server Pages'], blob("bar.gsp").language
+    assert_equal Language['Groovy Server Pages'], blob("hello-resources.gsp").language
+    assert_equal Language['Groovy Server Pages'], blob("hello-pagedirective.gsp").language
+    
   end
 
   def test_lexer


### PR DESCRIPTION
Adding support to detect the difference between a Grails gsp and a Gosu gsp.

This is important to get working because checking under explore github and looking at Gosu many of the top projects are actually Grails projects.
