### PR TITLE
Add interpreter for JavaScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -887,6 +887,8 @@ JavaScript:
   - .ssjs
   filenames:
   - Jakefile
+  interpreters:
+  - node
 
 Julia:
   type: programming


### PR DESCRIPTION
This adds an interpreter for JavaScript, so that executable JavaScript files without extensions, but with a shebang are correctly recognized. [`node`](http://nodejs.org/) is one of the interpreters for JavaScript files.
