### PR TITLE
Add .bash and .tmux as alternate shell extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1101,6 +1101,9 @@ Shell:
   - bash
   - zsh
   primary_extension: .sh
+  extensions:
+  - .bash
+  - .tmux
 
 Smalltalk:
   type: programming


### PR DESCRIPTION
Adds `.tmux` and `.bash` as valid extensions for shell
