### PR TITLE
Detect Arduino 1.0

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -66,6 +66,12 @@ Arc:
   extensions:
   - .arc
 
+Arduino:
+  type: programming
+  lexer: C++
+  extensions:
+  - .ino
+
 Assembly:
   type: programming
   lexer: NASM

--- a/test/fixtures/hello.ino
+++ b/test/fixtures/hello.ino
@@ -1,0 +1,7 @@
+void setup() {
+  Serial.begin(9600);
+}
+
+void loop() {
+  Serial.print("Hello");
+}

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -263,6 +263,7 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Language['Ruby'],        blob("foo.rb").language
     assert_equal Language['Ruby'],        blob("script.rb").language
     assert_equal Language['Ruby'],        blob("wrong_shebang.rb").language
+    assert_equal Language['Arduino'],     blob("hello.ino").language
     assert_nil blob("octocat.png").language
 
     # .pl disambiguation


### PR DESCRIPTION
Detect Arduino 1.0 files

With the 1.0 release of the Arduino ide the file extension will be changed from .pde to .ino, this change will make detection of Ardino repos possible.

For more info on the extension change: http://code.google.com/p/arduino/wiki/Arduino1
