### PR TITLE
Add gradle wrapper files to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -117,6 +117,13 @@
 # Sparkle
 - (^|/)Sparkle/
 
+## Groovy ##
+
+# Gradle
+- (^|/)gradlew$
+- (^|/)gradlew\.bat$
+- (^|/)gradle/wrapper/
+
 ## .NET ##
 
 # Visual Studio IntelliSense

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -343,6 +343,14 @@ class TestBlob < Test::Unit::TestCase
 
     # Vagrant
     assert blob("Vagrantfile").vendored?
+
+    # Gradle
+    assert blob("gradlew").vendored?
+    assert blob("gradlew.bat").vendored?
+    assert blob("gradle/wrapper/gradle-wrapper.properties").vendored?
+    assert blob("subproject/gradlew").vendored?
+    assert blob("subproject/gradlew.bat").vendored?
+    assert blob("subproject/gradle/wrapper/gradle-wrapper.properties").vendored?
   end
 
   def test_language


### PR DESCRIPTION
Gradle Wrapper [1] files are auto-generated. They shouldn't count in the language statistics.

[1] http://www.gradle.org/docs/current/userguide/gradle_wrapper.html
