### PR TITLE
Fixed problem where blob.pathname does not exist.

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -23,7 +23,7 @@ elsif File.file?(path)
 
   puts "#{blob.name}: #{blob.loc} lines (#{blob.sloc} sloc)"
   puts "  type:      #{type}"
-  puts "  extension: #{blob.pathname.extname}"
+  puts "  extension: #{blob.extname}"
   puts "  mime type: #{blob.mime_type}"
   puts "  language:  #{blob.language}"
 


### PR DESCRIPTION
Error:

```
$ linguist _layouts/inner.html 
_layouts/inner.html: 49 lines (46 sloc)
  type:      Text
/Library/Ruby/Gems/1.8/gems/github-linguist-2.2.1/bin/linguist:26: undefined method `pathname' for #<Linguist::FileBlob:0x10124c190> (NoMethodError)
    from /usr/bin/linguist:23:in `load'
    from /usr/bin/linguist:23
```

Mac OS X 10.6.8. Tested on `ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-darwin10.8.0]` (rvm) and `ruby 1.8.7 (2010-01-10 patchlevel 249) [universal-darwin10.0]` (system).
