### PR TITLE
Update to vendor.yml to include the ExtJS Javscript Framework

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -88,3 +88,6 @@
 
 # NuGet
 - ^[Pp]ackages/
+
+# ExtJS
+- (^|/)ext(js)?(-\d\.\d\.\d)?(-gpl)?/


### PR DESCRIPTION
Hi,

I have included ExtJS in a project I'm working on, but it doesn't appear to be excluded in the stat graph. I added a line at the bottom here which should match most installs of ExtJS, from my own personal, to the various forms you can get off their website.

Hope you'll consider it.

Graham
