### PR TITLE
Improving binary file detection by looking at bytes in each blob

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -70,7 +70,14 @@ module Linguist
     #
     # Return true or false
     def likely_binary?
-      binary_mime_type? && !Language.find_by_filename(name)
+      if binary_mime_type?
+        true
+      else
+        ascii = 0
+        total = 0
+        data.each_byte{|c| total += 1; ascii +=1 if c >= 128 or c == 0}
+        ascii.to_f / total.to_f > 0.33 ? true : false
+      end
     end
 
     # Public: Get the Content-Type header value


### PR DESCRIPTION
Hello Devs!

I've got a new project that we are migrating to GitHub.  It's currently private while we get approvals from our company to open source it, but we are being incorrectly categorized as Eiffel!

The issue is that we have a very large test suite with our software that stores output in "ExodusII" format which is a binary file that has a file extension of ".e".  I looked over the linguist code and it appears that the binary file checker is not very robust.  I did a little Googling and found a routine that determines the file type based on the actual bytes in the file instead of relying on mime-types or other less reliable methods.

Alternatively, I could propose some other directory names to skip.  We keep all of our tests in a directory named "tests" which is not currently in the "vendor.yml" file.  When our project goes public, I'll certainly be in touch to show you where our problems are at. 

Disclaimer: I'm not a ruby programmer so if there is a better way to do this test, please feel free to comment.  Have you guys considered allowing projects to put in a .linguist file in their directories to handle project by project configuration?

Thanks,
Cody
