### PR TITLE
langauges.yml: Add python syntax highlighting to waf's wscript files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -958,6 +958,8 @@ Python:
   - .pyw
   - .wsgi
   - .xpy
+  filenames:
+  - wscript
 
 Python traceback:
   type: data


### PR DESCRIPTION
[waf](http://code.google.com/p/waf/)'s wscript files are simply python files. It would be nice to have them correctly syntax highlighted on github.
