### PR TITLE
Ignore bootstrap's js files

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -67,6 +67,9 @@
 # MathJax
 - (^|/)MathJax/
 
+# Bootstrap
+- (^|/)bootstrap([^.]*)(\.min)?\.js$
+
 # SyntaxHighlighter - http://alexgorbatchev.com/
 - (^|/)shBrush([^.]*)\.js$
 - (^|/)shCore\.js$


### PR DESCRIPTION
Not sure if it's completely reasonable, but bootstrap's js is always used as a library.
