### PR TITLE
Add .es6 as JavaScript extension.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -735,7 +735,7 @@ Harbour:
   lexer: Text only
   color: "#0e60e3"
   primary_extension: .hb
- 
+
 Haskell:
   type: programming
   color: "#29b544"
@@ -860,6 +860,7 @@ JavaScript:
   extensions:
   - ._js
   - .bones
+  - .es6
   - .jake
   - .jsfl
   - .jsm
@@ -1196,7 +1197,7 @@ PAWN:
   lexer: C++
   color: "#dbb284"
   primary_extension: .pwn
-  
+
 PHP:
   type: programming
   ace_mode: php
@@ -1319,7 +1320,7 @@ Prolog:
   type: programming
   color: "#74283c"
   primary_extension: .prolog
-  extensions: 
+  extensions:
   - .pl
 
 Protocol Buffer:


### PR DESCRIPTION
Projects based on https://github.com/dockyard/ember-appkit-rails are starting to use `.es6` as a file extension for files using ECMAScript 6.

It would be great to have `.es6` files  highlighted. You can see an example file here https://github.com/abuiles/facturas/blob/master/app/models/client.es6
