### PR TITLE
Support of the .ecl file extension for Prolog.

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -19,6 +19,9 @@ module Linguist
         if languages.all? { |l| ["Perl", "Prolog"].include?(l) }
           disambiguate_pl(data, languages)
         end
+        if languages.all? { |l| ["ECL", "Prolog"].include?(l) }
+          disambiguate_ecl(data, languages)
+        end
         if languages.all? { |l| ["TypeScript", "XML"].include?(l) }
           disambiguate_ts(data, languages)
         end
@@ -43,6 +46,13 @@ module Linguist
       matches = []
       matches << Language["Prolog"] if data.include?(":-")
       matches << Language["Perl"] if data.include?("use strict")
+      matches
+    end
+
+    def self.disambiguate_ecl(data, languages)
+      matches = []
+      matches << Language["Prolog"] if data.include?(":-")
+      matches << Language["ECL"] if data.include?(":=")
       matches
     end
 

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1323,6 +1323,7 @@ Prolog:
   color: "#74283c"
   primary_extension: .prolog
   extensions:
+  - .ecl
   - .pl
 
 Protocol Buffer:

--- a/samples/Prolog/or-constraint.ecl
+++ b/samples/Prolog/or-constraint.ecl
@@ -1,0 +1,90 @@
+:- lib(ic).
+
+/**
+ * Question 1.11
+ * vabs(?Val, ?AbsVal)
+ */
+vabs(Val, AbsVal):-
+	AbsVal #> 0,
+	(
+		Val #= AbsVal
+	;
+		Val #= -AbsVal
+	),
+	labeling([Val, AbsVal]).
+
+/**
+ * vabsIC(?Val, ?AbsVal)
+ */
+vabsIC(Val, AbsVal):-
+	AbsVal #> 0,
+	Val #= AbsVal or Val #= -AbsVal,
+	labeling([Val, AbsVal]).
+
+/**
+ * Question 1.12
+ */
+% X #:: -10..10, vabs(X, Y).
+% X #:: -10..10, vabsIC(X, Y).
+
+/**
+ * Question 1.13
+ * faitListe(?ListVar, ?Taille, +Min, +Max)
+ */
+faitListe([], 0, _, _):-!.
+faitListe([First|Rest], Taille, Min, Max):-
+	First #:: Min..Max,
+	Taille1 #= Taille - 1,
+	faitListe(Rest, Taille1, Min, Max).
+
+/**
+ * Question 1.14
+ * suite(?ListVar)
+ */
+suite([Xi, Xi1, Xi2]):-
+	checkRelation(Xi, Xi1, Xi2).
+suite([Xi, Xi1, Xi2|Rest]):-
+	checkRelation(Xi, Xi1, Xi2),
+	suite([Xi1, Xi2|Rest]).
+
+/**
+ * checkRelation(?Xi, ?Xi1, ?Xi2)
+ */
+checkRelation(Xi, Xi1, Xi2):-
+	vabs(Xi1, VabsXi1),
+	Xi2 #= VabsXi1 - Xi.
+
+/**
+ * Question 1.15
+ * checkPeriode(+ListVar).
+ */
+% TODO Any better solution?
+checkPeriode(ListVar):-
+	length(ListVar, Length),
+	Length < 10.
+checkPeriode([X1, X2, X3, X4, X5, X6, X7, X8, X9, X10|Rest]):-
+	X1 =:= X10,
+	checkPeriode([X2, X3, X4, X5, X6, X7, X8, X9, X10|Rest]).
+% faitListe(ListVar, 18, -9, 9), suite(ListVar), checkPeriode(ListVar). => 99 solutions
+
+
+/**
+ * Tests
+ */
+/*
+vabs(5, 5). => Yes
+vabs(5, -5). => No
+vabs(-5, 5). => Yes
+vabs(X, 5).
+vabs(X, AbsX). 
+vabsIC(5, 5). => Yes
+vabsIC(5, -5). => No
+vabsIC(-5, 5). => Yes
+vabsIC(X, 5).
+vabsIC(X, AbsX).
+
+faitListe(ListVar, 5, 1, 3). => 243 solutions
+faitListe([_, _, _, _, _], Taille, 1, 3). => Taille = 5 !!!!!!!!!!!!!!!!
+
+faitListe(ListVar, 18, -9, 9), suite(ListVar). => 99 solutions
+*/

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -50,6 +50,18 @@ class TestHeuristcs < Test::Unit::TestCase
     results = Heuristics.disambiguate_pl(fixture("Perl/perl-test.t"), languages)
     assert_equal Language["Perl"], results.first
   end
+  
+  def test_ecl_prolog_by_heuristics
+    languages = ["ECL", "Prolog"]
+    results = Heuristics.disambiguate_ecl(fixture("Prolog/or-constraint.ecl"), languages)
+    assert_equal Language["Prolog"], results.first
+  end
+  
+  def test_ecl_ecl_by_heuristics
+    languages = ["ECL", "Prolog"]
+    results = Heuristics.disambiguate_ecl(fixture("ECL/sample.ecl"), languages)
+    assert_equal Language["ECL"], results.first
+  end
 
   def test_ts_typescript_by_heuristics
     languages = ["TypeScript", "XML"]


### PR DESCRIPTION
This adds the support of the .ecl file extension for Prolog.
.ecl is used for ECLiPSe Prolog files (as opposed to pure-Prolog files).
This search result displays misdetected files:
https://github.com/search?l=ECL&q=%3A-&ref=advsearch&type=Code
One of the best example being:
https://github.com/hakank/hakank/blob/d0de1db0f7b1f87847b2b2702dbcedd86cb7a5ff/eclipse_clp/discrete_tomography.ecl

The ECL language also uses this file extension thus I added some heuristics and a sample file to go with it.
