### PR TITLE
Update lib/linguist/languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1243,6 +1243,9 @@ XML:
   - .xsd
   - .xsl
   - .xul
+  - .dita
+  - .ditamap
+  - .ditaval
   filenames:
   - .classpath
   - .project


### PR DESCRIPTION
Add dita file extention to the XML markup.
DITA is the OASIS Darwin Information Typing Architecture used for technical documentation.
@see https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita
