### PR TITLE
Add tapesty (.tml) to XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1247,6 +1247,7 @@ XML:
   - .rss
   - .scxml
   - .svg
+  - .tml
   - .vxml
   - .wsdl
   - .wxi


### PR DESCRIPTION
Tapestry template files are well-formed XML documents.

http://tapestry.apache.org/component-templates.html
