### PR TITLE
Add Appraisals to Ruby filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1311,6 +1311,7 @@ Ruby:
   - .thor
   - .watchr
   filenames:
+  - Appraisals
   - Berksfile
   - Gemfile
   - Guardfile

--- a/lib/linguist/samples.json
+++ b/lib/linguist/samples.json
@@ -430,6 +430,7 @@
       "ack"
     ],
     "Ruby": [
+      "Appraisals",
       "Capfile",
       "Rakefile"
     ],

--- a/samples/Ruby/filenames/Appraisals
+++ b/samples/Ruby/filenames/Appraisals
@@ -1,0 +1,7 @@
+appraise "rails32" do
+  gem 'rails', '~> 3.2.0'
+end
+
+appraise "rails40" do
+  gem 'rails', '~> 4.0.0'
+end


### PR DESCRIPTION
Thoughtbot's [appraisal](https://github.com/thoughtbot/appraisal) gem is nearing a 1.0.0 release! This super-helpful library allows you to test your Ruby library against different versions of gems by using separate Gemfiles. Appraisal files, like Gemfiles, are run by Ruby.

Here are a few examples of Appraisals being used on github:
- [thinking-sphinx](https://github.com/pat/thinking-sphinx/blob/master/Appraisals)
- [paperclip](https://github.com/thoughtbot/paperclip/blob/master/Appraisals)
- [factory_girl](https://github.com/thoughtbot/factory_girl/blob/master/Appraisals)
- [shoulda-matchers](https://github.com/thoughtbot/shoulda-matchers/blob/master/Appraisals)
- [secretary-rails](https://github.com/SCPR/secretary-rails/blob/master/Appraisals)
