### PR TITLE
Remove rc extension from Rust language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -867,7 +867,6 @@ Rust:
   lexer: Text only
   primary_extension: .rs
   extensions:
-  - .rc
   - .rs
 
 SCSS:


### PR DESCRIPTION
Original discussion here - https://github.com/mozilla/rust/issues/1512
