### PR TITLE
Added detection for c2hs Haskell files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -162,6 +162,15 @@ C-ObjDump:
   extensions:
   - .c-objdump
 
+C2hs Haskell:
+  type: programming
+  lexer: Haskell
+  group: Haskell
+  aliases:
+  - c2hs
+  extensions:
+  - .chs
+
 CMake:
   extensions:
   - .cmake


### PR DESCRIPTION
C2hs program assists in the development of Haskell bindings to C libraries. It extracts interface information from C header files and generates Haskell code with foreign imports and marshaling. This ensures that C functions are imported with the correct Haskell types.

The .chs files are Haskell files that include normal Haskell code with C-like preprocessor directives and binding hooks that defines how to generate final binding code.

I added the chs file extension in the linguist module.
