### PR TITLE
Make sure we set content-type for non-binary types as well

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -69,8 +69,11 @@ module Linguist
     #
     # Returns a content type String.
     def content_type
-      @content_type ||= (binary_mime_type? || binary?) ? mime_type :
-        (encoding ? "text/plain; charset=#{encoding.downcase}" : "text/plain")
+      return @content_type if defined? @content_type
+
+      @content_type = mime_type ? mime_type : "text/plain"
+      @content_type << "; charset=#{encoding.downcase}"
+      @content_type
     end
 
     # Public: Get the Content-Disposition header value


### PR DESCRIPTION
Currently `BlobHelper#content_type` only returns a detected mime-type if the contents were determined to be binary while returning `text/plain` for everything else. I think this was so that we could serve raw blobs in the browser without it trying to download it?

What do you think?
