### PR TITLE
Add decimal places to statistic output

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -12,8 +12,9 @@ path = ARGV[0] || Dir.pwd
 if File.directory?(path)
   repo = Linguist::Repository.from_directory(path)
   repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
-    percentage = ((size / repo.size.to_f) * 100).round
-    puts "%-4s %s" % ["#{percentage}%", language]
+    percentage = ((size / repo.size.to_f) * 100)
+    percentage = sprintf '%.2f' % percentage
+    puts "%-7s %s" % ["#{percentage}%", language]
   end
 elsif File.file?(path)
   blob = Linguist::FileBlob.new(path, Dir.pwd)


### PR DESCRIPTION
If you analyze a project sometimes the statistic outputs a language with 0%. At first it seems that the language is not part of this project, but there are only some decimal places
missing.

This pull request adds two decimal places to the statistic output `linguist /folder/` or `bundle exec linguist /folder/`

**Original output (of a personal project)**

```
50%  Python
45%  Ruby
5%   PHP
```

**Output with PR (of a personal project)**

```
50.31%  Python
45.13%  Ruby
4.56%   PHP
```

**Original output (of [TYPO3 master](https://git.typo3.org/TYPO3v4/Core.git))**

```
84%  PHP
10%  JavaScript
6%   ActionScript
0%   XSLT
0%   Perl
0%   TypeScript
0%   Racket
0%   Shell
```

**Output with PR (of [TYPO3 master](https://git.typo3.org/TYPO3v4/Core.git))**

```
83.92%  PHP
9.96%   JavaScript
5.88%   ActionScript
0.13%   XSLT
0.04%   Perl
0.03%   TypeScript
0.02%   Racket
0.02%   Shell
```
