### PR TITLE
Add common Verilog extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1421,6 +1421,12 @@ Verilog:
   extensions:
   - .sv
   - .svh
+  - .tf
+  - .tfi
+  - .tft
+  - .tfw
+  - .veo
+  - .vf  
   - .vh
 
 VimL:


### PR DESCRIPTION
Add some common Verilog extensions that are missing. `.veo` is probably the most commonly used one that's missing, but there are a few others. See http://www.xilinx.com/support/answers/22777.htm for a list.
