### PR TITLE
Add Tcl module extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1626,6 +1626,7 @@ Tcl:
   primary_extension: .tcl
   extensions:
   - .adp
+  - .tm
 
 Tcsh:
   type: programming


### PR DESCRIPTION
Tcl uses modules which have the extension `.tm`, so I have added this extension for Tcl.

This is a new request without any samples, to replace the previous pull request which I have removed.

Reference to the `.tm` extension for modules can be seen in the Tcl manual:
  http://www.tcl.tk/man/tcl8.5/TclCmd/tm.htm#M9

Examples of Tcl modules are here:
  https://github.com/LawrenceWoodman/stream_tcl/blob/master/stream-0.1.tm
  https://github.com/LawrenceWoodman/xdgbasedir_tcl/blob/master/xdgbasedir-0.3.tm
