### PR TITLE
Set filenames `vimrc` and `gvimrc` to be VimL. 

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -987,6 +987,8 @@ VimL:
   filenames:
   - .gvimrc
   - .vimrc
+  - vimrc
+  - gvimrc
 
 Visual Basic:
   type: programming


### PR DESCRIPTION
Many people place their dotfiles on github or distribute their `.vimrc`. However some of those people elect to remove the dot from the filename when placing it under version control. Examples can be found [here](https://github.com/oryband/dotvim/blob/master/vimrc) and [here](https://github.com/carlhuda/janus/blob/master/vimrc). 

Currently these files have no syntax highlighting and it's quite annoying.
