### PR TITLE
Adding support for .sage file syntax highlighting

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -862,6 +862,14 @@ SQL:
   extensions:
   - .sql
 
+Sage:
+  type: programming
+  lexer: Python
+  group: Python
+  primary_extension: .sage
+  extensions:
+  - .sage
+
 Sass:
   type: markup
   group: CSS


### PR DESCRIPTION
This adds support for .sage file syntax highlighting. Sage uses python for syntax, but I added a separate section instead of adding an entry to the Python extensions list in case a separate lexer is needed in the future.

More information on sage is at http://sagemath.org
