### PR TITLE
Add Dogescript support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -422,6 +422,12 @@ DCPU-16 ASM:
 Diff:
   primary_extension: .diff
 
+Dogescript:
+  type: programming
+  lexer: Text only
+  color: "#cca760"
+  primary_extension: .djs
+
 Dylan:
   type: programming
   color: "#3ebc27"

--- a/lib/linguist/samples.json
+++ b/lib/linguist/samples.json
@@ -83,6 +83,9 @@
     "DM": [
       ".dm"
     ],
+    "Dogescript": [
+      ".djs"
+    ],
     "ECL": [
       ".ecl"
     ],
@@ -480,8 +483,8 @@
       ".gemrc"
     ]
   },
-  "tokens_total": 424168,
-  "languages_total": 489,
+  "tokens_total": 424198,
+  "languages_total": 490,
   "tokens": {
     "ABAP": {
       "*/**": 1,
@@ -13986,6 +13989,27 @@
       "CONST_VARIABLE": 1,
       "#undef": 1,
       "Undefine": 1
+    },
+    "Dogescript": {
+      "quiet": 1,
+      "wow": 4,
+      "such": 2,
+      "language": 3,
+      "very": 1,
+      "syntax": 1,
+      "github": 1,
+      "recognized": 1,
+      "loud": 1,
+      "much": 1,
+      "friendly": 2,
+      "rly": 1,
+      "is": 2,
+      "true": 1,
+      "plz": 2,
+      "console.loge": 2,
+      "with": 2,
+      "but": 1,
+      "module.exports": 1
     },
     "ECL": {
       "#option": 1,
@@ -43652,6 +43676,7 @@
     "Dart": 68,
     "Diff": 16,
     "DM": 169,
+    "Dogescript": 30,
     "ECL": 281,
     "edn": 227,
     "Elm": 628,
@@ -43779,6 +43804,7 @@
     "Dart": 1,
     "Diff": 1,
     "DM": 1,
+    "Dogescript": 1,
     "ECL": 1,
     "edn": 1,
     "Elm": 3,
@@ -43881,5 +43907,5 @@
     "Xtend": 2,
     "YAML": 1
   },
-  "md5": "647da23cd1eb02653f50ff9bfbb6e70d"
+  "md5": "913847d656c085e9aba2f1a16a795901"
 }

--- a/samples/Dogescript/example.djs
+++ b/samples/Dogescript/example.djs
@@ -1,0 +1,16 @@
+quiet
+ wow 
+    such language
+  very syntax
+        github recognized wow
+loud
+
+such language much friendly
+    rly friendly is true
+        plz console.loge with 'such friend, very inclusive'
+    but
+        plz console.loge with 'no love for doge'
+    wow
+wow
+
+module.exports is language


### PR DESCRIPTION
Dogescript: https://github.com/remixz/dogescript

Examples: 
- https://github.com/ngscheurich/doge-adventure
- https://github.com/Goos/dogenerator
- Dogescript compiling implemented in https://github.com/jenius/roots

```
 wow
     no dogescript on github
  much PR
      very syntax
    for great compile-to-JS
```
