### PR TITLE
Use JSON instead of YAML for loading samples.json

### DIFF
--- a/lib/linguist/samples.rb
+++ b/lib/linguist/samples.rb
@@ -1,4 +1,8 @@
-require 'json'
+begin
+  require 'json'
+rescue LoadError
+  require 'yaml'
+end
 
 require 'linguist/md5'
 require 'linguist/classifier'
@@ -14,7 +18,8 @@ module Linguist
 
     # Hash of serialized samples object
     if File.exist?(PATH)
-      DATA = JSON.load(File.read(PATH))
+      serializer = defined?(JSON) ? JSON : YAML
+      DATA = serializer.load(File.read(PATH))
     end
 
     # Public: Iterate over each sample.


### PR DESCRIPTION
This pull request swaps out `YAML.load` for `JSON.load` in samples loading if JSON is available.

JSON is about 10x quicker than YAML:

``` irb
>> Benchmark.measure { YAML.load(File.read("lib/linguist/samples.json")) }.to_s
=> "  0.690000   0.010000   0.700000 (  0.691805)\n"
>> Benchmark.measure { JSON.load(File.read("lib/linguist/samples.json")) }.to_s
=> "  0.050000   0.000000   0.050000 (  0.056488)\n"
```

On Ruby 1.8 where JSON is not in the stdlib, this will fall back to YAML if it can't require JSON.
