### PR TITLE
Support of AspectJ language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -129,6 +129,12 @@ AsciiDoc:
   - .adoc
   - .asc
 
+AspectJ:
+  type: programming
+  lexer: AspectJ
+  color: "#1957b0"
+  primary_extension: .aj
+
 Assembly:
   type: programming
   lexer: NASM

--- a/samples/AspectJ/CacheAspect.aj
+++ b/samples/AspectJ/CacheAspect.aj
@@ -1,0 +1,41 @@
+package com.blogspot.miguelinlas3.aspectj.cache;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.aspectj.lang.JoinPoint;
+
+import com.blogspot.miguelinlas3.aspectj.cache.marker.Cachable;
+
+/**
+ * This simple aspect simulates the behaviour of a very simple cache
+ *  
+ * @author migue
+ *
+ */
+public aspect CacheAspect {
+
+	public pointcut cache(Cachable cachable): execution(@Cachable * * (..)) && @annotation(cachable);
+	
+	Object around(Cachable cachable): cache(cachable){
+	
+		String evaluatedKey = this.evaluateKey(cachable.scriptKey(), thisJoinPoint);
+		
+		if(cache.containsKey(evaluatedKey)){
+			System.out.println("Cache hit for key " + evaluatedKey);
+			return this.cache.get(evaluatedKey);
+		}
+		
+		System.out.println("Cache miss for key " + evaluatedKey);
+		Object value = proceed(cachable);
+		cache.put(evaluatedKey, value);
+		return value;
+	}
+	
+	protected String evaluateKey(String key, JoinPoint joinPoint) {
+		// TODO add some smart staff to allow simple scripting in @Cachable annotation
+		return key;
+	}
+	
+	protected Map<String, Object> cache = new WeakHashMap<String, Object>();
+}

--- a/samples/AspectJ/OptimizeRecursionCache.aj
+++ b/samples/AspectJ/OptimizeRecursionCache.aj
@@ -1,0 +1,50 @@
+package aspects.caching;
+
+import java.util.Map;
+
+/**
+ * Cache aspect for optimize recursive functions.
+ * 
+ * @author Migueli
+ * @date 05/11/2013
+ * @version 1.0
+ *
+ */
+public abstract aspect OptimizeRecursionCache {
+		
+	@SuppressWarnings("rawtypes")
+	private Map _cache;
+	
+	public OptimizeRecursionCache() {
+		_cache = getCache();
+	}
+	
+	@SuppressWarnings("rawtypes")
+	abstract public Map getCache();
+	
+	abstract public pointcut operation(Object o);
+
+	pointcut topLevelOperation(Object o): operation(o) && !cflowbelow(operation(Object));
+
+	before(Object o) : topLevelOperation(o) {
+		System.out.println("Seeking value for " + o);
+	}
+
+	Object around(Object o) : operation(o) {
+		Object cachedValue = _cache.get(o);
+		if (cachedValue != null) {
+			System.out.println("Found cached value for " + o + ": " + cachedValue);
+			return cachedValue;
+		}
+		return proceed(o);
+	}
+
+	@SuppressWarnings("unchecked")
+	after(Object o) returning(Object result) : topLevelOperation(o) {
+		_cache.put(o, result);
+	}
+	
+	after(Object o) returning(Object result) : topLevelOperation(o) {
+		System.out.println("cache size: " + _cache.size());
+	}
+}

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -10,6 +10,7 @@ class TestLanguage < Test::Unit::TestCase
 
   def test_lexer
     assert_equal Lexer['ActionScript 3'], Language['ActionScript'].lexer
+    assert_equal Lexer['AspectJ'], Language['AspectJ'].lexer
     assert_equal Lexer['Bash'], Language['Gentoo Ebuild'].lexer
     assert_equal Lexer['Bash'], Language['Gentoo Eclass'].lexer
     assert_equal Lexer['Bash'], Language['Shell'].lexer


### PR DESCRIPTION
Support of AspectJ language as discussed here: #968.
AspectJ files are currently recognized as Java files.
They are currently the only language with the .aj extension (thus no conflicts).

Some examples on GitHub:
https://github.com/Migueli/AspectJ
https://github.com/migue/blog-examples
https://github.com/eclipsesource/com.eclipsesource.tycho.aspectj.demo

I added two sample codes.
