### PR TITLE
Added non-hidden shell run commands as filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -921,6 +921,8 @@ Shell:
   - .zlogin
   - .zsh
   - .zshrc
+  - bashrc
+  - zshrc
 
 Smalltalk:
   type: programming


### PR DESCRIPTION
There are plenty of users that I think would benefit from having syntax highlighting work on non-hidden bashrc and zshrc files
