### PR TITLE
Added detection for the XC programming language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1292,6 +1292,13 @@ Visual Basic:
   - .vba
   - .vbs
 
+XC:
+  type: programming
+  lexer: C
+  primary_extension: .xc
+  extensions:
+  - .xc
+
 XML:
   type: markup
   ace_mode: xml

--- a/test/fixtures/xc/main.xc
+++ b/test/fixtures/xc/main.xc
@@ -1,0 +1,10 @@
+int main()
+{
+  int x;
+  chan c;
+  par {
+    c <: 0;
+    c :> x;
+  }
+  return x;
+}


### PR DESCRIPTION
This adds detection for the XC programming language (see http://en.wikipedia.org/wiki/XC_Programming_Language), a C like language for developing embedded applications on XMOS devices.

There are various examples of projects using XC to be found at https://github.com/xcore and it would be great if XC was detected as a language.

I have successfully tested this using bundle exec rake test.
