### PR TITLE
Attempt to fix issue #272

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -756,9 +756,8 @@ Matlab:
   primary_extension: .m
   extensions:
   - .fig
-  - .m
-  - .mexmac
   - .mexglx
+  - .mexmac
   - .mexw32
   - .p
 


### PR DESCRIPTION
< This pull request isn't ready!! >

Added .m as the primary extension for Matlab and removed the bogus 
.matlab extension that doesn't qualify as a Matlab file extension. 
Extensions taken from: 
http://en.wikipedia.org/wiki/MATLAB#File_extensions
