### PR TITLE
Treat .opencl files as OpenCL

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -862,6 +862,8 @@ OpenCL:
   group: C
   lexer: C
   primary_extension: .cl
+  extensions:
+  - .opencl
 
 OpenEdge ABL:
   type: programming


### PR DESCRIPTION
My projects use .opencl as the file extension for OpenCL files. It would be great if they were properly detected.
