### PR TITLE
Add the ".cljx" file extension to the list of Clojure languages.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -242,6 +242,7 @@ Clojure:
   primary_extension: .clj
   extensions:
   - .cljs
+  - .cljx
   filenames:
   - riemann.config
 


### PR DESCRIPTION
Some people start writing portable Clojure/Clojurescript code and use
the ".cljx" file extension for that. This is driven by this project:

https://github.com/lynaghk/cljx
