### PR TITLE
Update vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -28,7 +28,7 @@
 - ^rebar$
 
 # Vendored dependencies
-- vendor/
+- vendors?/
 
 # Debian packaging
 - ^debian/


### PR DESCRIPTION
extend the vendor/ exclusion to handle vendors/

Some projects use this folder to store external libaries (eg https://github.com/Elgg/Elgg)
