### PR TITLE
Add interpreter for CoffeeScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -343,6 +343,8 @@ CoffeeScript:
   - .iced
   filenames:
   - Cakefile
+  interpreters:
+  - coffee
 
 ColdFusion:
   type: programming


### PR DESCRIPTION
This adds an interpreter for CoffeeScript, so that executable coffee files without extensions, but with a shebang are correctly recognized. `coffee` is [the interpreter](http://coffeescript.org/#usage) for CoffeeScript files.
