### PR TITLE
Add secondary filename extensions for Lasso

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -682,6 +682,12 @@ Lasso:
   ace_mode: lasso
   color: "#2584c3"
   primary_extension: .lasso
+  extensions:
+  - .inc
+  - .las
+  - .lasso
+  - .lasso9
+  - .ldml
 
 Less:
   type: markup


### PR DESCRIPTION
Somehow these got omitted from languages.yml
