### PR TITLE
Recognise riemann.config files as Clojure files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -232,6 +232,8 @@ Clojure:
   primary_extension: .clj
   extensions:
   - .cljs
+  filenames:
+  - riemann.config
 
 CoffeeScript:
   type: programming

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -242,6 +242,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal [Language['Shell']], Language.find_by_filename('.bashrc')
     assert_equal [Language['Shell']], Language.find_by_filename('bash_profile')
     assert_equal [Language['Shell']], Language.find_by_filename('.zshrc')
+    assert_equal [Language['Clojure']], Language.find_by_filename('riemann.config')
   end
 
   def test_find


### PR DESCRIPTION
This pull request adds the filename `riemann.config` as a filename for Clojure, because [Riemann](http://riemann.io/index.html) configuration files are Clojure code.
