### PR TITLE
Highlight Drupal CMS code as PHP

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -949,6 +949,11 @@ PHP:
   - .php4
   - .php5
   - .phpt
+  - .inc
+  - .module
+  - .test
+  - .install
+  - .profile
   filenames:
   - Phakefile
 


### PR DESCRIPTION
Drupal modules consist of PHP files with different extensions:
*.module - main module's files
*.inc - generic include
*.test - simpletest secenario (written in PHP)
*.install - module installation file
*.profile - installation profile main file
