### PR TITLE
Add support for Tcl Modules

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1626,6 +1626,7 @@ Tcl:
   primary_extension: .tcl
   extensions:
   - .adp
+  - .tm
 
 Tcsh:
   type: programming


### PR DESCRIPTION
Tcl uses modules which have the extension `.tm`, so I have added this extension for Tcl.
