### PR TITLE
Highlight ".vapi" files as Vala

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -970,6 +970,7 @@ Vala:
   type: programming
   extensions:
   - .vala
+  - .vapi
 
 Verilog:
   type: programming


### PR DESCRIPTION
.vapi files are vala interface definitions for external C libraries,
and use the same syntax as regular .vala files. Support highlighting them
as well.
