### PR TITLE
Add Verilog (.vh) and SystemVerilog (.sv, .svh) filename extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1192,6 +1192,10 @@ Verilog:
   lexer: verilog
   color: "#848bf3"
   primary_extension: .v
+  extensions:
+  - .vh
+  - .sv
+  - .svh
 
 VimL:
   type: programming


### PR DESCRIPTION
Most Verilog files use the *.vh extension for header files.

Since the IEEE 1800-2009 SystemVerilog standard, it is common for
hardware and verification files written using the newer language
constructs to use the *.sv extension for design elements, and *.svh for
headers.
