### PR TITLE
Add support for Eclipse metadata files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -445,6 +445,7 @@ INI:
   - .cfg
   - .ini
   - .properties
+  - .prefs
   filenames:
   - .gitconfig
 
@@ -989,6 +990,9 @@ XML:
   - .xsd
   - .xsl
   - .xul
+  filenames:
+  - .classpath
+  - .project
 
 XQuery:
   type: programming


### PR DESCRIPTION
`.project` and `.classpath` are XML files that contain information about the project.

`.prefs` files are preferences that are Java properties files.
