### PR TITLE
Add five new extensions to XML, YAML in support of ROS usage.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1611,6 +1611,7 @@ XML:
   - .grxml
   - .jelly
   - .kml
+  - .launch
   - .mxml
   - .plist
   - .pluginspec
@@ -1620,6 +1621,7 @@ XML:
   - .rdf
   - .rss
   - .scxml
+  - .srdf
   - .svg
   - .tmCommand
   - .tmLanguage
@@ -1628,12 +1630,14 @@ XML:
   - .tmTheme
   - .tml
   - .ui
+  - .urdf
   - .vxml
   - .wsdl
   - .wxi
   - .wxl
   - .wxs
   - .x3d
+  - .xacro
   - .xaml
   - .xlf
   - .xliff
@@ -1686,6 +1690,7 @@ YAML:
   primary_extension: .yml
   extensions:
   - .reek
+  - .rviz
   - .yaml
 
 eC:


### PR DESCRIPTION
These extensions are in common use in packages part of ROS, the Robot Operating System.

[urdf](http://wiki.ros.org/urdf), [srdf](http://wiki.ros.org/srdf): These are Robot Description Files, XML documents which describe the physical realities of a robotics platform, for the purposes of consumption by common libraries.

[xacro](http://wiki.ros.org/xacro) is for input files to the XML macro processor xacro, which is used in ROS to output URDF and SRDF files.

[launch](http://wiki.ros.org/roslaunch/XML): Documents which describe sets of ROS nodes to launch together.

[rviz](https://github.com/ros-visualization/rviz/blob/hydro-devel/default.rviz): YAML configuration files belonging to the [rviz](http://wiki.ros.org/rviz#Overview) utility.

Each one has been in use for several years in various ROS-related applications; lots of examples should be apparent in orgs like ros, ros-drivers, ros-visualization, pr2, turtlebot, husky, etc.

Thanks for your consideration!
