### PR TITLE
Added detection for the Elm language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -392,6 +392,13 @@ Elixir:
   - .ex
   - .exs
 
+Elm:
+  type: programming
+  lexer: Haskell
+  primary_extension: .elm
+  extensions:
+  - .elm
+
 Emacs Lisp:
   type: programming
   lexer: Scheme


### PR DESCRIPTION
http://elm-lang.org/

The lexer is set to Haskell, since at the moment Elm is syntactically a subset of Haskell. The official website uses CodeMirror with the mode set to Haskell, as well.
