### PR TITLE
Add phpunit.xml.dist to XML filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1622,6 +1622,7 @@ XML:
   filenames:
   - .classpath
   - .project
+  - phpunit.xml.dist
 
 XProc:
   type: programming


### PR DESCRIPTION
PHPUnit (a popular unit testing tool for PHP) uses `phpunit.xml` for its configuration.

However it would use `phpunit.xml.dist` as well if `phpunit.xml` is not available.

The reason is to track `phpunit.xml.dist` in your repo. And to ignore `phpunit.xml`. By default everyone (including a CI) would use `phpunit.xml.dist` except you add `phpunit.xml` locally.

`phpunit.xml.dist` has the same XML structure as `phpunit.xml`. So it should be detected as XML by linguist.

Example: https://github.com/erusev/parsedown/blob/master/phpunit.xml.dist

I don't know why linguist is not detecting this file as XML since it starts with `<?xml`. Perhaps it is another issue.
