### PR TITLE
Detect Inno Setup installer scripts

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -623,6 +623,9 @@ INI:
   - .prefs
   - .properties
   primary_extension: .ini
+  
+Inno Setup:
+  primary_extension: .iss
 
 IRC log:
   lexer: IRC logs


### PR DESCRIPTION
Just a small addition to detect [Inno Setup](http://www.jrsoftware.org/isinfo.php) installer scripts. I'd :heart: to have syntax highlighting like NSIS scripts got in #423, but since I don't have the ability to do that, this will do for now. :smiley:
