### PR TITLE
Update languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -120,6 +120,7 @@ Awk:
   - .gawk
   - .mawk
   - .nawk
+  - .auk
 
 Batchfile:
   type: programming


### PR DESCRIPTION
I'm porting to github my "auk" pre-processor language for "awk". currently, auk is in auk.googlecode.com

a ".auk" file gets converted to ".awk" after pulling out multi-line comments and add in support for structures.

when browsing, a ".auk" file, it  should be syntax highlighted as a ".awk" file

hence, i've changed languages.yml accordingly

t
