### PR TITLE
add detection for Arch Linux PKGBUILDs

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1141,6 +1141,7 @@ Shell:
   - .zshrc
   - bashrc
   - zshrc
+  - PKGBUILD
 
 Smalltalk:
   type: programming

--- a/test/fixtures/PKGBUILD
+++ b/test/fixtures/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Daniel Micay <danielmicay@gmail.com>
+pkgname=stud-git
+pkgver=20120316
+pkgrel=1
+pkgdesc="The Scalable TLS Unwrapping Daemon"
+arch=(i686 x86_64)
+url="https://github.com/bumptech/stud"
+license=('BSD')
+depends=(libev openssl)
+makedepends=(git)
+provides=(stud)
+conflicts=(stud)
+
+_gitroot=https://github.com/bumptech/stud.git
+_gitname=stud
+
+build() {
+  cd "$srcdir"
+  msg "Connecting to GIT server...."
+
+  if [[ -d "$_gitname" ]]; then
+    cd "$_gitname" && git pull origin
+    msg "The local files are updated."
+  else
+    git clone "$_gitroot" "$_gitname"
+  fi
+
+  msg "GIT checkout done or server timeout"
+  msg "Starting build..."
+
+  rm -rf "$srcdir/$_gitname-build"
+  git clone "$srcdir/$_gitname" "$srcdir/$_gitname-build"
+  cd "$srcdir/$_gitname-build"
+
+  make
+}
+
+package() {
+  cd "$srcdir/$_gitname-build"
+  make PREFIX=/usr DESTDIR="$pkgdir/" install
+  install -Dm755 init.stud "$pkgdir/etc/rc.d/stud"
+  mkdir -p "$pkgdir/etc/stud"
+}

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -434,6 +434,9 @@ class TestBlob < Test::Unit::TestCase
 
     # Dart: http://dartlang.org/
     assert_equal Language['Dart'], blob("point.dart").language
+
+    # Arch Linux PKGBUILD
+    assert_equal Language['Shell'], blob("PKGBUILD").language
   end
 
   def test_lexer
@@ -447,6 +450,7 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Lexer['vhdl'], blob("foo.vhd").lexer
     assert_equal Lexer['Julia'], blob("stockcorr.jl").lexer
     assert_equal Lexer['Dart'], blob("point.dart").lexer
+    assert_equal Lexer['Bash'], blob("PKGBUILD").lexer
   end
 
   def test_shebang_script

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -273,6 +273,7 @@ class TestLanguage < Test::Unit::TestCase
   end
 
   def test_find_by_filename
+    assert_equal Language['Shell'], Language.find_by_filename('PKGBUILD')
     assert_equal Language['Ruby'], Language.find_by_filename('foo.rb')
     assert_equal Language['Ruby'], Language.find_by_filename('foo/bar.rb')
     assert_equal Language['Ruby'], Language.find_by_filename('Rakefile')


### PR DESCRIPTION
This adds support for the Arch Linux [PKGBUILD format](https://www.archlinux.org/pacman/PKGBUILD.5.html).
