### PR TITLE
Perl plx extension support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -733,6 +733,7 @@ Perl:
   - .perl
   - .ph
   - .pl
+  - .plx
   - .pm
   - .pod
   - .psgi


### PR DESCRIPTION
Perl .plx files are now picked up. The .plx file extension is used to denote a Perl file that is executable.

`bundle install && bundle exec rake test` passed.

Cheers.
