### PR TITLE
Get scons files recognized as python

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1289,6 +1289,8 @@ Python:
   - .xpy
   filenames:
   - wscript
+  - SConstruct
+  - SConscript
   interpreters:
   - python
 


### PR DESCRIPTION
I was looking at one of my repos that uses SCons as the build system and was surprised that the SConstruct and SConscript files weren't being recognized as python. I've added the two to the filenames section of the Python rule.
