### PR TITLE
Add interpreter for AppleScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -104,6 +104,8 @@ AppleScript:
   primary_extension: .applescript
   extensions:
   - .scpt
+  interpreters:
+  - osascript
 
 Arc:
   type: programming


### PR DESCRIPTION
This adds an interpreter for AppleScript, so that executable AppleScript files without extensions, but with a shebang are correctly recognized. [`osascript`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/osascript.1.html) is an interpreter for AppleScript files.
