### PR TITLE
Add support for OpenEdge ABL language

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -417,6 +417,17 @@ module Linguist
       end
     end
 
+    # Internal: Guess language of .cls files
+    #
+    # Returns a Language.
+    def guess_cls_language
+      if lines.grep(/^(%|\\)/).any?
+        Language['TeX']
+      else
+        Language['OpenEdge ABL']
+      end
+    end
+
     # Internal: Guess language of header files (.h).
     #
     # Returns a Language.

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -740,6 +740,19 @@ OpenCL:
   extensions:
   - .cl
 
+OpenEdge ABL:
+  type: programming
+  aliases:
+  - progress
+  - openedge
+  - abl
+  primary_extension: .p
+  overrides:
+  - .cls
+  extensions:
+  - .cls
+  - .p
+
 PHP:
   type: programming
   extensions:

--- a/test/fixtures/latex.cls
+++ b/test/fixtures/latex.cls
@@ -1,0 +1,8 @@
+% latex.cls
+%
+% A barebones LaTeX2e class file
+
+\def\author{Abe Voelker}
+\def\fileversion{0.1}
+\NeedsTeXFormat{LaTeX2e}
+

--- a/test/fixtures/openedge.cls
+++ b/test/fixtures/openedge.cls
@@ -1,0 +1,10 @@
+USING Progress.Lang.*.
+
+CLASS HelloWorld:
+
+  CONSTRUCTOR PUBLIC HelloWorld():
+    SUPER().
+    MESSAGE "Hello, world!".
+  END CONSTRUCTOR.
+
+END CLASS.

--- a/test/fixtures/openedge.p
+++ b/test/fixtures/openedge.p
@@ -1,0 +1,1 @@
+MESSAGE "Hello, world!".

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -287,6 +287,10 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Language['Arduino'],     blob("hello.ino").language
     assert_nil blob("octocat.png").language
 
+    # .cls disambiguation
+    assert_equal Language['OpenEdge ABL'], blob("openedge.cls").language
+    assert_equal Language['TeX'], blob("latex.cls").language
+
     # .pl disambiguation
     assert_equal Language['Prolog'],      blob("test-prolog.pl").language
     assert_equal Language['Perl'],        blob("test-perl.pl").language
@@ -405,6 +409,9 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Language['CSS'], blob("screen.sass").language.group
     assert_equal Language['SCSS'], blob("screen.scss").language
     assert_equal Language['CSS'], blob("screen.scss").language.group
+
+    # OpenEdge ABL / Progress
+    assert_equal Language['OpenEdge ABL'], blob("openedge.p").language
   end
 
   def test_lexer

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -9,6 +9,9 @@ class TestLanguage < Test::Unit::TestCase
   Lexer = Pygments::Lexer
 
   def test_ambiguous_extensions
+    assert Language.ambiguous?('.cls')
+    assert_equal Language['OpenEdge ABL'], Language.find_by_extension('cls')
+
     assert Language.ambiguous?('.h')
     assert_equal Language['C'], Language.find_by_extension('h')
 
@@ -53,6 +56,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Lexer['NASM'], Language['Assembly'].lexer
     assert_equal Lexer['OCaml'], Language['F#'].lexer
     assert_equal Lexer['OCaml'], Language['OCaml'].lexer
+    assert_equal Lexer['OpenEdge ABL'], Language['OpenEdge ABL'].lexer
     assert_equal Lexer['Standard ML'], Language['Standard ML'].lexer
     assert_equal Lexer['Ooc'], Language['ooc'].lexer
     assert_equal Lexer['REBOL'], Language['Rebol'].lexer
@@ -104,6 +108,9 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['JavaScript'], Language.find_by_alias('js')
     assert_equal Language['Literate Haskell'], Language.find_by_alias('lhs')
     assert_equal Language['Literate Haskell'], Language.find_by_alias('literate-haskell')
+    assert_equal Language['OpenEdge ABL'], Language.find_by_alias('openedge')
+    assert_equal Language['OpenEdge ABL'], Language.find_by_alias('progress')
+    assert_equal Language['OpenEdge ABL'], Language.find_by_alias('abl')
     assert_equal Language['Parrot Internal Representation'], Language.find_by_alias('pir')
     assert_equal Language['Powershell'], Language.find_by_alias('posh')
     assert_equal Language['Puppet'], Language.find_by_alias('puppet')


### PR DESCRIPTION
The tests won't pass until pygments.rb gets updated to a new version of Pygments ([already pull requested](https://github.com/tmm1/pygments.rb/pull/12)).  They pass using a custom pygments.rb gem built from that branch.
