### PR TITLE
Add common file extensions to the c++ language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -184,8 +184,10 @@ C++:
   - .H
   - .h++
   - .hh
+  - .hpp
   - .hxx
   - .tcc
+  - .tpp
 
 C-ObjDump:
   type: data


### PR DESCRIPTION
.hpp and .tpp extensions are of common use respectively for headers files and separate implementation of template classes/methods.
