### PR TITLE
Add support for the CLIPS programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -207,6 +207,7 @@ C2hs Haskell:
 
 CLIPS:
   type: programming
+  lexer: Text only
   primary_extension: .clp
 
 CMake:


### PR DESCRIPTION
CLIPS or C language integrated production system is a tool for writing expert
systems.

I did not add a syntax highlighter nor test files because my objective was to make sure that github tags my projects as CLIPS because right now they're blank. 
