### PR TITLE
add Frege programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -468,6 +468,12 @@ Fantom:
   extensions:
   - .fan
 
+Frege:
+  type: programming
+  primary_extension: .fr
+  extensions:
+  - .fr
+
 GAS:
   type: programming
   group: Assembly


### PR DESCRIPTION
This is just a simple addition to the languages.yaml file for the
Frege programming language (http://code.google.com/p/frege/)
