### PR TITLE
Adding .x3d to the list of .xml extensions.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1430,6 +1430,7 @@ XML:
   - .wxi
   - .wxl
   - .wxs
+  - .x3d
   - .xaml
   - .xlf
   - .xliff


### PR DESCRIPTION
Adding .x3d to the list of .xml extensions: [x3d specifications](http://www.web3d.org/x3d/specifications/x3d_specification.html)
