### PR TITLE
Ignore test suite folders for language tagging and stats

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -96,3 +96,6 @@
 
 # Samples folders
 - ^[Ss]amples/
+
+# Test suite folders
+- (^|/)t(ests?)?/


### PR DESCRIPTION
I've updated the vendor.yml file to exclude folders like t/, test/, and tests/.

I've been crazy to see most of my pure C and pure Lua projects get tagged as Perl stuffs just because I use Perl for their test suites.

Hopefully this patch can get merged and applied to GitHub soon.

Thank you in advance!
