### PR TITLE
Add Awk Support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -109,6 +109,20 @@ AutoHotkey:
   - ahk
   primary_extension: .ahk
 
+Awk:
+  type: programming
+  lexer: Awk
+  color: "#6666cc"
+  aliases:
+  - gawk
+  - mawk
+  - nawk
+  primary_extension: .awk
+  extensions:
+  - .gawk
+  - .mawk
+  - .nawk
+
 Batchfile:
   type: programming
   group: Shell

--- a/samples/Awk/hello_world.awk
+++ b/samples/Awk/hello_world.awk
@@ -1,0 +1,15 @@
+#!/usr/bin/awk -f
+BEGIN {
+    RS = ORS = "\r\n"
+    HttpService = "/inet/tcp/8080/0/0"
+    Hello = "<HTML><HEAD>" \
+            "<TITLE>A Famous Greeting</TITLE></HEAD>" \
+            "<BODY><H1>Hello, world</H1></BODY></HTML>"
+    Len = length(Hello) + length(ORS)
+    print "HTTP/1.0 200 OK"          |& HttpService
+    print "Content-Length: " Len ORS |& HttpService
+    print Hello                      |& HttpService
+    while ((HttpService |& getline) > 0)
+        continue;
+    close(HttpService)
+}

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -10,6 +10,7 @@ class TestLanguage < Test::Unit::TestCase
 
   def test_lexer
     assert_equal Lexer['ActionScript 3'], Language['ActionScript'].lexer
+    assert_equal Lexer['Awk'], Language['Awk'].lexer
     assert_equal Lexer['Bash'], Language['Gentoo Ebuild'].lexer
     assert_equal Lexer['Bash'], Language['Gentoo Eclass'].lexer
     assert_equal Lexer['Bash'], Language['Shell'].lexer
@@ -63,6 +64,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['ActionScript'], Language.find_by_alias('as3')
     assert_equal Language['ApacheConf'], Language.find_by_alias('apache')
     assert_equal Language['Assembly'], Language.find_by_alias('nasm')
+    assert_equal Language['Awk'], Language.find_by_alias('gawk')
     assert_equal Language['Batchfile'], Language.find_by_alias('bat')
     assert_equal Language['C#'], Language.find_by_alias('c#')
     assert_equal Language['C#'], Language.find_by_alias('csharp')


### PR DESCRIPTION
I know that some efforts have been made to add [AWK](http://en.wikipedia.org/wiki/AWK) support ([#164](https://github.com/github/linguist/pull/164) and [#275](https://github.com/github/linguist/pull/275)), but here comes another try.

AWK is a handy text processing language which [a lot of people still work with](https://github.com/search?q=extension%3Aawk). Since pygments has a lexer for it, it seems quite reasonable to have it supported by GitHub.

have chosen [#6666cc](http://www.colorhexa.com/6666cc) as its color. and followed pygments' naming convention `Awk` (instead of all-capitial `AWK`)
