### PR TITLE
languages.yml: add .dpr and .dfm extension to Delphi

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -344,8 +344,8 @@ Delphi:
   color: "#b0ce4e"
   primary_extension: .pas
   extensions:
-  - .dpr
   - .dfm
+  - .dpr
   - .lpr
   - .pas
 


### PR DESCRIPTION
.dfm is Delphi formulars
.dpr is the main source file, before any .pas.

if your Delphi app does not use any formulars or units
(e.g. console app), there is basically only one .dpr file.
