### PR TITLE
Add dita file extention to the XML type

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1223,6 +1223,9 @@ XML:
   primary_extension: .xml
   extensions:
   - .ccxml
+  - .dita
+  - .ditamap
+  - .ditaval
   - .glade
   - .grxml
   - .kml


### PR DESCRIPTION
2nd try. Add dita file extention to the XML markup.
DITA is the OASIS Darwin Information Typing Architecture used for technical documentation.
@see https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=dita
