### PR TITLE
Added SQF language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1282,6 +1282,11 @@ SuperCollider:
   lexer: Text only
   primary_extension: .sc
 
+SQF:
+  type: programming
+  color: "#555"
+  primary_extension: .sqf
+
 TOML:
   type: data
   primary_extension: .toml


### PR DESCRIPTION
SQF is the primary language used by Bohemia Interactive in their ArmA game series.
