### PR TITLE
Language colors

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -94,7 +94,7 @@ Arduino:
 Assembly:
   type: programming
   lexer: NASM
-  color: "#00ff00" # Hacker green
+  color: "#a67219"
   search_term: nasm
   aliases:
   - nasm


### PR DESCRIPTION
Now that language colors are more visible with the new awesome repository next, language colors should aim to represent branding as accurate as possible so users feel familiar with them, this pull request proposes branding colors for several languages.

In example, this is Java currently

![Ugly Java color](http://i.imgur.com/r8fPA7J.png)

This matches Java branding "blue" to look like

![Java cute and familiar color](http://i.imgur.com/JoisVqO.png)
