### PR TITLE
Add bones suffix to JavaScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -506,6 +506,7 @@ JavaScript:
   - node
   primary_extension: .js
   extensions:
+  - .bones
   - .jake
   - .js
   - .jsm


### PR DESCRIPTION
This adds the suffix `.bones` to the JavaScript parser. `.bones` is used by the [bones framework](https://github.com/developmentseed/bones), a client/server-targeting Backbone-based system. It's used in [TileMill](https://github.com/mapbox/tilemill), [TileStream](https://github.com/mapbox/tilestream), and in plugins like [bones-admin](https://github.com/developmentseed/bones-auth).

All `.bones` files are proper JavaScript files with no language changes.
