### PR TITLE
adding JSON5 support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -785,6 +785,11 @@ JSON:
   - .jshintrc
   - composer.lock
 
+JSON5:
+  type: data
+  lexer: JavaScript
+  primary_extension: .json5
+
 Jade:
   group: HTML
   type: markup

--- a/samples/JSON5/example.json5
+++ b/samples/JSON5/example.json5
@@ -1,0 +1,29 @@
+/*
+ * The following is a contrived example, but it illustrates most of the features:
+ */
+
+{
+    foo: 'bar',
+    while: true,
+
+    this: 'is a \
+multi-line string',
+
+    // this is an inline comment
+    here: 'is another', // inline comment
+
+    /* this is a block comment
+       that continues on another line */
+
+    hex: 0xDEADbeef,
+    half: .5,
+    delta: +10,
+    to: Infinity,   // and beyond!
+
+    finally: 'a trailing comma',
+    oh: [
+        "we shouldn't forget",
+        'arrays can have',
+        'trailing commas too',
+    ],
+}

--- a/samples/JSON5/package.json5
+++ b/samples/JSON5/package.json5
@@ -1,0 +1,28 @@
+// This file is written in JSON5 syntax, naturally, but npm needs a regular
+// JSON file, so compile via `npm run build`. Be sure to keep both in sync!
+
+{
+    name: 'json5',
+    version: '0.2.0',
+    description: 'JSON for the ES5 era.',
+    keywords: ['json', 'es5'],
+    author: 'Aseem Kishore <aseem.kishore@gmail.com>',
+    contributors: [
+        'Max Nanasy <max.nanasy@gmail.com>',
+    ],
+    main: 'lib/json5.js',
+    bin: 'lib/cli.js',
+    dependencies: {},
+    devDependencies: {
+        mocha: '~1.0.3',
+    },
+    scripts: {
+        build: './lib/cli.js -c package.json5',
+        test: 'mocha --ui exports --reporter spec',
+    },
+    homepage: 'http://json5.org/',
+    repository: {
+        type: 'git',
+        url: 'https://github.com/aseemk/json5.git',
+    },
+}


### PR DESCRIPTION
I got tired of seeing [this](https://github.com/aseemk/json5/blob/develop/package.json5) without syntax highlighting.

Not adding samples.json changes since rake task reordered the entire file (44859 additions, 44810 deletions, see [samples branch](https://github.com/rlidwka/linguist/compare/samples)), so I thought you don't want to have that in your git history. 
