### PR TITLE
Add identification for System Verilog.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1667,6 +1667,14 @@ SuperCollider:
   lexer: Text only
   primary_extension: .scd
 
+SystemVerilog:
+  type: programming
+  lexer: verilog
+  color: "#848bf3"
+  primary_extension: .sv
+  extensions:
+  - .vh
+
 TOML:
   type: data
   primary_extension: .toml


### PR DESCRIPTION
Used same lexer, same color as Verilog. System Verilog uses '.sv' file extension for source files and '.vh' for libraries and packages.
