### PR TITLE
add Cirru with some samples

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -296,6 +296,16 @@ ChucK:
   lexer: Java
   primary_extension: .ck
 
+Cirru:
+  type: programming
+  color: "#aaaaff"
+  primary_extension: .cirru
+  # ace_mode: cirru
+  # lexer: Cirru
+  lexer: Text only
+  extensions:
+  - .cr
+
 Clean:
   type: programming
   color: "#3a81ad"

--- a/samples/Cirru/array.cirru
+++ b/samples/Cirru/array.cirru
@@ -1,0 +1,12 @@
+
+print $ array
+  int 1
+  string 2
+
+print $ array
+  int 1
+  array
+    int 2
+    string 3
+    array
+      string 4

--- a/samples/Cirru/block.cirru
+++ b/samples/Cirru/block.cirru
@@ -1,0 +1,7 @@
+
+set f $ block (a b c)
+  print a b c
+
+call f (int 1) (int 2) (int 3)
+
+f (int 1) (int 2) (int 3)

--- a/samples/Cirru/bool.cirru
+++ b/samples/Cirru/bool.cirru
@@ -1,0 +1,7 @@
+
+print $ bool true
+print $ bool false
+print $ bool yes
+print $ bool no
+print $ bool 1
+print $ bool 0

--- a/samples/Cirru/map.cirru
+++ b/samples/Cirru/map.cirru
@@ -1,0 +1,14 @@
+
+print $ map
+  a $ int 5
+  b $ array (int 1) (int 2)
+  c $ map
+    int 1
+    array (int 4)
+
+set m $ map
+  a $ int 1
+
+set m b $ int 2
+
+print m

--- a/samples/Cirru/number.cirru
+++ b/samples/Cirru/number.cirru
@@ -1,0 +1,3 @@
+
+print $ int 1
+print $ float 1.2

--- a/samples/Cirru/require.cirru
+++ b/samples/Cirru/require.cirru
@@ -1,0 +1,2 @@
+
+require ./stdio.cr

--- a/samples/Cirru/scope.cirru
+++ b/samples/Cirru/scope.cirru
@@ -1,0 +1,23 @@
+
+set a (int 2)
+
+print (self)
+
+set c (child)
+
+under c
+  under parent
+    print a
+
+print $ get c a
+
+set c x (int 3)
+print $ get c x
+
+set just-print $ code
+  print a
+
+print just-print
+
+eval (self) just-print
+eval just-print

--- a/samples/Cirru/stdio.cirru
+++ b/samples/Cirru/stdio.cirru
@@ -1,0 +1,55 @@
+
+set a $ string 1
+print a
+
+print (string 1)
+
+print nothing
+
+print
+  map
+    a (int 4)
+    b $ map
+      a $ int 5
+      b $ int 6
+      c $ map
+        int 7
+
+print
+  array
+    int 1
+    int 2
+    array
+      int 3
+      int 4
+
+print
+  array
+    int 1
+    map
+      a $ int 2
+      b $ array
+        int 3
+
+print
+  int 1
+  int 2
+
+print $ code
+  set a 1
+  print (get a)
+  print $ array
+    int a
+    array
+      int a
+
+set container (map)
+set container code $ code
+  set a 1
+  print (get a)
+  print $ array
+    int a
+    array
+      int a
+
+print container

--- a/samples/Cirru/string.cirru
+++ b/samples/Cirru/string.cirru
@@ -1,0 +1,3 @@
+
+print $ string a
+print $ string "a b"


### PR DESCRIPTION
Cirru is a set of grammar rules designed for scripting langauges based on indentations.
Home page: http://cirru.org/

Pygments support merged but not released:
https://bitbucket.org/birkenfeld/pygments-main/pull-request/275/add-syntax-for-cirru/diff
Syntax support of Ace editor not merged yet: https://github.com/ajaxorg/ace/pull/1780
I'm not sure when they are possible to be run on GitHub, so I commented them by now.
