### PR TITLE
Use the Haxe lexer for Haxe

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -612,7 +612,6 @@ Haskell:
 
 Haxe:
   type: programming
-  lexer: haXe
   ace_mode: haxe
   color: "#346d51"
   primary_extension: .hx


### PR DESCRIPTION
The lexer for Haxe is no longer named haXe, so linguist is currently
unable to find it.  This fixes that.
