### PR TITLE
ignore more Git local config files to avoid them being misidentified as ...

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -117,9 +117,11 @@
 # Samples folders
 - ^[Ss]amples/
 
-# LICENSE files and gitignore
+# LICENSE and git config files
 - ^LICENSE$
+- gitattributes$
 - gitignore$
+- gitmodules$
 
 # Test fixtures
 - ^[Tt]est/fixtures/


### PR DESCRIPTION
...Racket, Ruby or else
