### PR TITLE
More robust heuristics for .m files and 3 new Matlab tests. Finally.

### DIFF
--- a/test/fixtures/matlab_class.m
+++ b/test/fixtures/matlab_class.m
@@ -1,0 +1,29 @@
+classdef matlab_class
+    properties
+        R;
+        G;
+        B;
+    end
+    methods
+        function obj = matlab_class(r,g,b)
+            obj.R = r;
+            obj.G = g;
+            obj.B = b;
+        end
+        function disp(obj)
+            disp(['Red: ' num2str(obj.R) ...
+                ', Green: ' num2str(obj.G) ...
+                ', Blue: ' num2str(obj.B)]);
+        end
+    end
+    enumeration
+        red     (1,0,0)
+        green   (0,1,0)
+        blue    (0,0,1)
+        cyan    (0,1,1)
+        magenta (1,0,1)
+        yellow  (1,1,0)
+        black   (0,0,0)
+        white   (1,1,1)
+    end
+end

--- a/test/fixtures/matlab_function2.m
+++ b/test/fixtures/matlab_function2.m
@@ -1,0 +1,33 @@
+   function ret = matlab_function2(A,B)
+% Simple function that combines two values using function handles and displays
+% the return value
+
+% create function handles
+fun1=@interface;
+fun2=@implementation;
+fun3=@property;
+fun4=@synthesize;
+
+% use function handles
+ret = fun1(A)+fun2(A)+fun3(B)+fun4(B);
+
+% Display the return value
+disp('Return value in function');
+disp(ret);
+
+
+function A=interface(A)
+% simple sub-function with same name Objective-C @keyword
+A=2*A;
+
+function A=implementation(A)
+% simple sub-function with same name Objective-C @keyword
+A=A^2;
+
+function B=property(B)
+% simple sub-function with same name Objective-C @keyword
+B=2*B;
+
+function B=synthesize(B)
+% simple sub-function with same name Objective-C @keyword
+B=B^2;

--- a/test/fixtures/matlab_script2.m
+++ b/test/fixtures/matlab_script2.m
@@ -1,0 +1,13 @@
+  % Matlab example script 2
+  % Comments precended with arbitrary whitespace (spaces or tabs)
+
+  %Call matlab_function function which resides in the same directory
+
+value1 = 5 % semicolon at end of line is not mandatory, only suppresses output to command line.
+value2 = 3
+
+  % Calculate sum of value1 and value2
+result = matlab_function(value1,value2);
+
+disp('called from script')
+disp(result);

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -311,6 +311,9 @@ class TestBlob < Test::Unit::TestCase
     assert_equal Language['Objective-C'], blob("hello.m").language
     assert_equal Language['Matlab'], blob("matlab_function.m").language
     assert_equal Language['Matlab'], blob("matlab_script.m").language
+    assert_equal Language['Matlab'], blob("matlab_function2.m").language
+    assert_equal Language['Matlab'], blob("matlab_script2.m").language
+    assert_equal Language['Matlab'], blob("matlab_class.m").language
 
     # .r disambiguation
     assert_equal Language['R'],           blob("hello-r.R").language


### PR DESCRIPTION
Support for Objective-C detection fully intact; all tests pass. Detection of Objective-C keywords @implementation, @property, @interface, and @synthesize removed to avoid possible conflicts with user-created Matlab function handles. Only @end is detected, which is not valid in Matlab. Matlab class files (classdef) now detected in addition to function files. Comments preceded by whitespace detected for Objective-C and Matlab.

I know Matlab intimately and I'm willing to do a bit of work to finally get Matlab and Objective-C .m files to be reliably distinguished from one another (there are Matlab repositories on GitHub that are misclassified, including one of mine: github.com/horchler/QTWriter). Let me know how I can help.

Signed-off-by: Andrew D. Horchler adh9@case.edu
