### PR TITLE
Added detection for Bluespec System Verilog

### DIFF
--- a/lib/linguist/classifier.yml
+++ b/lib/linguist/classifier.yml
@@ -1,11 +1,12 @@
 --- !ruby/object:Linguist::Classifier
-languages_total: 217
-tokens_total: 152712
+languages_total: 218
+tokens_total: 152750
 languages:
   "Apex": 6
   "AppleScript": 2
   "Arduino": 1
   "AutoHotkey": 1
+  "Bluespec": 1
   "C": 18
   "C++": 14
   "CoffeeScript": 9
@@ -72,6 +73,7 @@ language_tokens:
   "AppleScript": 190
   "Arduino": 20
   "AutoHotkey": 3
+  "Bluespec": 38
   "C": 34180
   "C++": 8284
   "CoffeeScript": 2340
@@ -568,6 +570,25 @@ tokens:
     "Hello": 1
     "MsgBox": 1
     "World": 1
+  "Bluespec":
+    "(": 4
+    ")": 4
+    "*": 2
+    "//": 8
+    ";": 5
+    "Empty": 1
+    "Tb": 2
+    "display": 1
+    "endmodule": 1
+    "endpackage": 1
+    "endrule": 1
+    "finish": 1
+    "greet": 1
+    "mkTb": 2
+    "module": 1
+    "package": 1
+    "rule": 1
+    "synthesize": 1
   "C":
     "#": 17
     "#define": 57

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -134,6 +134,13 @@ BlitzMax:
   extensions:
   - .bmx
 
+Bluespec:
+  type: programming
+  lexer: verilog
+  color: "#848bf3"
+  extensions:
+  - .bsv
+  
 Boo:
   type: programming
   color: "#d4bec1"

--- a/samples/bluespec/Tb.bsv
+++ b/samples/bluespec/Tb.bsv
@@ -1,0 +1,24 @@
+// Copyright 2008 Bluespec, Inc.  All rights reserved.
+
+// ================================================================
+// Small Example Suite: Example 1a
+// Very basic 'Hello World' example just to go through the
+// mechanics of actually building and running a small BSV program
+// (and not intended to teach anything about hardware!).
+// ================================================================
+
+package Tb;
+
+(* synthesize *)
+module mkTb (Empty);
+
+   rule greet;
+      $display ("Hello World!");
+      $finish (0);
+   endrule
+
+endmodule: mkTb
+
+endpackage: Tb
+
+// ================================================================


### PR DESCRIPTION
Added the language specification to the YAML file. Extension is .bsv and does not conflict with any other definitions for now. No conflicts foreseeable in future either. No pygments lexer is available for BSV and hence I am defaulting to Verilog for now.
