### PR TITLE
Adding PHP syntax highlighting for Phake

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -784,6 +784,8 @@ PHP:
   - .php4
   - .php5
   - .phpt
+  filenames:
+  - Phakefile
 
 Parrot:
   type: programming


### PR DESCRIPTION
This commit adds support for syntax highlighting (PHP) of Phakefiles.

Phake is PHP's version of Rake. See: https://github.com/jaz303/phake
