### PR TITLE
Fixing support for Forth Language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -601,11 +601,15 @@ Fantom:
 
 Forth:
   type: programming
-  primary_extension: .fth
+  primary_extension: .fs
   color: "#341708"
   lexer: Text only
   extensions:
   - .4th
+  - .fi
+  - .fb
+  - .ds
+  - .fth
 
 GAS:
   type: programming


### PR DESCRIPTION
Per the GForth man page under the FILES section:

FILES
       .../gforth.fi  default Forth image
       *.fi           Forth loadable image
       *.fs           Forth source (sequential)
       *.fb           Forth source (block)
       *.fd           generated with makedoc.fs
       *.i            C include files
       *.ds           documentation source
       *TAGS          etags files

The primary extension for Forth source uses the .fs extension when stored in source files, .fb for forth blocks.  Currently linguist is detecting most of the gforth code base as being F# which is obviously wrong.
