### PR TITLE
Add deface extension support.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -566,7 +566,9 @@ HTML+ERB:
   primary_extension: .erb
   extensions:
   - .erb
+  - .erb.deface
   - .html.erb
+  - .html.erb.deface
 
 HTML+PHP:
   type: markup
@@ -590,6 +592,8 @@ Haml:
   group: HTML
   type: markup
   primary_extension: .haml
+  extensions:
+  - .haml.deface
 
 Haskell:
   type: programming


### PR DESCRIPTION
Deface has a nice template dsl (https://github.com/spree/deface#using-the-deface-dsl-deface-files) when using the .deface extension.  Now it will look great with syntax highlighting on Github.
