### PR TITLE
Additional XQuery file extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1333,8 +1333,8 @@ XQuery:
   - .xq
   - .xql
   - .xqm
-  - .xqy
   - .xquery
+  - .xqy
 
 XS:
   lexer: C


### PR DESCRIPTION
Two common XQuery file extensions were missing from Linguist's definitions: .xql and .xqm.  Adding these will help Linguist recognize XQuery projects in Github as such.  Thanks for considering this.
