### PR TITLE
Added Turing language detection

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -467,6 +467,20 @@ module Linguist
         Language['R']
       end
     end
+    
+    # Internal: Guess language of .t files.
+    #
+    # Makes fairly sure that it is Turing.
+    # Turing is not very popular so it would not be good to have perl users' files being confused.
+    #
+    # Returns a Language.
+    def guess_t_language
+      if lines.grep(/:=/).any? && lines.grep(/proc |procedure |fcn |function /).any? && lines.grep(/var/).any?
+        Language['Turing']
+      else
+        Language['Perl']
+      end
+    end
 
     # Internal: Guess language of .gsp files.
     #

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -717,6 +717,7 @@ Perl:
   type: programming
   overrides:
   - .pl
+  - .t
   primary_extension: .pl
   extensions:
   - .PL
@@ -965,6 +966,14 @@ Textile:
   lexer: Text only
   extensions:
   - .textile
+  
+Turing:
+  type: programming
+  lexer: Text only
+  primary_extension: .t
+  extensions:
+  - .t
+  - .tu
 
 Twig:
   type: markup


### PR DESCRIPTION
Detects the Turing programming language. It is used by high school programmers to learn programming. It is mainly used in Canada. Currently Github detects Turing as Perl because of the .t extension.

This detects Turing and makes sure it is not Perl. Does not have a lexer yet. Uses the plain text lexer.

More info on Turing: http://en.wikipedia.org/wiki/Turing_(programming_language)
