### PR TITLE
Remove XProc and XSLT from the group XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1328,7 +1328,6 @@ XML:
   aliases:
   - rss
   - xsd
-  - xsl
   - wsdl
   primary_extension: .xml
   extensions:
@@ -1368,7 +1367,6 @@ XML:
 
 XProc:
   type: programming
-  group: XML
   lexer: XML
   primary_extension: .xpl
   extensions:
@@ -1388,7 +1386,8 @@ XS:
 
 XSLT:
   type: programming
-  group: XML
+  aliases:
+  - xsl
   primary_extension: .xslt
   extensions:
     - .xsl

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -133,7 +133,6 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['Shell'], Language['Gentoo Ebuild'].group
     assert_equal Language['Shell'], Language['Gentoo Eclass'].group
     assert_equal Language['Shell'], Language['Tcsh'].group
-    assert_equal Language['XML'], Language['XSLT'].group
 
     # Ensure everyone has a group
     Language.all.each do |language|


### PR DESCRIPTION
XProc and XSLT are two distinct programming languages, they should both appear individually in the programming language stats.
This PR removes them from a common "XML" group to fix this.
