### PR TITLE
Highlight ".mk" files as Makefiles.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -566,6 +566,7 @@ Lua:
 
 Makefile:
   extensions:
+  - .mk
   - .mak
   filenames:
   - makefile


### PR DESCRIPTION
Makefiles sometimes named with `.mk` extension. You can look at [Android NDK](https://github.com/CyanogenMod/android_ndk) for example. Added highlighting for that extension.
