### PR TITLE
Added Eagle for .brd and .sch.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -363,6 +363,12 @@ Dylan:
   color: "#3ebc27"
   primary_extension: .dylan
 
+Eagle:
+  primary_extension: .sch
+  lexer: Eagle
+  extensions:
+  - .brd
+
 Ecere Projects:
   type: data
   group: JavaScript


### PR DESCRIPTION
This was asked for in linguist Issue #365, which is closed but "pull requests are welcome."

Eagle files are schematics and board layouts. Currently my repos with Eagle files don't have any other code so they are showing no language at all. Searching GitHub for "eagle schematic" yields 39 repositories and 16,531 code hits. Two high-profile communities with unlabeled Eagle repos are 'adafruit' and 'sparkfun'. 
