### PR TITLE
add extension .cc for c++

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -254,6 +254,7 @@ C++:
   extensions:
   - .C
   - .c++
+  - .cc
   - .cxx
   - .H
   - .h++


### PR DESCRIPTION
now that there is `.hh` for the header, `.cc` should be there for the source.
