### PR TITLE
Ignore typescript definition files.

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -63,6 +63,9 @@
 - (^|/)controls\.js$
 - (^|/)dragdrop\.js$
 
+# Typesciprt
+- (.*?)\.d\.ts #Typscript definition files
+
 # MooTools
 - (^|/)mootools([^.]*)\d+\.\d+.\d+([^.]*)\.js$
 


### PR DESCRIPTION
Adds pattern for typescript definition files (by convention named with a .d.ts extension). Typescript definition files may be very big. The jquery.d.ts file form the DefinitelyTyped repo on GitHub is 11k lines.
