### PR TITLE
Added detection for the M (aka MUMPS) programming language.

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -457,6 +457,9 @@ module Linguist
     # * Leading function keyword
     # * "%" comments
     #
+    # M heuristics:
+    # * ";" comments
+    #
     # Returns a Language.
     def guess_m_language
       # Objective-C keywords
@@ -470,6 +473,10 @@ module Linguist
       # Matlab comment
       elsif lines.grep(/^%/).any?
         Language['Matlab']
+
+      # M comment
+      elsif lines.grep(/^[ \t]*;/).any?
+        Language['M']
 
       # Fallback to Objective-C, don't want any Matlab false positives
       else

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -627,6 +627,14 @@ Lua:
   - .lua
   - .nse
 
+M:
+  type: programming
+  lexer: Text only
+  aliases:
+  - mumps
+  extensions:
+  - .m
+
 Makefile:
   extensions:
   - .mak

--- a/test/fixtures/m_simple.m
+++ b/test/fixtures/m_simple.m
@@ -1,0 +1,4 @@
+fox
+	; The quick brown fox jumps over the lazy dog
+	write "The quick brown fox jumps over the lazy dog",!
+	quit

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -307,6 +307,7 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Language['Objective-C'], blob("hello.m").language
     assert_equal Language['Matlab'], blob("matlab_function.m").language
     assert_equal Language['Matlab'], blob("matlab_script.m").language
+    assert_equal Language['M'], blob("m_simple.m").language
 
     # .r disambiguation
     assert_equal Language['R'],           blob("hello-r.R").language


### PR DESCRIPTION
This add detection for the M (aka MUMPS) programming language (see https://en.wikipedia.org/wiki/MUMPS).

I have successfully tested this using `bundle exec rake test`.

I have also called `bundle exec linguist` on the following projects, which I know have M files in them :

```
lparenteau/httpm
luisibanez/fis-gtm
luisibanez/VistA-FOIA
```
