### PR TITLE
Add .rabl extension to Ruby language

### DIFF
--- a/samples/ruby/rabl.rabl
+++ b/samples/ruby/rabl.rabl
@@ -1,0 +1,16 @@
+object @user => :person
+
+attributes :username, :email, :location
+attributes :created_at => :registered_at
+
+node :role do |user|
+  user.is_admin ? 'admin' : 'normal'
+end
+
+child :phone_numbers => :pnumbers do
+  extends "users/phone_number"
+end
+
+node :node_numbers do |u|
+  partial("users/phone_number", :object => u.phone_numbers)
+end


### PR DESCRIPTION
This pull request adds support for `.rabl` files (as Ruby) for the popular [RABL](https://github.com/nesquena/rabl) templating engine.
