### PR TITLE
Exception for GNU autotools generated configure scripts

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -94,3 +94,6 @@
 
 # Samples folders
 - ^[Ss]amples/
+
+# GNU autotools created configure script
+- configure$


### PR DESCRIPTION
Exception for GNU autotools generated configure scripts, these are generated from configure.ac and **not** written by hand.
