### PR TITLE
Pessimistic versioning for pygments.rb, and bump to latest

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'charlock_holmes', '~> 0.6.6'
   s.add_dependency 'escape_utils',    '~> 0.2.3'
   s.add_dependency 'mime-types',      '~> 1.19'
-  s.add_dependency 'pygments.rb',     '>= 0.3.0'
+  s.add_dependency 'pygments.rb',     '~> 0.3.7'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This bumps us to the latest pygments.rb with updated lexers, and it also switches to the pessimistic version constraint for greater stability.

cc @josh
