### PR TITLE
new R language extension added

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1053,7 +1053,9 @@ R:
   type: programming
   color: "#198ce7"
   lexer: S
-  primary_extension: .r
+  primary_extension: .R
+  extensions:
+  - .r
 
 RHTML:
   type: markup


### PR DESCRIPTION
I added ".R" as the primary extension for the R programming language, as this is what is most commonly used in publicly distributed R code from major curators such as Bioconductor.
