### PR TITLE
Added another python sample for detection via hashbang line

### DIFF
--- a/samples/Python/script
+++ b/samples/Python/script
@@ -1,0 +1,31 @@
+#!/usr/bin/env python2
+
+# Copyright (c) 2013 Blake Rainwater
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#   The above copyright notice and this permission notice shall be
+#   included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Copywrite notice copied from
+# https://github.com/github/linguist/blob/aac1c6ebc5cd7b02f80e87c4aa30de621822f5ef/LICENSE
+
+# Copywrite included due to prevalence of copywrite notices at the
+# top of source files, so as to hopefully enhance detection.
+
+print 'A Message'


### PR DESCRIPTION
Created a sample file that includes the env of 'python2', which had caused the python file at https://github.com/mstill/thunner/blob/c3ede9b791a23266c8a19387868a1650161a6833/thunner to be incorrectly detected, causing an unmatched single quote that was in fact an apostrophe in a comment (see line 219 and below). Also see issue https://github.com/github/linguist/issues/264 as it is related (though I don't think this will fix that specific issue).
