### PR TITLE
add haxelib run.n neko bytecode file to vendor list

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -47,6 +47,9 @@
 # Debian packaging
 - ^debian/
 
+# Haxelib projects often contain a neko bytecode file named run.n
+- run\.n
+
 ## Commonly Bundled JavaScript frameworks ##
 
 # jQuery


### PR DESCRIPTION
Many haxelib projects ([like this one](https://github.com/HaxeFoundation/hxcs) or [this](https://github.com/HaxeFoundation/hxjava)) contain a "run.n" (neko bytecode) file which linguist treats like Nemerle source code.
