### PR TITLE
Confusing Typo Fix

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -75,7 +75,7 @@ module Linguist
 
     # Internal: Is the blob minified files?
     #
-    # Consider a file minified if it contains more than 5% spaces.
+    # Consider a file minified if it contains less than 5% spaces.
     # Currently, only JS and CSS files are detected by this method.
     #
     # Returns true or false.


### PR DESCRIPTION
I noticed that the documentation comment for `Linguist::Generated#minified_files?` says “more than 5% spaces” while the test in the body of that method really tests for _less_ than 5% spaces.
