### PR TITLE
Add .litcoffee as a Markdown extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -753,6 +753,7 @@ Markdown:
   wrap: true
   primary_extension: .md
   extensions:
+  - .litcoffee
   - .markdown
   - .mkd
   - .mkdown


### PR DESCRIPTION
Ref http://coffeescript.org/#literate

CoffeeScript as of version 1.5.0 uses the ".litcoffee" extension
for Literate CoffeeScript: CoffeeScript programs written in Markdown.
