### PR TITLE
Add ._js & ._coffee extensions for Streamline.js.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -216,9 +216,9 @@ CoffeeScript:
   ace_mode: coffee
   aliases:
   - coffee
+  primary_extension: .coffee
   extensions:
   - ._coffee
-  - .coffee
   filenames:
   - Cakefile
 

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -337,6 +337,8 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal '.pl', Language['Perl'].primary_extension
     assert_equal '.py', Language['Python'].primary_extension
     assert_equal '.rb', Language['Ruby'].primary_extension
+    assert_equal '.js', Language['JavaScript'].primary_extension
+    assert_equal '.coffee', Language['CoffeeScript'].primary_extension
 
     # This is a nasty requirement, but theres some code in GitHub that
     # expects this. Really want to drop this.


### PR DESCRIPTION
Streamline.js by Bruno Jouhier (@Sage) is a library/tool that lets you write
synchronous-looking JavaScript/CoffeeScript, and have it compile to Node-style
asynchronous JavasScript/CoffeeScript. (It's amazing and super elegant.)

https://github.com/Sage/streamlinejs

From the start, Streamline was designed to be exactly JavaScript/CoffeeScript,
so that it works with existing editors and tools. No new keywords or syntax --
it simply reserves `_` as a function parameter name.

Streamline files have thus kept `.js` and `.coffee` as extensions, so that no
changes need to be made to tools; Streamline has just used the convention of
ending file basenames with `_`, like `foo_.js` or `foo_.coffee`.

Unfortunately, to get the most optimal Node.js integration, with on-the-fly
compilation (like CoffeeScript), files now need to have their own extension.
So Bruno has decided to make `._js` and `._coffee` the extensions of choice.

The good news is that the language is still exactly JavaScript/CoffeeScript;
it's only the extension that's changed. It's simple to add these extensions
into our editors, but I'm wondering if we can add this to GitHub too. =)

This change is super simple and shouldn't affect any other language, so I hope
you guys are open to it. Thanks for your consideration!
