### PR TITLE
Add support for the Bro IDS scripting language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -120,6 +120,11 @@ Brainfuck:
   - .b
   - .bf
 
+Bro:
+  type: programming
+  extensions:
+  - .bro
+
 C:
   type: programming
   overrides:


### PR DESCRIPTION
Pygments now offers a Bro lexer [1] and officially supports the Bro IDS
scripting language. Time to integrate it in linguist!

[1] https://bitbucket.org/birkenfeld/pygments-main/pull-request/5/add-lexer-for-the-bro-language
[2] http://www.bro-ids.org
