### PR TITLE
Adding vendor files for django (admin_media) and SyntaxHightlighter JavaScript library

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -61,7 +61,15 @@
 # MathJax
 - (^|/)MathJax/
 
+# SyntaxHighlighter - http://alexgorbatchev.com/
+- (^|/)shBrush([^.]*)\.js$
+- (^|/)shCore\.js$
+- (^|/)shLegacy\.js$
+
 ## Python ##
+
+# django
+- (^|/)admin_media/
 
 # Fabric
 - ^fabfile\.py$


### PR DESCRIPTION
SyntaxHighlighter should be recognized as a vendor library. 
Also enhance detection of the django template and treat _admin_media_ directory and files as vendor.
