### PR TITLE
Add extension for AppleScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -74,6 +74,9 @@ AppleScript:
   aliases:
   - osascript
   primary_extension: .scpt
+  extensions:
+  - .applescript
+  - .scpt
 
 Arc:
   type: programming


### PR DESCRIPTION
I have a repo with a .applescript file which is not recognized.
I found out that only .scpt is listed in the yml.
However, scpt is more likely used for binary and applescript for source.

A sample file with applescript extension already exists.
