### PR TITLE
Add .njs as a Javascript extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -839,6 +839,7 @@ JavaScript:
   - .jsm
   - .jss
   - .jsx
+  - .njs
   - .pac
   - .sjs
   - .ssjs


### PR DESCRIPTION
.njs is an extension used to denote node javascript files.

Fixes https://github.com/github/linguist/issues/865
