### PR TITLE
Fix handling of invalid UTF-8 byte sequences in Ruby 1.9+.

### DIFF
--- a/lib/linguist/samples.json
+++ b/lib/linguist/samples.json
@@ -509,8 +509,8 @@
       ".gemrc"
     ]
   },
-  "tokens_total": 426869,
-  "languages_total": 499,
+  "tokens_total": 426870,
+  "languages_total": 500,
   "tokens": {
     "ABAP": {
       "*/**": 1,
@@ -37649,6 +37649,7 @@
       "meth": 5,
       "request.method.lower": 1,
       "request.method": 2,
+      "SHEBANG#!python": 5,
       "google.protobuf": 4,
       "descriptor": 1,
       "_descriptor": 1,
@@ -37690,7 +37691,6 @@
       "Person": 1,
       "_message.Message": 1,
       "_reflection.GeneratedProtocolMessageType": 1,
-      "SHEBANG#!python": 4,
       "print": 39,
       "os": 1,
       "main": 4,
@@ -44870,7 +44870,7 @@
     "Processing": 74,
     "Prolog": 4040,
     "Protocol Buffer": 63,
-    "Python": 5715,
+    "Python": 5716,
     "R": 175,
     "Racket": 331,
     "Ragel in Ruby Host": 593,
@@ -45005,7 +45005,7 @@
     "Processing": 1,
     "Prolog": 6,
     "Protocol Buffer": 1,
-    "Python": 7,
+    "Python": 8,
     "R": 2,
     "Racket": 2,
     "Ragel in Ruby Host": 3,
@@ -45047,5 +45047,5 @@
     "Xtend": 2,
     "YAML": 1
   },
-  "md5": "8d40049b60f9c3a47eafac12ac2e9f8f"
+  "md5": "c7117d48c4310c71fcfe24b1321d008c"
 }

--- a/samples/Python/invalid-encoding.py
+++ b/samples/Python/invalid-encoding.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# Here is a string that cannot be decoded in line mode: Â.
+
+# From: llvm.org/svn/llvm-project/llvm/trunk/utils/lit/tests/shtest-encoding.py


### PR DESCRIPTION
This pull request is a proposal to fix #830, and closes #829.

Basically:
- explicitly convert text to UTF-8, replacing invalid characters prior to spitting into lines and/or parsing.  
  See changes in [blob_helper.rb](https://github.com/pullreq/linguist/blob/master/lib/linguist/blob_helper.rb) and [sample.rb](https://github.com/pullreq/linguist/blob/master/lib/linguist/sample.rb).
- Adds a test case (from LLVM's [lit](http://llvm.org/docs/CommandGuide/lit.html) testsuite) as [samples/Python/invalid-encoding.py](https://github.com/pullreq/linguist/blob/samples/Python/invalid-encoding.py).

Tested with Ruby 1.8.7p358 and 2.0.0p353 on Darwin.
