### PR TITLE
Added detection for Python xpy files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -775,6 +775,7 @@ Python:
   - .py
   - .pyw
   - .wsgi
+  - .xpy
 
 Python traceback:
   type: data


### PR DESCRIPTION
As requested by Petros Amiridis:

> Hi Rob,
> You can try creating a pull request. We'll examine it and if it is not a problem we'll accept it.
> Thanks

I branched and ran the tests:

$ pwd
/path/to/linguist

$ bundle install

``` ruby
Using rake (0.9.2.2) 
Using blankslate (2.1.2.4) 
Using charlock_holmes (0.6.8) 
Using escape_utils (0.2.4) 
Using ffi (1.0.11) 
Using mime-types (1.17.2) 
Using rubypython (0.5.3) 
Using pygments.rb (0.2.4) 
Using linguist (1.0.0) from source at . Enter your password to install the bundled RubyGems to your system: 

Using bundler (1.0.21) 
Your bundle is complete! Use `bundle show [gemname]` to see where a bundled gem is installed.
```

$ bundle exec rake

``` ruby
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/pathname.rb:263: warning: `*' interpreted as argument prefix
/Library/Ruby/Gems/1.8/gems/rubypython-0.5.3/lib/rubypython/operators.rb:67: warning: `*' interpreted as argument prefix
/Library/Ruby/Gems/1.8/gems/rubypython-0.5.3/lib/rubypython/operators.rb:75: warning: `*' interpreted as argument prefix
/Library/Ruby/Gems/1.8/gems/rubypython-0.5.3/lib/rubypython/operators.rb:86: warning: `*' interpreted as argument prefix
/Library/Ruby/Gems/1.8/gems/rubypython-0.5.3/lib/rubypython/pygenerator.rb:43: warning: `*' interpreted as argument prefix
/Library/Ruby/Gems/1.8/gems/pygments.rb-0.2.4/lib/pygments/ffi.rb:116: warning: private attribute?
Loaded suite /Library/Ruby/Gems/1.8/gems/rake-0.9.2.2/lib/rake/rake_test_loader
Started
.............................................................
Finished in 4.128323 seconds.

61 tests, 1730 assertions, 0 failures, 0 errors
```

Thanks for your consideration.
- Rob
