### PR TITLE
Add .nqp to the list of Perl file extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1008,13 +1008,13 @@ Perl:
   primary_extension: .pl
   extensions:
   - .PL
+  - .nqp
   - .perl
   - .ph
   - .plx
   - .pm6
   - .pod
   - .psgi
-  - .nqp
 
 Pike:
   type: programming


### PR DESCRIPTION
NQP is a subset of Perl 6 that is being used by implementations of Perl 6.

See:
https://github.com/perl6/nqp
and
https://github.com/rakudo/rakudo/tree/nom/src/Perl6
