### PR TITLE
Experimental QML support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1059,6 +1059,13 @@ Python traceback:
   searchable: false
   primary_extension: .pytb
 
+QML:
+  type: markup
+  group: CSS  
+  ace_mode: css
+  color: "#34A938"
+  primary_extension: .qml
+
 R:
   type: programming
   color: "#198ce7"

--- a/samples/QML/foo.qml
+++ b/samples/QML/foo.qml
@@ -1,0 +1,50 @@
+import QtQuick 1.0
+
+
+Item {
+    id: top_
+    width: 320
+    height: 240
+    
+    property color fg: "red"
+    property int size: 42  
+    property bool idevice: false
+    
+    signal stuff();
+        
+    Rectangle { 
+        id: r0_
+        anchors.fill: parent 
+        color: "blue"
+            Behavior on color { ColorAnimation { duration: 1000 } }
+        
+        Rectangle {
+            id: r1_
+            anchors.centerIn: parent            
+            color: "orange"
+            width: 42
+            height: 42
+            scale: ma_.pressed ? 0.9 : 1
+            Behavior on scale { NumberAnimation { duration: 23 } }
+            Behavior on color { ColorAnimation { duration: 250 } }
+            
+            MouseArea {
+                id: ma_
+                anchors.fill: parent
+                onClicked: top_.stuff();
+                visible: !top_.idevice
+            }
+        }            
+        
+        Text {
+            anchors.centerIn: parent
+            font.pixelSize: 42
+            text: "" + r0_.color + "\n\n" + r1_.color
+        }        
+    }
+    
+    onStuff: {
+        r0_.color =  Qt.rgba(Math.random(), 0.5, 0, 1); 
+        r1_.color =  Qt.rgba(0.5, Math.random(), 0.5, 1); 
+    }
+}   


### PR DESCRIPTION
QML (the markup language of Qt) is used in many new open source projects - specially on ubuntu desktop and in mobile space, e.g. Meego, Jolla, BlackBerry & ubuntomobile as the primary development language and also on Android, iOS to a lesser extent. 

This tiny patch will hopefully allow QML projects to be detected as such instead of JavaScript as it is currently done...
