### PR TITLE
Add bootstrap to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -70,6 +70,9 @@
 # MathJax
 - (^|/)MathJax/
 
+# Bootstrap
+- (^|/)bootstrap/
+
 # SyntaxHighlighter - http://alexgorbatchev.com/
 - (^|/)shBrush([^.]*)\.js$
 - (^|/)shCore\.js$


### PR DESCRIPTION
Bootstrap is a lot of CSS, and this will stop that from interfering with the language stats.
