### PR TITLE
Add ASDF files to Common Lisp

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -247,9 +247,9 @@ Common Lisp:
   - lisp
   primary_extension: .lisp
   extensions:
+  - .asd
   - .lsp
   - .ny
-  - .asd
 
 Coq:
   type: programming


### PR DESCRIPTION
ASDF is a build system for common lisp. The .asd extension is just convention, as far as I can tell. The file is plain CL.

http://www.cliki.net/asdf

Some examples:
- https://github.com/edicl/hunchentoot/blob/master/hunchentoot.asd
- https://github.com/cmoore/inez/blob/master/inez.asd
