### PR TITLE
Support of Qt Designer .ui files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1345,12 +1345,12 @@ XML:
   - .rss
   - .scxml
   - .svg
-  - .ui
   - .tmCommand
   - .tmLanguage
   - .tmPreferences
   - .tmSnippet
   - .tml
+  - .ui
   - .vxml
   - .wsdl
   - .wxi


### PR DESCRIPTION
Qt Designer uses .ui files to store ui in xml. This commit should highlight all *.ui files to XML - it's very important.
