### PR TITLE
Add .editorconfig as an INI file

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -585,6 +585,8 @@ INI:
   - .prefs
   - .properties
   primary_extension: .ini
+  filenames:
+  - .editorconfig
 
 IRC log:
   lexer: IRC logs

--- a/samples/INI/filenames/.editorconfig
+++ b/samples/INI/filenames/.editorconfig
@@ -1,0 +1,10 @@
+; editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Reattempting #370, after working out that you need to add filenames to languages.yml, prior to adding files inside samples/filenames/ and only after you regenerate the samples.json can you remove the references in languages.yml.

See http://editorconfig.org
