### PR TITLE
Add .mako file extension for Mako

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -583,6 +583,7 @@ Makefile:
 
 Mako:
   extensions:
+  - .mako
   - .mao
 
 Markdown:


### PR DESCRIPTION
Adds the `.mako` file extension for [Mako templates](http://makotemplates.org).
