### PR TITLE
Updated language list to include HOW, and fixed the lack of lexer proble...

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -519,6 +519,14 @@ F#:
   - .fsi
   - .fsx
 
+FLUX:
+  type: programming
+  color: "#33CCFF"
+  primary_extension: .fx
+  lexer: Text only
+  extensions:
+  - .flux
+
 FORTRAN:
   type: programming
   lexer: Fortran
@@ -540,14 +548,6 @@ FORTRAN:
   - .f95
   - .for
   - .fpp
-
-FLUX:
-  type: programming
-  color: "#33CCFF"
-  primary_extension: .fx
-  lexer: Text only
-  extensions:
-  - .flux
 
 Factor:
   type: programming


### PR DESCRIPTION
...m.

Because HOW does not yet have a standardized lexer, I left the "lexer" field as "Text only". 
