### PR TITLE
XSLT as a programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1262,7 +1262,6 @@ XML:
   - .xlf
   - .xliff
   - .xsd
-  - .xsl
   - .xul
   filenames:
   - .classpath


### PR DESCRIPTION
XSLT should be identified as a programming language, rather than just a generic markup syntax.
