### PR TITLE
Adding localization of the "\Samples

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -94,3 +94,57 @@
 
 # Samples folders
 - ^[Ss]amples/
+- ^[Ss]ample/
+- ^[Ee]xample/
+- ^[Ee]xamples/
+- ^[Mm]uestras/
+- ^[Mm]uestra/
+- ^[Ss]pecimenoj/
+- ^[Ss]pecimeno/
+- ^[Éé]chantillons/
+- ^[Éé]chantillon/
+- ^[Pp]roben/
+- ^[Pp]robe/
+- ^[Vv]zorky/
+- ^[Mm]ostres/
+- ^[Mm]ostra/
+- ^[Pp]røver/
+- ^[Pp]røve/
+- ^[Mm]onsters/
+- ^[Mm]onster/
+- ^[Pp]roovid/
+- ^[Pp]roovi/
+- ^[Nn]äytteet/
+- ^[Nn]äyte/
+- ^[Δδ]είγματα/
+- ^[Δδ]είγμα/
+- ^[Ee]chantiyon yo genyen/
+- ^[Ee]chantiyon/
+- ^[Kk]uaj/
+- ^[Ss]aj/
+- ^[Aa] minták/
+- ^[Mm]inta/
+- ^[Ss]ampel/
+- ^[Cc]ampioni/
+- ^[Cc]ampione/
+- ^[Pp]araugi/
+- ^[Pp]araugs/
+- ^[Mm]ėginiai/
+- ^[Mm]ėginys/
+- ^[Ee]ksempler/
+- ^[Pp]róbki/
+- ^[Aa]mostras/
+- ^[Aa]mostra/
+- ^[Ee]șantioane/
+- ^[Ee]șantion/
+- ^[Пп]римеры/
+- ^[Пп]ример/
+- ^[Vv]zorky/
+- ^[Vv]zorky/
+- ^[Vv]zorci/
+- ^[Vv]zorec/
+- ^[Öö]rnekleri/
+- ^[Öö]rnek/
+- ^[mM]ẫu/
+
+


### PR DESCRIPTION
Adding localization of the "\Samples" folder for Bulgarian, Catalan, Czech, Danish, Dutch, Estonian, Finnish, Greek, Creole, Hmong Daw, Hungarian, Indonesian, Italian, Latvian, Lithuanian, Norwegian, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Swedish, Turkish, and Vietnamese
