### PR TITLE
Add LESS support (.less)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -731,6 +731,13 @@ Lasso:
   - .lasso9
   - .ldml
 
+Less:
+  type: markup
+  group: CSS
+  lexer: CSS
+  ace_mode: less
+  primary_extension: .less
+
 LilyPond:
   lexer: Text only
   primary_extension: .ly

--- a/samples/Less/screen.less
+++ b/samples/Less/screen.less
@@ -1,0 +1,14 @@
+@blue: #3bbfce;
+@margin: 16px;
+
+.content-navigation {
+  border-color: @blue;
+  color:
+    darken(@blue, 9%);
+}
+
+.border {
+  padding: @margin / 2;
+  margin: @margin / 2;
+  border-color: @blue;
+}


### PR DESCRIPTION
Cheating slightly as it uses the CSS lexer, as pygments currently does
not have a dedicated less lexer. But I figure language recognition and
90% percent correct syntax highlighting is better than neither.

---

If the lexer is deemed to be ill-fitting then even using the "Text Only" lexer would be worthwhile, just so the primary language of Github's most popular repo (i.e [twitter/bootstrap](https://github.com/twitter/bootstrap)) can be recognized as such.
