### PR TITLE
Vendor test/fixtures

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -108,3 +108,6 @@
 
 # Samples folders
 - ^[Ss]amples/
+
+# Test fixtures
+- ^[Tt]est/fixtures/

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -273,6 +273,10 @@ class TestBlob < Test::Unit::TestCase
 
     # NuGet Packages
     assert blob("packages/Modernizr.2.0.6/Content/Scripts/modernizr-2.0.6-development-only.js").vendored?
+
+    # Test fixtures
+    assert blob("test/fixtures/random.rkt").vendored?
+    assert blob("Test/fixtures/random.rkt").vendored?
   end
 
   def test_indexable


### PR DESCRIPTION
We should ignore stuff in `test/fixtures` — https://github.com/brianmario/charlock_holmes is a good example (`racket` comes up at 21 percent)
