### PR TITLE
Added .tmTheme as XML extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1373,6 +1373,7 @@ XML:
   - .tmLanguage
   - .tmPreferences
   - .tmSnippet
+  - .tmTheme
   - .tml
   - .ui
   - .vxml


### PR DESCRIPTION
Files with the `.tmTheme` extension similar to `.tmCommand`, `.tmLanguage`, `.tmPreferences` and `.tmSnippet` are configuration XML files for TextMate or SublimeText.

The `.tmTheme` extension was missing from this list.
