### PR TITLE
Add extension support for Iced Coffeescript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -225,6 +225,7 @@ CoffeeScript:
   extensions:
   - ._coffee
   - .cson
+  - .iced
   filenames:
   - Cakefile
 


### PR DESCRIPTION
[Iced Coffeescript](http://maxtaco.github.com/coffee-script/) is a relatively popular extension of Coffeescript. The only difference is the addition of two new keywords, so syntax highlighting should work pretty much 99% out of the box.
