### PR TITLE
.ins and .dtx hightlighting

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -937,6 +937,7 @@ TeX:
   - .tex
   - .toc
   - .dtx
+  - .ins
 
 Text:
   type: data


### PR DESCRIPTION
The .dtx and .ins files are  used in TeX world, to generate .cls, .sty and documentation
