### PR TITLE
Exclude dependencies for C/C++ even if they are not in root folder.

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -14,7 +14,7 @@
 
 # C deps
 #  https://github.com/joyent/node
-- ^deps/
+- (^|/)deps/
 - ^tools/
 
 # Node depedencies


### PR DESCRIPTION
This is needed by my project and for any one who wants to store dependencies not in the root folder.
