### PR TITLE
add ^external/ to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -23,6 +23,9 @@
 # Vendored depedencies
 - vendor/
 
+# External
+- ^external/
+
 
 ## Commonly Bundled JavaScript frameworks ##
 

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -192,6 +192,9 @@ class TestBlob < Test::Unit::TestCase
     assert blob("deps/http_parser/http_parser.c").vendored?
     assert blob("deps/v8/src/v8.h").vendored?
 
+    # External
+    assert blob("external/llvm-3.0/lib/CodeGen/Analysis.cpp").vendored?
+
     # Prototype
     assert !blob("public/javascripts/application.js").vendored?
     assert blob("public/javascripts/prototype.js").vendored?


### PR DESCRIPTION
Ideally we'd just add:

```
linguist:
  exclude:
    - ^external/
```

to our `$repo/.github` file, but this is the next best thing.
