### PR TITLE
Added most common MSBuild project file extensions 

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1356,6 +1356,7 @@ XML:
   extensions:
   - .axml
   - .ccxml
+  - .csproj
   - .dita
   - .ditamap
   - .ditaval
@@ -1369,14 +1370,18 @@ XML:
   - .rss
   - .scxml
   - .svg
+  - .targets
   - .tmCommand
   - .tmLanguage
   - .tmPreferences
   - .tmSnippet
   - .tml
   - .ui
+  - .vbproj
+  - .vcxproj
   - .vxml
   - .wsdl
+  - .wixproj
   - .wxi
   - .wxl
   - .wxs


### PR DESCRIPTION
Added:  
c# projects  `.csproj`
c++ projects `.vcxproj`
vb projects  `.vbproj`
WiX projects  `.wixproj`
msbuild extensions `.targets`

There are more, but they're not as common as these (and I'm not sure that all files with those extensions would be XML ... some of them seem iffy to me)
