### PR TITLE
Add extensions for ConTeXt

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1267,6 +1267,7 @@ TeX:
   - .ltx
   - .mkii
   - .mkiv
+  = .mkvi
   - .sty
   - .toc
 


### PR DESCRIPTION
[ConTeXt](http://wiki.contextgarden.net/) is a macro language build on TeX (just as LaTeX is build on
TeX). It tends to use `.mkii` and `.mkiv` extensions to represent files used in
Mark II (MkII) version and Mark IV (MkIV) version of ConTeXt.
