### PR TITLE
Highlight .jelly files as XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1464,6 +1464,7 @@ XML:
   - .ditaval
   - .glade
   - .grxml
+  - .jelly
   - .kml
   - .mxml
   - .plist


### PR DESCRIPTION
[Jelly](http://commons.apache.org/proper/commons-jelly/) is used heavily by stapler/stapler and jenkinsci/jenkins.
