### PR TITLE
Added detection for MoonScript language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -633,6 +633,11 @@ Moocode:
   extensions:
   - .moo
 
+Moonscript:
+  type: programming
+  extensions:
+  - .moon
+
 Myghty:
   extensions:
   - .myt


### PR DESCRIPTION
Added detection for http://moonscript.org

An associated lexer was recently added to pygments-main as well: https://bitbucket.org/birkenfeld/pygments-main/changeset/e483f89414dc
