### PR TITLE
Add Berksfile to the list of Ruby types

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1136,6 +1136,7 @@ Ruby:
   - .thor
   - .watchr
   filenames:
+  - Berksfile
   - Gemfile
   - Guardfile
   - Podfile


### PR DESCRIPTION
Berksfile is the equivalent of a Gemfile for Chef cookbooks. It should be treated like any other Ruby file.
