### PR TITLE
Clojure projects mislabeled

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -23,6 +23,8 @@
 # Vendored depedencies
 - vendor/
 
+# Java assets
+- resources/
 
 ## Commonly Bundled JavaScript frameworks ##
 


### PR DESCRIPTION
I don't know if this is a universal java thing, but having my Clojure projects mis-labeled has happened a bunch over the last few years. resources/ is a common place to drop images, CSS, JS, etc. Not dropping another vendor/ directory under resources/js to please the Gods has bitten me on more than one occasion. I'm not sure this is the perfect solution, but it does seem to be quite common to nest assets under resources/*. Leiningen (a common build tool for Clojure) seems opinionated about this and defaults to adding it to the classpath IIRC. Thanks in advance!
