### PR TITLE
Ungroup Elm from Haskell

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -403,7 +403,6 @@ Elixir:
 Elm:
   type: programming
   lexer: Haskell
-  group: Haskell
   primary_extension: .elm
 
 Emacs Lisp:


### PR DESCRIPTION
Elm is its own language and should be counted as such
