### PR TITLE
Add composer.lock to JSON filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -747,6 +747,8 @@ JSON:
   - .sublime_session
   - .sublime-settings
   - .sublime-workspace
+  filenames:
+  - composer.lock
 
 Jade:
   group: HTML


### PR DESCRIPTION
[Composer](http://getcomposer.org) uses one configuration file (composer.json)
and one lock file (composer.lock). They both use valid JSON.

Example: https://github.com/OpenBuildings/jam/blob/master/composer.lock
