### PR TITLE
Added the XLIFF extensions as XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1058,6 +1058,8 @@ XML:
   - .wxl
   - .wxs
   - .xaml
+  - .xlf
+  - .xliff
   - .xml
   - .xsd
   - .xsl


### PR DESCRIPTION
This adds the XLIFF extension as XML for translation files. `.xlf` is the official one but `.xliff` is also used by some projects (including Symfony2)
