### PR TITLE
Don't explode on invalid shebang

### DIFF
--- a/lib/linguist/samples.json
+++ b/lib/linguist/samples.json
@@ -260,8 +260,8 @@
       ".gemrc"
     ]
   },
-  "tokens_total": 271187,
-  "languages_total": 275,
+  "tokens_total": 271188,
+  "languages_total": 276,
   "tokens": {
     "Apex": {
       "global": 70,
@@ -25252,7 +25252,7 @@
     },
     "Shell": {
       "SHEBANG#!bash": 6,
-      "echo": 52,
+      "echo": 53,
       "export": 6,
       "PATH": 5,
       "pkgname": 1,
@@ -27795,7 +27795,7 @@
     "Scheme": 3478,
     "Scilab": 69,
     "SCSS": 39,
-    "Shell": 2008,
+    "Shell": 2009,
     "Standard ML": 243,
     "SuperCollider": 135,
     "Tea": 3,
@@ -27866,7 +27866,7 @@
     "Scheme": 1,
     "Scilab": 3,
     "SCSS": 1,
-    "Shell": 16,
+    "Shell": 17,
     "Standard ML": 2,
     "SuperCollider": 1,
     "Tea": 1,
@@ -27881,5 +27881,5 @@
     "XSLT": 1,
     "YAML": 1
   },
-  "md5": "8591cfa68ab6fe3b3dacbcb885be70d0"
+  "md5": "384f02c0bd223479bf750d4cd36daf71"
 }

--- a/lib/linguist/tokenizer.rb
+++ b/lib/linguist/tokenizer.rb
@@ -138,7 +138,7 @@ module Linguist
           s.scan(/\s+/)
           script = s.scan(/\S+/)
         end
-        script = script[/[^\d]+/, 0]
+        script = script[/[^\d]+/, 0] if script
         return script
       end
 

--- a/samples/Shell/invalid-shebang.sh
+++ b/samples/Shell/invalid-shebang.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env 
+
+echo "wat"

--- a/test/test_tokenizer.rb
+++ b/test/test_tokenizer.rb
@@ -94,6 +94,7 @@ class TestTokenizer < Test::Unit::TestCase
     assert_equal "SHEBANG#!ruby", tokenize(:"Ruby/ruby.script!")[0]
     assert_equal "SHEBANG#!ruby", tokenize(:"Ruby/ruby2.script!")[0]
     assert_equal "SHEBANG#!node", tokenize(:"JavaScript/js.script!")[0]
+    assert_equal "echo", tokenize(:"Shell/invalid-shebang.sh")[0]
   end
 
   def test_javascript_tokens


### PR DESCRIPTION
A shebang like this currently throws an exception all the way up.

```
#!/usr/bin/env 
```

Fixed.
