### PR TITLE
Standard ML is actually a programming language... and it has a specific lexer now.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -898,7 +898,8 @@ Smarty:
   - .tpl
 
 Standard ML:
-  lexer: OCaml
+  type: programming
+  lexer: Standard ML
   aliases:
   - sml
   primary_extension: .sml


### PR DESCRIPTION
Standard ML files still haven't been showing up as languages in GitHub's "what languages does this project use" view; is the lack of a "type: programming" line the reason why? 

Additionally, the Standard ML-specific lexer has been added to Pygments on Bitbucket's; GitHub may not use bleeding-edge Pygments, but it should be eventually possible to use Standard ML-specific lexer rather than the OCaml one.
