### PR TITLE
Do not reset options when calling highlight

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -485,7 +485,7 @@ module Linguist
     #
     # Returns html String
     def colorize(text, options = {})
-      lexer.highlight(text, options = {})
+      lexer.highlight(text, options)
     end
 
     # Public: Return name as String representation

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -387,4 +387,13 @@ class TestLanguage < Test::Unit::TestCase
 </pre></div>
     HTML
   end
+
+  def test_colorize_with_options
+    assert_equal <<-HTML.chomp, Language['Ruby'].colorize("def foo\n  'foo'\nend\n", :options => { :cssclass => "highlight highlight-ruby" })
+<div class="highlight highlight-ruby"><pre><span class="k">def</span> <span class="nf">foo</span>
+  <span class="s1">&#39;foo&#39;</span>
+<span class="k">end</span>
+</pre></div>
+    HTML
+  end
 end


### PR DESCRIPTION
Option hash was reset to an empty hash every time you call `#colorize`. Removed this so you can pass options to Pygments' formatters.

Included a test case.
