### PR TITLE
Add common VHDL file extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1405,6 +1405,14 @@ VHDL:
   lexer: vhdl
   color: "#543978"
   primary_extension: .vhdl
+  extensions:
+  - .vhd
+  - .vhf
+  - .vhi
+  - .vho
+  - .vhs
+  - .vht
+  - .vhw
 
 Vala:
   type: programming


### PR DESCRIPTION
Many common VHDL file extensions aren't listed. `.vhd` is the main one, but there are others. See http://www.xilinx.com/support/answers/22777.htm for a list of VHDL extensions.
