### PR TITLE
Add `csv?` BlobHelper

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -158,6 +158,13 @@ module Linguist
       extname.downcase == '.stl'
     end
 
+    # Public: Is this blob a CSV file?
+    #
+    # Return true or false
+    def csv?
+      text? && extname.downcase == '.csv'
+    end
+
     # Public: Is the blob a PDF?
     #
     # Return true or false

--- a/samples/Text/cars.csv
+++ b/samples/Text/cars.csv
@@ -1,0 +1,3 @@
+Year,Make,Model,Length
+1997,Ford,E350,2.34
+2000,Mercury,Cougar,2.38

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -137,6 +137,10 @@ class TestBlob < Test::Unit::TestCase
     assert blob("Text/cube.stl").solid?
   end
 
+  def test_csv
+    assert blob("Text/cars.csv").csv?
+  end
+
   def test_pdf
     assert blob("Binary/foo.pdf").pdf?
   end


### PR DESCRIPTION
Add the `csv?` test to `BlobHelper` defined as a text file with a `.csv` extension and a simple test for it.
