### PR TITLE
Include Qt QML markup detection

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1058,6 +1058,11 @@ Python traceback:
   searchable: false
   primary_extension: .pytb
 
+QML:
+  type: markup
+  color: "#44a51c"
+  primary_extension: .qml
+
 R:
   type: programming
   color: "#198ce7"


### PR DESCRIPTION
QML itself has distinct extension .qml, but was misidentified as Prolog.
