### PR TITLE
Add jQuery UI and more ASP.NET MVC files to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -85,7 +85,8 @@
 - -vsdoc\.js$
 
 # jQuery validation plugin (MS bundles this with asp.net mvc)
-- (^|/)jquery([^.]*)\.validate(\.min)?\.js$
+- (^|/)jquery([^.]*)\.validate(\.unobtrusive)?(\.min)?\.js$
+- (^|/)jquery([^.]*)\.unobtrusive\-ajax(\.min)?\.js$
 
 # Microsoft Ajax
 - (^|/)[Mm]icrosoft([Mm]vc)?([Aa]jax|[Vv]alidation)(\.debug)?\.js$

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -269,6 +269,11 @@ class TestBlob < Test::Unit::TestCase
 
     # jQuery validation plugin (MS bundles this with asp.net mvc)
     assert blob("Scripts/jquery.validate.js").vendored?
+    assert blob("Scripts/jquery.validate.min.js").vendored?
+    assert blob("Scripts/jquery.validate.unobtrusive.js").vendored?
+    assert blob("Scripts/jquery.validate.unobtrusive.min.js").vendored?
+    assert blob("Scripts/jquery.unobtrusive-ajax.js").vendored?
+    assert blob("Scripts/jquery.unobtrusive-ajax.min.js").vendored?
 
     # NuGet Packages
     assert blob("packages/Modernizr.2.0.6/Content/Scripts/modernizr-2.0.6-development-only.js").vendored?


### PR DESCRIPTION
jQuery UI is used in quite some projects and should be recognized as a vendor library too. Also enhance detection of the jQuery validation plugin that is Microsoft adds to ASP.NET MVC projects by default. 
