### PR TITLE
Add extjs to ignored vendored Javascript libraries

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -61,6 +61,11 @@
 # MathJax
 - (^|/)MathJax/
 
+# ExtJS
+- (^|/)ext(-(all|base|core|debug|dev))?([^.]*)?\.js$
+- (^|/)ext-([-.]*-)?adapter(-debug[^.]*)?\.js$
+
+
 ## Python ##
 
 # Fabric


### PR DESCRIPTION
This merely adds ExtJS to the list of vendored Javascript libraries. It matches against all versions of ExtJS's common js files. It doesn't match some of the fully split-out modules, but those aren't common to find in a project and messy to match.
