### PR TITLE
languages.yml: support GNUmakefile and makefile

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -568,7 +568,9 @@ Makefile:
   extensions:
   - .mak
   filenames:
+  - makefile
   - Makefile
+  - GNUmakefile
 
 Mako:
   extensions:


### PR DESCRIPTION
GNU make manpage says: "If  no  -f  option  is present,  make will look
for the makefiles GNUmakefile, makefile, and Makefile, in that order."

@Tekkub HERE IT IS! KTHXBYE :cake:
![](http://memegenerator.net/cache/instances/400x/11/11329/11601590.jpg)
