### PR TITLE
Update vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -139,6 +139,10 @@
 # NuGet
 - ^[Pp]ackages/
 
+# Globalize NuGet package. Ignore the 350 javascript files containing culture settings
+- (^|/)globalize/cultures/globalize.culture.*.js$
+
+
 # ExtJS
 - (^|/)extjs/.*?\.js$
 - (^|/)extjs/.*?\.xml$


### PR DESCRIPTION
Hello,

I have a C# repository containing C# libraries and an ASP.NET MVC project and the repository is marked as Javascript language. It seems that the problem is a NuGet package called Globalize. It adds 350 javascript to the folder "globalize/cultures" and with the pattern "globalize.culture.*.js". These files contain culture settings for each supported culture.

This package can be located here: http://www.nuget.org/packages/jquery-globalize/

This is my repository: https://github.com/Appverse/appverse-net

I have added this new exception to the file:
Globalize NuGet package. Ignore the 350 javascript files containing culture settings
- (^|/)globalize/cultures/globalize.culture.*.js$
