### PR TITLE
Add misser lexer entry for nesC to languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1734,6 +1734,7 @@ mupad:
 nesC:
   type: programming
   color: "#ffce3b"
+  lexer: nesc
   primary_extension: .nc
 
 ooc:


### PR DESCRIPTION
The nesC entry in the languages.yml file was missing a lexer entry
and thus wasn't getting picked up. This adds the required lexer line.
