### PR TITLE
Highlight MQL syntax as C

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -215,6 +215,8 @@ C:
   primary_extension: .c
   extensions:
   - .w
+  - .mqh
+  - .mq4
 
 C#:
   type: programming


### PR DESCRIPTION
Taken from http://docs.mql4.com/basis/syntax:

> Syntax of MQL4 is much a C-like syntax

Just for reference, here is a MQL file on Github without highlight:

https://github.com/sergeylukin/mql4-mysql/blob/master/src/mql4-mysql.mqh

and here is C lexer applied to an MQL file (see "How to use" section):

https://github.com/sergeylukin/mql4-mysql/blob/master/README.md
