### PR TITLE
Added RMarkdown to the list of languages

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1340,6 +1340,14 @@ RHTML:
   group: HTML
   primary_extension: .rhtml
 
+RMarkdown:
+  type: markup
+  lexer: Text only
+  wrap: true
+  primary_extension: .rmd
+  extensions:
+  - .Rmd
+
 Racket:
   type: programming
   lexer: Racket


### PR DESCRIPTION
RMarkdown is a markup language that allows combining Markdown with chunks of executable R code. It is increasingly used for literate programming and generating reproducible reports and papers in R.

Additional Details:
http://www.rstudio.com/ide/docs/r_markdown
