### PR TITLE
Add .lmi to Python extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1230,6 +1230,7 @@ Python:
   primary_extension: .py
   extensions:
   - .gyp
+  - .lmi
   - .pyt
   - .pyw
   - .wsgi


### PR DESCRIPTION
The OpenLMI project provides a scripting environment based on
Python (wrapping the Python interpreter with the 'lmishell'
command). Python scripts intended to be executed via lmishell are
conventionally given the suffix .lmi to identify them. Since the
syntax is identical to that of Python, it would be best to
identify it that way.
