### PR TITLE
Add Modulefile to Puppet

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -825,6 +825,8 @@ Puppet:
   lexer: Text only
   extensions:
   - .pp
+  filenames:
+  - Modulefile
 
 Pure Data:
   type: programming


### PR DESCRIPTION
Puppet modules should contain a Modulefile, and so it should be a Puppet file.
