### PR TITLE
Add .pm6 to  Perl extensions for Perl6 

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -908,6 +908,7 @@ Perl:
   - .pl
   - .plx
   - .pm
+  - .pm6
   - .pod
   - .psgi
   - .t


### PR DESCRIPTION
Added .pm6 to Perl extensions. 

Conventionally, some Perl6 modules use pm6 as extension to differentiate from the currently common Perl 5 modules. Here are some examples: 
-   https://github.com/uasi/messagepack-pm6/blob/master/lib/MessagePack.pm6
-   https://github.com/supernovus/perl6-mime-types/blob/master/lib/MIME/Types.pm6

So I believe adding .pm6 to perl syntax blob sets makes sense.
