### PR TITLE
AutoHotkey Support (Syntax highlighting)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -62,7 +62,6 @@ AppleScript:
 
 AutoHotkey:
   type: programming
-  lexer: Text only
   aliases:
   - ahk
   extensions:


### PR DESCRIPTION
tinku99 [mentioned](https://github.com/github/linguist/pull/71#issuecomment-1984377) that his lexer has been included in Pygments since v1.4. These changes allow the AutoHotkey lexer to be used to provide syntax highlighting for AutoHotkey scripts.
