### PR TITLE
Exclude haxe library run.n files

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -172,3 +172,6 @@
 
 # .DS_Store's
 - .[Dd][Ss]_[Ss]tore$
+
+#haxe lib binary
+- run.n


### PR DESCRIPTION
Haxe libraries often have compiled neko run.n binary files included for easy installation from git repos. The run.n files should be ignored when determining the language of a repo. Currently they seem to marked as Nemerle source.
