### PR TITLE
Add fish support (.fish)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1285,6 +1285,12 @@ eC:
   extensions:
   - .eh
 
+fish:
+  type: programming
+  group: Shell
+  lexer: Text only
+  primary_extension: .fish
+
 mupad:
   lexer: MuPAD
   primary_extension: .mu

--- a/samples/fish/config.fish
+++ b/samples/fish/config.fish
@@ -1,0 +1,98 @@
+#
+# Main file for fish command completions. This file contains various
+# common helper functions for the command completions. All actual
+# completions are located in the completions subdirectory.
+#
+
+#
+# Set default field separators
+#
+
+set -g IFS \n\ \t
+
+#
+# Set default search paths for completions and shellscript functions
+# unless they already exist
+#
+
+set -l configdir ~/.config
+
+if set -q XDG_CONFIG_HOME
+	set configdir $XDG_CONFIG_HOME
+end
+
+# __fish_datadir, __fish_sysconfdir, __fish_help_dir, __fish_bin_dir
+# are expected to have been set up by read_init from fish.cpp
+
+# Set up function and completion paths. Make sure that the fish
+# default functions/completions are included in the respective path.
+
+if not set -q fish_function_path
+	set fish_function_path $configdir/fish/functions    $__fish_sysconfdir/functions    $__fish_datadir/functions
+end
+
+if not contains $__fish_datadir/functions $fish_function_path
+	set fish_function_path[-1] $__fish_datadir/functions
+end
+
+if not set -q fish_complete_path
+	set fish_complete_path $configdir/fish/completions  $__fish_sysconfdir/completions  $__fish_datadir/completions
+end
+
+if not contains $__fish_datadir/completions $fish_complete_path
+	set fish_complete_path[-1] $__fish_datadir/completions
+end
+
+#
+# This is a Solaris-specific test to modify the PATH so that
+# Posix-conformant tools are used by default. It is separate from the
+# other PATH code because this directory needs to be prepended, not
+# appended, since it contains POSIX-compliant replacements for various
+# system utilities.
+#
+
+if test -d /usr/xpg4/bin
+	if not contains /usr/xpg4/bin $PATH
+		set PATH /usr/xpg4/bin $PATH
+	end
+end
+
+#
+# Add a few common directories to path, if they exists. Note that pure
+# console programs like makedep sometimes live in /usr/X11R6/bin, so we
+# want this even for text-only terminals.
+#
+
+set -l path_list /bin /usr/bin /usr/X11R6/bin /usr/local/bin $__fish_bin_dir
+
+# Root should also have the sbin directories in the path
+switch $USER
+	case root
+	set path_list $path_list /sbin /usr/sbin /usr/local/sbin
+end
+
+for i in $path_list
+	if not contains $i $PATH
+		if test -d $i
+			set PATH $PATH $i
+		end
+	end
+end
+
+#
+# Launch debugger on SIGTRAP
+#
+function fish_sigtrap_handler --on-signal TRAP --no-scope-shadowing --description "Signal handler for the TRAP signal. Lanches a debug prompt."
+	breakpoint
+end
+
+#
+# Whenever a prompt is displayed, make sure that interactive
+# mode-specific initializations have been performed.
+# This handler removes itself after it is first called.
+#
+function __fish_on_interactive --on-event fish_prompt
+	__fish_config_interactive
+	functions -e __fish_on_interactive
+end
+

--- a/samples/fish/eval.fish
+++ b/samples/fish/eval.fish
@@ -1,0 +1,28 @@
+
+function eval -S -d "Evaluate parameters as a command"
+
+	# If we are in an interactive shell, eval should enable full
+	# job control since it should behave like the real code was
+	# executed.  If we don't do this, commands that expect to be
+	# used interactively, like less, wont work using eval.
+
+	set -l mode
+	if status --is-interactive-job-control
+		set mode interactive
+	else
+		if status --is-full-job-control
+			set mode full
+		else
+			set mode none
+		end
+	end
+	if status --is-interactive
+		status --job-control full
+	end
+
+	echo "begin; $argv ;end eval2_inner <&3 3<&-" | . 3<&0
+	set -l res $status
+
+	status --job-control $mode
+	return $res
+end

--- a/samples/fish/funced.fish
+++ b/samples/fish/funced.fish
@@ -1,0 +1,101 @@
+function funced --description 'Edit function definition'
+    set -l editor $EDITOR
+    set -l interactive
+    set -l funcname
+    while set -q argv[1]
+        switch $argv[1]
+            case -h --help
+                __fish_print_help funced
+                return 0
+
+            case -e --editor
+                set editor $argv[2]
+                set -e argv[2]
+
+            case -i --interactive
+                set interactive 1
+
+            case --
+                set funcname $funcname $argv[2]
+                set -e argv[2]
+
+            case '-*'
+                set_color red
+                printf (_ "%s: Unknown option %s\n") funced $argv[1]
+                set_color normal
+                return 1
+
+            case '*' '.*'
+                set funcname $funcname $argv[1]
+        end
+        set -e argv[1]
+    end
+
+    if begin; set -q funcname[2]; or not test "$funcname[1]"; end
+        set_color red
+        _ "funced: You must specify one function name
+"
+        set_color normal
+        return 1
+    end
+
+    set -l init
+    switch $funcname
+        case '-*'
+        set init function -- $funcname\n\nend
+        case '*'
+        set init function $funcname\n\nend
+    end
+
+    # Break editor up to get its first command (i.e. discard flags)
+    if test -n "$editor"
+        set -l editor_cmd
+        eval set editor_cmd $editor
+        if not type -f "$editor_cmd[1]" >/dev/null
+            _ "funced: The value for \$EDITOR '$editor' could not be used because the command '$editor_cmd[1]' could not be found
+    "
+            set editor fish
+        end
+    end
+    
+    # If no editor is specified, use fish
+    if test -z "$editor"
+        set editor fish
+    end
+
+    if begin; set -q interactive[1]; or test "$editor" = fish; end
+        set -l IFS
+        if functions -q -- $funcname
+            # Shadow IFS here to avoid array splitting in command substitution
+            set init (functions -- $funcname | fish_indent --no-indent)
+        end
+
+        set -l prompt 'printf "%s%s%s> " (set_color green) '$funcname' (set_color normal)'
+        # Unshadow IFS since the fish_title breaks otherwise
+        set -e IFS
+        if read -p $prompt -c "$init" -s cmd
+            # Shadow IFS _again_ to avoid array splitting in command substitution
+            set -l IFS
+            eval (echo -n $cmd | fish_indent)
+        end
+        return 0
+    end
+
+    set -q TMPDIR; or set -l TMPDIR /tmp
+    set -l tmpname (printf "$TMPDIR/fish_funced_%d_%d.fish" %self (random))
+    while test -f $tmpname
+        set tmpname (printf "$TMPDIR/fish_funced_%d_%d.fish" %self (random))
+    end
+
+    if functions -q -- $funcname
+        functions -- $funcname > $tmpname
+    else
+        echo $init > $tmpname
+    end
+    if eval $editor $tmpname
+        . $tmpname
+    end
+    set -l stat $status
+    rm -f $tmpname >/dev/null
+    return $stat
+end


### PR DESCRIPTION
Add [fish](https://github.com/fish-shell/fish-shell) support.

Using `lexer: Text only`, as Pygments currently does not have a dedicated fish lexer.
Have tried `lexer: Bash` but the result was not acceptable.
