### PR TITLE
Recognize Umbrello .xmi files as XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1400,6 +1400,7 @@ XML:
   - .xaml
   - .xlf
   - .xliff
+  - .xmi
   - .xsd
   - .xul
   - .zcml


### PR DESCRIPTION
Linguist is currently misclassifying .xmi files produced by [Umbrello](http://umbrello.kde.org/) (containing an XML representation of a UML model) as Logos files. You can see an example of this in action by looking at the language stats of [genetik](https://github.com/abahgat/genetik).

According to Wikipedia,

> The [XML Metadata Interchange](http://en.wikipedia.org/wiki/XML_Metadata_Interchange) (XMI) is an Object Management Group (OMG) standard for exchanging metadata information via Extensible Markup Language (XML).
> It can be used for any metadata whose metamodel can be expressed in Meta-Object Facility (MOF).
> The most common use of XMI is as an interchange format for UML models, although it can also be used for serialization of models of other languages (metamodels).

This pull request fixes the problem by adding .xmi to the list of extensions for XML.
