### PR TITLE
Add support for detecting .geojson files

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -158,6 +158,13 @@ module Linguist
       extname.downcase == '.stl'
     end
 
+    # Public: Is the blob a supported map format?
+    #
+    # Return true or false
+    def mappable?
+      extname.downcase == '.geojson'
+    end
+
     # Public: Is this blob a CSV file?
     #
     # Return true or false


### PR DESCRIPTION
Adds a `mappable?` method to the blog helper to detect `.geojson` files.
