### PR TITLE
Add support for nesC

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1451,6 +1451,11 @@ mupad:
   lexer: MuPAD
   primary_extension: .mu
 
+nesC:
+  type: programming
+  color: "#ffce3b"
+  primary_extension: .nc
+
 ooc:
   type: programming
   lexer: Ooc


### PR DESCRIPTION
nesC is an embedded systems language. It it is a stable product (~10
years old) primarily used for TinyOS, an embedded operating system.
Development has recently moved to github (https://github.com/tinyos/nesc).

Pygments has now pulled the nesC lexer as of 2013/5/6:
  https://bitbucket.org/birkenfeld/pygments-main/pull-request/166/

Please let me know if I need to do anything else / add more information.
