### PR TITLE
FORTRAN => Fortran

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -528,28 +528,6 @@ F#:
   - .fsi
   - .fsx
 
-FORTRAN:
-  type: programming
-  lexer: Fortran
-  color: "#4d41b1"
-  primary_extension: .f90
-  extensions:
-  - .F
-  - .F03
-  - .F08
-  - .F77
-  - .F90
-  - .F95
-  - .FOR
-  - .FPP
-  - .f
-  - .f03
-  - .f08
-  - .f77
-  - .f95
-  - .for
-  - .fpp
-
 Factor:
   type: programming
   color: "#636746"
@@ -579,6 +557,27 @@ Forth:
   lexer: Text only
   extensions:
   - .4th
+
+Fortran:
+  type: programming
+  color: "#4d41b1"
+  primary_extension: .f90
+  extensions:
+  - .F
+  - .F03
+  - .F08
+  - .F77
+  - .F90
+  - .F95
+  - .FOR
+  - .FPP
+  - .f
+  - .f03
+  - .f08
+  - .f77
+  - .f95
+  - .for
+  - .fpp
 
 GAS:
   type: programming
@@ -723,7 +722,7 @@ Harbour:
   lexer: Text only
   color: "#0e60e3"
   primary_extension: .hb
- 
+
 Haskell:
   type: programming
   color: "#29b544"
@@ -1184,7 +1183,7 @@ PAWN:
   lexer: C++
   color: "#dbb284"
   primary_extension: .pwn
-  
+
 PHP:
   type: programming
   ace_mode: php
@@ -1307,7 +1306,7 @@ Prolog:
   type: programming
   color: "#74283c"
   primary_extension: .prolog
-  extensions: 
+  extensions:
   - .pl
 
 Protocol Buffer:

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -20,7 +20,6 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Lexer['Coq'], Language['Coq'].lexer
     assert_equal Lexer['FSharp'], Language['F#'].lexer
     assert_equal Lexer['FSharp'], Language['F#'].lexer
-    assert_equal Lexer['Fortran'], Language['FORTRAN'].lexer
     assert_equal Lexer['Gherkin'], Language['Cucumber'].lexer
     assert_equal Lexer['Groovy'], Language['Groovy'].lexer
     assert_equal Lexer['HTML'], Language['HTML'].lexer


### PR DESCRIPTION
The all-caps spelling is a historical artifact.

<blockquote>The official language standards now refer to the language as "Fortran".</blockquote> See http://en.wikipedia.org/wiki/Fortran#Capitalization for more.
