### PR TITLE
Ignore non-minified bootstrap files

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -138,7 +138,7 @@
 - ^[Ss]amples/
 
 # LICENSE, README, git config files
-- ^COPYIboNG$
+- ^COPYING$
 - LICENSE$
 - gitattributes$
 - gitignore$


### PR DESCRIPTION
- bootstrap.min.js is already excluded, but bootstrap.js is not.

It seems like this may have been intentional (d5002ef06a9f3463919a3fe8919844c3aea46fc0), though I'm not sure. As it stands, it causes some of my projects (like https://github.com/ChimeraCoder/go-server-bootstrap) to be categorized in correctly).

(Thanks to @coyotebush for pointing this out, and @thedaniel as well: https://news.ycombinator.com/item?id=6955670)
