### PR TITLE
Add vendor patterns for bower_components files

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -27,6 +27,9 @@
 # Node dependencies
 - node_modules/
 
+# Bower Components
+- bower_components/
+
 # Erlang bundles
 - ^rebar$
 

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -224,6 +224,11 @@ class TestBlob < Test::Unit::TestCase
     # Node dependencies
     assert blob("node_modules/coffee-script/lib/coffee-script.js").vendored?
 
+    # Bower Components
+    assert blob("bower_components/custom/custom.js").vendored?
+    assert blob("app/bower_components/custom/custom.js").vendored?
+    assert blob("vendor/assets/bower_components/custom/custom.js").vendored?
+
     # Rails vendor/
     assert blob("vendor/plugins/will_paginate/lib/will_paginate.rb").vendored?
 
@@ -326,7 +331,7 @@ class TestBlob < Test::Unit::TestCase
     # Test fixtures
     assert blob("test/fixtures/random.rkt").vendored?
     assert blob("Test/fixtures/random.rkt").vendored?
-    
+
     # Cordova/PhoneGap
     assert blob("cordova.js").vendored?
     assert blob("cordova.min.js").vendored?


### PR DESCRIPTION
Adds Bower Component files to the vendored files list.  This
uses the `bower_components` directory, which is the standard set by the
Bower package manager.
