### PR TITLE
Add ignore pattern for RSpec

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -72,6 +72,9 @@
 - (^|/)shCore\.js$
 - (^|/)shLegacy\.js$
 
+# RSpec
+- (^|/)spec/$
+
 ## Python ##
 
 # django


### PR DESCRIPTION
Such as [this repo](https://github.com/xuhdev/indent-java.vim), there should be no Ruby and Java at all, but the statistical data has show some Ruby and Java percentages.
