### PR TITLE
The .fun extension is commonly used for Standard ML.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1218,6 +1218,8 @@ Standard ML:
   aliases:
   - sml
   primary_extension: .sml
+  extensions:
+  - .fun
 
 SuperCollider:
   type: programming


### PR DESCRIPTION
Some projects written in Standard ML use the .fun extension.  For example:
- [RedBlackTree.fun](https://github.com/clf/celf/blob/master/RedBlackTree.fun)
- [main.fun](https://github.com/MLton/mlton/blob/master/mlton/main/main.fun)

Also, the Pygments Standard ML lexer recognizes the .fun extension; see:
- [functional.py](https://bitbucket.org/birkenfeld/pygments-main/src/0710694cba81a1544e6f789953ef164c7cfc4251/pygments/lexers/functional.py?at=default#cl-1082)

In contrast to pull request #440, this pull request only modifies `lib/linguist/languages.yml` and does not modify `samples/Standard ML/` (which makes the volatile `lib/linguist/samples.json` out of date).
