### PR TITLE
Update PowerShell File Extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1436,8 +1436,8 @@ XML:
   - .kml
   - .mxml
   - .plist
-  - .psc1
   - .ps1xml
+  - .psc1
   - .pt
   - .rdf
   - .rss


### PR DESCRIPTION
The three core PowerShell language extensions are .psd1, .ps1 and .psm1 -- plus two xml file extensions: .ps1xml and .clixml which are for formatting rules and serialization.
.psm1 modules files use exactly the same syntax as scripts, but are imported rather than executed.
.psd1 are metadata files which use a subset of the same syntax (they can be highlighted using the same highlighter, it's just some commands, variables, and types aren't allowed in data files)

https://en.wikipedia.org/wiki/Windows_PowerShell#File_extensions
http://msdn.microsoft.com/en-us/library/dd878324

But there are pages about each one, if you look carefully:
- ps1xml
  - http://msdn.microsoft.com/en-us/library/dd878306 
  - http://msdn.microsoft.com/en-us/library/hh847881
- psm1 
  - http://msdn.microsoft.com/en-us/library/dd901839
  - http://msdn.microsoft.com/en-us/library/hh847841
- psd1 
  - http://msdn.microsoft.com/en-us/library/dd878297
  - http://msdn.microsoft.com/en-us/library/hh849919
