### PR TITLE
Add `.jshintrc` to JSON filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -782,6 +782,7 @@ JSON:
   - .sublime-settings
   - .sublime-workspace
   filenames:
+  - .jshintrc
   - composer.lock
 
 Jade:


### PR DESCRIPTION
JSHint tool for linting JavaScript uses `.jshintrc` configuration file. It is
in JSON format.

Example: https://github.com/jquery/jquery/blob/master/.jshintrc
