### PR TITLE
Fix C's .h files parsed as C++ and vice versa, fixes issue #554

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -9,6 +9,7 @@ require 'linguist/file_blob'
 require 'linguist/repository'
 
 path = ARGV[0] || Dir.pwd
+$global_path = path
 
 if File.directory?(path)
   repo = Linguist::Repository.from_directory(path)

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -86,6 +86,17 @@ module Linguist
       if File.extname(name).empty? && mode && (mode.to_i(8) & 05) == 05
         name += ".script!"
       end
+      # An ugly hack to detect C as the language
+      # If there is foo.h, check for foo.c, and return C if true
+      if File.extname(name) == ".h"
+        if($global_path != nil)
+          filepath = $global_path + "/" + File.dirname(name) + "/" \
+                       + File.basename(name, ".h") + ".c"
+          if File.exists?(filepath)
+            return Language["C"]
+          end
+        end
+      end
 
       possible_languages = find_by_filename(name)
 


### PR DESCRIPTION
Fixes #554. It uses a global variable to pass the path though, because I don't know enough Ruby to fix these without one or alternatively modifying all functions to pass the value. There probably is a better way to do it.
