### PR TITLE
Add support for RobotFramework .robot files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1187,6 +1187,12 @@ Rebol:
 Redcode:
   primary_extension: .cw
 
+RobotFramework:
+  type: programming
+  primary_extension: .robot
+  # extensions:
+  # - .txt
+
 Rouge:
   type: programming
   lexer: Clojure

--- a/samples/RobotFramework/data_driven.robot
+++ b/samples/RobotFramework/data_driven.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Documentation     Example test cases using the data-driven testing approach.
+...
+...               Tests use `Calculate` keyword created in this file, that in
+...               turn uses keywords in `CalculatorLibrary`. An exception is
+...               the last test that has a custom _template keyword_.
+...
+...               The data-driven style works well when you need to repeat
+...               the same workflow multiple times.
+...
+...               Notice that one of these tests fails on purpose to show how
+...               failures look like.
+Test Template     Calculate
+Library           CalculatorLibrary
+
+*** Test Cases ***    Expression    Expected
+Addition              12 + 2 + 2    16
+                      2 + -3        -1
+
+Subtraction           12 - 2 - 2    8
+                      2 - -3        5
+
+Multiplication        12 * 2 * 2    48
+                      2 * -3        -6
+
+Division              12 / 2 / 2    3
+                      2 / -3        -1
+
+Failing               1 + 1         3
+
+Calculation error     [Template]    Calculation should fail
+                      kekkonen      Invalid button 'k'.
+                      ${EMPTY}      Invalid expression.
+                      1 / 0         Division by zero.
+
+*** Keywords ***
+Calculate
+    [Arguments]    ${expression}    ${expected}
+    Push buttons    C${expression}=
+    Result should be    ${expected}
+
+Calculation should fail
+    [Arguments]    ${expression}    ${expected}
+    ${error} =    Should cause error    C${expression}=
+    Should be equal    ${expected}    ${error}    # Using `BuiltIn` keyword

--- a/samples/RobotFramework/gherkin.robot
+++ b/samples/RobotFramework/gherkin.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Documentation     Example test case using the gherkin syntax.
+...
+...               This test has a workflow similar to the keyword-driven
+...               examples. The difference is that the keywords use higher
+...               abstraction level and their arguments are embedded into
+...               the keyword names.
+...
+...               This kind of _gherkin_ syntax has been made popular by
+...               [http://cukes.info|Cucumber]. It works well especially when
+...               tests act as examples that need to be easily understood also
+...               by the business people.
+Library           CalculatorLibrary
+
+*** Test Cases ***
+Addition
+    Given calculator has been cleared
+    When user types "1 + 1"
+    and user pushes equals
+    Then result is "2"
+
+*** Keywords ***
+Calculator has been cleared
+    Push button    C
+
+User types "${expression}"
+    Push buttons    ${expression}
+
+User pushes equals
+    Push button    =
+
+Result is "${result}"
+    Result should be    ${result}

--- a/samples/RobotFramework/keyword_driven.robot
+++ b/samples/RobotFramework/keyword_driven.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Documentation     Example test cases using the keyword-driven testing approach.
+...
+...               All tests contain a workflow constructed from keywords in
+...               `CalculatorLibrary`. Creating new tests or editing existing
+...               is easy even for people without programming skills.
+...
+...               This kind of style works well for normal test automation.
+...               If also business people need to understand tests, using
+...               _gherkin_ style may work better.
+Library           CalculatorLibrary
+
+*** Test Cases ***
+Push button
+    Push button    1
+    Result should be    1
+
+Push multiple buttons
+    Push button    1
+    Push button    2
+    Result should be    12
+
+Simple calculation
+    Push button    1
+    Push button    +
+    Push button    2
+    Push button    =
+    Result should be    3
+
+Longer calculation
+    Push buttons    5 + 4 - 3 * 2 / 1 =
+    Result should be    3
+
+Clear
+    Push button    1
+    Push button    C
+    Result should be    ${EMPTY}    # ${EMPTY} is a built-in variable


### PR DESCRIPTION
> RobotFramework is a generic test automation framework for acceptance testing and acceptance test-driven development (ATDD). It has easy-to-use tabular test data syntax and utilizes the keyword-driven testing approach. Its testing capabilities can be extended by test libraries implemented either with Python or Java, and users can create new keywords from existing ones using the same syntax that is used for creating test cases.

Its homepage is http://robotframework.org
It also has a GitHub Org at https://github.com/robotframework

Searching on Github can see many projects has adopted RobotFramework as a part of their testing solutions.
https://github.com/search?l=&p=1&q=extension%3Arobot&ref=advsearch&type=Code

PS. The RobotFramework also supports using .txt as a file extension for test case files, but I don't know how to make the [Bayesian classifier](https://github.com/github/linguist/blob/master/lib/linguist/classifier.rb) work in this case, so I am just adding support for .robot for now.

Thanks.
