### PR TITLE
Add interpreter for Groovy language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -653,6 +653,8 @@ Groovy:
   ace_mode: groovy
   color: "#e69f56"
   primary_extension: .groovy
+  interpreters:
+  - groovy
 
 Groovy Server Pages:
   group: Groovy


### PR DESCRIPTION
This adds an interpreter for Groovy, so that executable groovy files without extensions, but with a shebang (such as [this one](https://github.com/arturoherrero/sparky/blob/master/sparky)) are correctly recognized.
