### PR TITLE
Use the "Racket" lexer for Racket.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1033,7 +1033,7 @@ RHTML:
 Racket:
   type: programming
   lexer: Racket
-  color: "#ae17ff"
+  color: "#ae18ff"
   primary_extension: .rkt
   extensions:
   - .rkt


### PR DESCRIPTION
Use the dedicated Racket lexer from https://github.com/tmm1/pygments.rb/pull/52,
which in turn pulls from https://bitbucket.org/birkenfeld/pygments-main/pull-request/94/add-lexer-for-racket-language/diff
