### PR TITLE
Ignore 'thirdparty' directories in addition to 'vendor'

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -29,6 +29,7 @@
 
 # Vendored dependencies
 - vendor/
+- thirdparty/
 
 # Debian packaging
 - ^debian/

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -212,6 +212,7 @@ class TestBlob < Test::Unit::TestCase
 
     # Rails vendor/
     assert blob("vendor/plugins/will_paginate/lib/will_paginate.rb").vendored?
+    assert blob("thirdparty/plugins/will_paginate/lib/will_paginate.rb").vendored?
 
     # C deps
     assert blob("deps/http_parser/http_parser.c").vendored?


### PR DESCRIPTION
Add 'thirdparty' as another keyword to filter out dependency or vendor libraries in repos.
