### PR TITLE
Adds detection for the Flua programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -469,6 +469,13 @@ Fantom:
   extensions:
   - .fan
 
+Flua:
+  type: programming
+  color: "#ffff00"
+  primary_extension: .flua
+  extensions:
+  - .flua
+
 GAS:
   type: programming
   group: Assembly


### PR DESCRIPTION
Haven't tested it but according to the linguist README that should be enough.
See https://github.com/blitzprog/flua for more information.
