### PR TITLE
Added Gemfile.lock to the list of Ruby filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1524,6 +1524,7 @@ Ruby:
   - Appraisals
   - Berksfile
   - Gemfile
+  - Gemfile.lock
   - Guardfile
   - Podfile
   - Thorfile


### PR DESCRIPTION
Hopefully, this is enough to make Gemfile.lock syntax highlighting not look totally crazy. If not, please point me in the right direction and I'll do more.

For example, https://github.com/G5/g5-phone-number-service/blob/master/Gemfile.lock

<3
