### PR TITLE
Added JSON extensions for Sublime Text

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -632,6 +632,14 @@ JSON:
   ace_mode: json
   searchable: false
   primary_extension: .json
+  extensions:
+  - .sublime-keymap
+  - .sublime_metrics
+  - .sublime-mousemap
+  - .sublime-project
+  - .sublime_session
+  - .sublime-settings
+  - .sublime-workspace
 
 Java:
   type: programming


### PR DESCRIPTION
Sublime Text editor uses some extensions of its own which uses the JSON format.

It's popular to track such configuration files on GitHub so it would be useful to have JSON highlighting for them.
