### PR TITLE
Added support for IEC 61131-3 languages (ST and IL)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -613,6 +613,21 @@ Haxe:
   extensions:
   - .hxsl
 
+IEC 61131-3:
+  type: programming
+  lexer: iec
+  color: "#4dd8ff"
+  extensions:
+  - .txt
+  - .st
+  - .stx
+  - .awl
+  - .stl
+  - .il
+  - .plc
+  - .fcl
+  - .asc
+
 INI:
   type: data
   extensions:


### PR DESCRIPTION
Support for PLCs' textual programming languages as defined by IEC 61131-3, which are ST (Structured Text) and IL (Instruction List). Sadly, they don't have default file extensions, each vendor choses their own, and some even use *.txt for their code files.
