### PR TITLE
Remove extra extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1060,6 +1060,7 @@ Shell:
   color: "#5861ce"
   aliases:
   - sh
+  - bash
   - zsh
   primary_extension: .sh
 


### PR DESCRIPTION
This removes the superfluous extensions when we already have the `primary_extension`.
