### PR TITLE
Add .C and .H as C++ file extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -179,8 +179,10 @@ C++:
   - cpp
   primary_extension: .cpp
   extensions:
+  - .C
   - .c++
   - .cxx
+  - .H
   - .h++
   - .hh
   - .hxx


### PR DESCRIPTION
Captial C and capital H are two file extensions recognized by gcc as indicating C++ source code. 
