### PR TITLE
Treat `.pyt` files as Python source

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1044,10 +1044,10 @@ Python:
   primary_extension: .py
   extensions:
   - .gyp
+  - .pyt
   - .pyw
   - .wsgi
   - .xpy
-  - .pyt
   filenames:
   - wscript
 


### PR DESCRIPTION
[Esri](https://github.com/esri) introduced [Python Toolboxes in ArcGIS 10.1](http://resources.arcgis.com/en/help/main/10.1/index.html#//001500000022000000). They are simply Python source code with a different extension. [A user requested syntax highlighting of `.pyt` files on GitHub](http://ideas.arcgis.com/ideaView?id=087E00000004m2eIAA). Should be a trivial merge. Thanks.
