### PR TITLE
Move .gyp from Python to it's own language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1281,7 +1281,6 @@ Python:
   color: "#3581ba"
   primary_extension: .py
   extensions:
-  - .gyp
   - .lmi
   - .pyt
   - .pyw
@@ -1291,6 +1290,13 @@ Python:
   - wscript
   interpreters:
   - python
+
+GYP:
+  ace_mode: json
+  color: "#f3d158"
+  primary_extension: .gyp
+  extensions
+  - .gyp
 
 Python traceback:
   type: data
@@ -1468,7 +1474,7 @@ Scala:
 Scaml:
   group: HTML
   type: markup
-  primary_extension: .scaml
+  primary_extension: .scamlp
 
 Scheme:
   type: programming


### PR DESCRIPTION
Though GYP is primarily used with Python, other languages also implement it, such as Node.js via node-gyp. I'm proposing to move GYP by itself and recognise it as independent, so projects are not falsely interpreted as using Python. GYP is JSON like, so I've chosen JSON for the ace_mode.
