### PR TITLE
Update languages.yml to include .inc for PHP

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -976,6 +976,7 @@ PHP:
   - .php4
   - .php5
   - .phpt
+  - .inc
   filenames:
   - Phakefile
 


### PR DESCRIPTION
`.inc` is often used in PHP libraries for included files.
