### PR TITLE
Add .lsp as an extension for Common Lisp

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -227,6 +227,7 @@ Common Lisp:
   primary_extension: .lisp
   extensions:
   - .lisp
+  - .lsp
   - .ny
 
 Coq:


### PR DESCRIPTION
I've seen this used especially with newLISP, but I think giving it Common Lisp highlighting as a default makes a lot of sense.

I don't see any tests related to existing Lisp-highlighting functionality, so I haven't added any myself.
