### PR TITLE
Recognize jQuery >= 1.10.0

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -37,7 +37,7 @@
 
 # jQuery
 - (^|/)jquery([^.]*)(\.min)?\.js$
-- (^|/)jquery\-\d\.\d(\.\d)?(\.min)?\.js$
+- (^|/)jquery\-\d\.\d+(\.\d+)?(\.min)?\.js$
 
 # jQuery UI
 - (^|/)jquery\-ui(\-\d\.\d+(\.\d+)?)?(\.\w+)?(\.min)?\.(js|css)$

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -236,6 +236,8 @@ class TestBlob < Test::Unit::TestCase
     assert blob("public/javascripts/jquery-1.5.2.js").vendored?
     assert blob("public/javascripts/jquery-1.6.1.js").vendored?
     assert blob("public/javascripts/jquery-1.6.1.min.js").vendored?
+    assert blob("public/javascripts/jquery-1.10.1.js").vendored?
+    assert blob("public/javascripts/jquery-1.10.1.min.js").vendored?
     assert !blob("public/javascripts/jquery.github.menu.js").vendored?
 
     # jQuery UI


### PR DESCRIPTION
jQuery recently passed 1.10, but the vendor regexp assumed each
component of the version number would be only one digit.  Allow
multiple digits for the minor and micro versions.
