### PR TITLE
Add Hy language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -733,6 +733,13 @@ Haxe:
   extensions:
   - .hxsl
 
+Hy:
+  type: programming
+  lexer: Clojure
+  ace_mode: clojure
+  color: "#7891b1"
+  primary_extension: .hy
+
 IDL:
   type: programming
   lexer: Text only

--- a/samples/Hy/fibonacci.hy
+++ b/samples/Hy/fibonacci.hy
@@ -1,0 +1,9 @@
+;; Fibonacci example in Hy.
+
+(defn fib [n]
+  (if (<= n 2) n
+      (+ (fib (- n 1)) (fib (- n 2)))))
+
+(if (= __name__ "__main__")
+  (for [x [1 2 3 4 5 6 7 8]]
+    (print (fib x))))

--- a/samples/Hy/hello-world.hy
+++ b/samples/Hy/hello-world.hy
@@ -1,0 +1,13 @@
+;; The concurrent.futures example in Hy.
+
+(import [concurrent.futures [ThreadPoolExecutor as-completed]]
+        [random [randint]]
+        [sh [sleep]])
+
+(defn task-to-do []
+  (sleep (randint 1 5)))
+
+(with-as (ThreadPoolExecutor 10) executor
+  (setv jobs (list-comp (.submit executor task-to-do) (x (range 0 10))))
+  (for (future (as-completed jobs))
+    (.result future)))


### PR DESCRIPTION
Hy is a dialect of Lisp that’s embedded in Python.
- Documentation: http://docs.hylang.org/en/latest/index.html
- Try Hy: https://try-hy.appspot.com/
- Source code: https://github.com/hylang/hy
