### PR TITLE
added Prolog .pl extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1021,6 +1021,7 @@ Prolog:
   primary_extension: .prolog
   extensions:
   - .pro
+  - .pl
 
 Puppet:
   type: programming


### PR DESCRIPTION
.pl is one of the two most common Prolog file extensions, and that used in the samples folder for Linguist. Unfortunately it's more commonly used by Perl so can't be the default extension.
