### PR TITLE
Add unity vendor files

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -180,3 +180,7 @@
 
 #.meta files
 -.meta$
+
+#c sharp project files
+-.csproj$
+-.sln$


### PR DESCRIPTION
My project (https://github.com/cineboxandrew/voxelgon) was showing as C, and I suspect that the .meta files are to blame. Also added .csproj and .sln for good measure.
