### PR TITLE
Delete primary_extension from language data

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -24,7 +24,6 @@ module Linguist
     @extension_index          = Hash.new { |h,k| h[k] = [] }
     @interpreter_index        = Hash.new { |h,k| h[k] = [] }
     @filename_index           = Hash.new { |h,k| h[k] = [] }
-    @primary_extension_index  = {}
 
     # Valid Languages types
     TYPES = [:data, :markup, :programming, :prose]
@@ -79,12 +78,6 @@ module Linguist
 
         @extension_index[extension] << language
       end
-
-      if @primary_extension_index.key?(language.primary_extension)
-        raise ArgumentError, "Duplicate primary extension: #{language.primary_extension}"
-      end
-
-      @primary_extension_index[language.primary_extension] = language
 
       language.interpreters.each do |interpreter|
         @interpreter_index[interpreter] << language
@@ -191,8 +184,7 @@ module Linguist
     # Returns all matching Languages or [] if none were found.
     def self.find_by_filename(filename)
       basename, extname = File.basename(filename), File.extname(filename)
-      langs = [@primary_extension_index[extname]] +
-              @filename_index[basename] +
+      langs = @filename_index[basename] +
               @extension_index[extname]
       langs.compact.uniq
     end
@@ -299,15 +291,6 @@ module Linguist
       @interpreters = attributes[:interpreters]   || []
       @filenames  = attributes[:filenames]  || []
 
-      unless @primary_extension = attributes[:primary_extension]
-        raise ArgumentError, "#{@name} is missing primary extension"
-      end
-
-      # Prepend primary extension unless its already included
-      if primary_extension && !extensions.include?(primary_extension)
-        @extensions = [primary_extension] + extensions
-      end
-
       # Set popular, and searchable flags
       @popular    = attributes.key?(:popular)    ? attributes[:popular]    : false
       @searchable = attributes.key?(:searchable) ? attributes[:searchable] : true
@@ -395,20 +378,6 @@ module Linguist
     # Returns the extensions Array
     attr_reader :extensions
 
-    # Deprecated: Get primary extension
-    #
-    # Defaults to the first extension but can be overridden
-    # in the languages.yml.
-    #
-    # The primary extension can not be nil. Tests should verify this.
-    #
-    # This attribute is only used by app/helpers/gists_helper.rb for
-    # creating the language dropdown. It really should be using `name`
-    # instead. Would like to drop primary extension.
-    #
-    # Returns the extension String.
-    attr_reader :primary_extension
-
     # Public: Get interpreters
     #
     # Examples
@@ -430,6 +399,22 @@ module Linguist
     # Public: Return all possible extensions for language
     def all_extensions
       (extensions + [primary_extension]).uniq
+    end
+
+    # Deprecated: Get primary extension
+    #
+    # Defaults to the first extension but can be overridden
+    # in the languages.yml.
+    #
+    # The primary extension can not be nil. Tests should verify this.
+    #
+    # This method is only used by app/helpers/gists_helper.rb for creating
+    # the language dropdown. It really should be using `name` instead.
+    # Would like to drop primary extension.
+    #
+    # Returns the extension String.
+    def primary_extension
+      extensions.first
     end
 
     # Public: Get URL escaped name.
@@ -573,9 +558,8 @@ module Linguist
       :group_name        => options['group'],
       :searchable        => options.key?('searchable') ? options['searchable'] : true,
       :search_term       => options['search_term'],
-      :extensions        => options['extensions'].sort,
+      :extensions        => [options['extensions'].first] + options['extensions'][1..-1].sort,
       :interpreters      => options['interpreters'].sort,
-      :primary_extension => options['primary_extension'],
       :filenames         => options['filenames'],
       :popular           => popular.include?(name)
     )

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9,12 +9,9 @@
 #                     includes name.downcase)
 # ace_mode          - A String name of Ace Mode (if available)
 # wrap              - Boolean wrap to enable line wrapping (default: false)
-# extension         - An Array of associated extensions
+# extension         - An Array of associated extensions (the first one is
+#                     considered the primary extension)
 # interpreters      - An Array of associated interpreters
-# primary_extension - A String for the main extension associated with
-#                     the language. Must be unique. Used when a Language is picked
-#                     from a dropdown and we need to automatically choose an
-#                     extension.
 # searchable        - Boolean flag to enable searching (defaults to true)
 # search_term       - Deprecated: Some languages maybe indexed under a
 #                     different alias. Avoid defining new exceptions.
@@ -28,13 +25,15 @@
 ABAP:
   type: programming
   lexer: ABAP
-  primary_extension: .abap
+  extensions:
+  - .abap
 
 ANTLR:
   type: programming
   color: "#9DC3FF"
   lexer: ANTLR
-  primary_extension: .g4
+  extensions:
+  - .g4
 
 ASP:
   type: programming
@@ -44,8 +43,8 @@ ASP:
   aliases:
   - aspx
   - aspx-vb
-  primary_extension: .asp
   extensions:
+  - .asp
   - .asax
   - .ascx
   - .ashx
@@ -56,11 +55,11 @@ ASP:
 ATS:
   type: programming
   color: "#1ac620"
-  primary_extension: .dats
   lexer: OCaml
   aliases:
   - ats2
   extensions:
+  - .dats
   - .atxt
   - .hats
   - .sats
@@ -72,19 +71,21 @@ ActionScript:
   search_term: as3
   aliases:
   - as3
-  primary_extension: .as
+  extensions:
+  - .as
 
 Ada:
   type: programming
   color: "#02f88c"
-  primary_extension: .adb
   extensions:
+  - .adb
   - .ads
 
 Agda:
   type: programming
   color: "#467C91"
-  primary_extension: .agda
+  extensions:
+  - .agda
 
 Alloy:
   type: programming  # 'modeling' would be more appropiate
@@ -96,19 +97,21 @@ ApacheConf:
   type: markup
   aliases:
   - apache
-  primary_extension: .apacheconf
+  extensions:
+  - .apacheconf
 
 Apex:
   type: programming
   lexer: Text only
-  primary_extension: .cls
+  extensions:
+  - .cls
 
 AppleScript:
   type: programming
   aliases:
   - osascript
-  primary_extension: .applescript
   extensions:
+  - .applescript
   - .scpt
   interpreters:
   - osascript
@@ -117,21 +120,23 @@ Arc:
   type: programming
   color: "#ca2afe"
   lexer: Text only
-  primary_extension: .arc
+  extensions:
+  - .arc
 
 Arduino:
   type: programming
   color: "#bd79d1"
   lexer: C++
-  primary_extension: .ino
+  extensions:
+  - .ino
 
 AsciiDoc:
   type: prose
   lexer: Text only
   ace_mode: asciidoc
   wrap: true
-  primary_extension: .asciidoc
   extensions:
+  - .asciidoc
   - .adoc
   - .asc
 
@@ -148,11 +153,13 @@ Assembly:
   search_term: nasm
   aliases:
   - nasm
-  primary_extension: .asm
+  extensions:
+  - .asm
 
 Augeas:
   type: programming
-  primary_extension: .aug
+  extensions:
+  - .aug
 
 AutoHotkey:
   type: programming
@@ -160,7 +167,8 @@ AutoHotkey:
   color: "#6594b9"
   aliases:
   - ahk
-  primary_extension: .ahk
+  extension:
+  - .ahk
 
 AutoIt:
   type: programming
@@ -169,13 +177,14 @@ AutoIt:
   - au3
   - AutoIt3
   - AutoItScript
-  primary_extension: .au3
+  extensions:
+  - .au3
 
 Awk:
   type: programming
   lexer: Awk
-  primary_extension: .awk
   extensions:
+  - .awk
   - .auk
   - .gawk
   - .mawk
@@ -192,54 +201,60 @@ Batchfile:
   search_term: bat
   aliases:
   - bat
-  primary_extension: .bat
   extensions:
+  - .bat
   - .cmd
 
 Befunge:
-  primary_extension: .befunge
+  extensions:
+  - .befunge
 
 BlitzBasic:
   type: programming
   aliases:
   - blitzplus
   - blitz3d
-  primary_extension: .bb
   extensions:
+  - .bb
   - .decls
 
 BlitzMax:
-  primary_extension: .bmx
+  extensions:
+  - .bmx
 
 Bluespec:
   type: programming
   lexer: verilog
-  primary_extension: .bsv
+  extensions:
+  - .bsv
 
 Boo:
   type: programming
   color: "#d4bec1"
-  primary_extension: .boo
+  extensions:
+  - .boo
 
 Brainfuck:
-  primary_extension: .b
   extensions:
+  - .b
   - .bf
 
 Brightscript:
   type: programming
   lexer: Text only
-  primary_extension: .brs
+  extensions:
+  - .brs
 
 Bro:
   type: programming
-  primary_extension: .bro
+  extensions:
+  - .bro
 
 C:
   type: programming
   color: "#555"
-  primary_extension: .c
   extensions:
+  - .c
   - .cats
   - .w
 
@@ -250,8 +265,8 @@ C#:
   color: "#5a25a2"
   aliases:
   - csharp
-  primary_extension: .cs
   extensions:
+  - .cs
   - .cshtml
   - .csx
 
@@ -262,8 +277,8 @@ C++:
   color: "#f34b7d"
   aliases:
   - cpp
-  primary_extension: .cpp
   extensions:
+  - .cpp
   - .C
   - .c++
   - .cc
@@ -280,7 +295,8 @@ C++:
 C-ObjDump:
   type: data
   lexer: c-objdump
-  primary_extension: .c-objdump
+  extensions:
+  - .c-objdump
 
 C2hs Haskell:
   type: programming
@@ -288,24 +304,26 @@ C2hs Haskell:
   group: Haskell
   aliases:
   - c2hs
-  primary_extension: .chs
+  extensions:
+  - .chs
 
 CLIPS:
   type: programming
   lexer: Text only
-  primary_extension: .clp
+  extensions:
+  - .clp
 
 CMake:
-  primary_extension: .cmake
   extensions:
+  - .cmake
   - .cmake.in
   filenames:
   - CMakeLists.txt
 
 COBOL:
   type: programming
-  primary_extension: .cob
   extensions:
+  - .cob
   - .cbl
   - .ccp
   - .cobol
@@ -314,39 +332,43 @@ COBOL:
 CSS:
   ace_mode: css
   color: "#563d7c"
-  primary_extension: .css
+  extensions:
+  - .css
 
 Ceylon:
   type: programming
   lexer: Ceylon
-  primary_extension: .ceylon
+  extensions:
+  - .ceylon
 
 ChucK:
   lexer: Java
-  primary_extension: .ck
+  extensions:
+  - .ck
 
 Cirru:
   type: programming
   color: "#aaaaff"
-  primary_extension: .cirru
   # ace_mode: cirru
   # lexer: Cirru
   lexer: Text only
+  extensions:
+  - .cirru
 
 Clean:
   type: programming
   color: "#3a81ad"
   lexer: Text only
-  primary_extension: .icl
   extensions:
+  - .icl
   - .dcl
 
 Clojure:
   type: programming
   ace_mode: clojure
   color: "#db5855"
-  primary_extension: .clj
   extensions:
+  - .clj
   - .cl2
   - .cljc
   - .cljs
@@ -364,8 +386,8 @@ CoffeeScript:
   aliases:
   - coffee
   - coffee-script
-  primary_extension: .coffee
   extensions:
+  - .coffee
   - ._coffee
   - .cson
   - .iced
@@ -382,8 +404,8 @@ ColdFusion:
   search_term: cfm
   aliases:
   - cfm
-  primary_extension: .cfm
   extensions:
+  - .cfm
   - .cfc
 
 Common Lisp:
@@ -391,8 +413,8 @@ Common Lisp:
   color: "#3fb68b"
   aliases:
   - lisp
-  primary_extension: .lisp
   extensions:
+  - .lisp
   - .asd
   - .cl
   - .lsp
@@ -407,13 +429,14 @@ Common Lisp:
 
 Coq:
   type: programming
-  primary_extension: .coq
+  extensions:
+  - .coq
 
 Cpp-ObjDump:
   type: data
   lexer: cpp-objdump
-  primary_extension: .cppobjdump
   extensions:
+  - .cppobjdump
   - .c++objdump
   - .cxx-objdump
 
@@ -421,83 +444,90 @@ Creole:
   type: prose
   lexer: Text only
   wrap: true
-  primary_extension: .creole
+  extensions:
+  - .creole
 
 Crystal:
   type: programming
   lexer: Ruby
-  primary_extension: .cr
+  extensions:
+  - .cr
   ace_mode: ruby
 
 Cucumber:
   lexer: Gherkin
-  primary_extension: .feature
+  extensions:
+  - .feature
 
 Cuda:
   lexer: CUDA
-  primary_extension: .cu
   extensions:
+  - .cu
   - .cuh
 
 Cython:
   type: programming
   group: Python
-  primary_extension: .pyx
   extensions:
+  - .pyx
   - .pxd
   - .pxi
 
 D:
   type: programming
   color: "#fcd46d"
-  primary_extension: .d
   extensions:
+  - .d
   - .di
 
 D-ObjDump:
   type: data
   lexer: d-objdump
-  primary_extension: .d-objdump
+  extensions:
+  - .d-objdump
 
 DM:
   type: programming
   color: "#075ff1"
   lexer: C++
-  primary_extension: .dm
+  extension:
+  - .dm
   aliases:
   - byond
 
 DOT:
   type: programming
   lexer: Text only
-  primary_extension: .dot
   extensions:
+  - .dot
   - .gv
 
 Darcs Patch:
   search_term: dpatch
   aliases:
   - dpatch
-  primary_extension: .darcspatch
   extensions:
+  - .darcspatch
   - .dpatch
 
 Dart:
   type: programming
   color: "#98BAD6"
-  primary_extension: .dart
+  extensions:
+  - .dart
 
 DCPU-16 ASM:
   type: programming
   lexer: dasm16
-  primary_extension: .dasm16
   extensions:
+  - .dasm16
   - .dasm
   aliases:
   - dasm16
 
 Diff:
-  primary_extension: .diff
+  extensions:
+  - .diff
 
 Dogescript:
   type: programming
@@ -508,8 +538,8 @@ Dogescript:
 Dylan:
   type: programming
   color: "#3ebc27"
-  primary_extension: .dylan
   extensions:
+  - .dylan
   - .intr
   - .lid
 
@@ -523,14 +553,15 @@ Ecere Projects:
   type: data
   group: JavaScript
   lexer: JSON
-  primary_extension: .epj
+  extensions:
+  - .epj
 
 ECL:
   type: programming
   color: "#8a1267"
-  primary_extension: .ecl
   lexer: ECL
   extensions:
+  - .ecl
   - .eclxml
 
 Eagle:
@@ -545,19 +576,21 @@ Eiffel:
   type: programming
   lexer: Text only
   color: "#946d57"
-  primary_extension: .e
+  extensions:
+  - .e
 
 Elixir:
   type: programming
   color: "#6e4a7e"
-  primary_extension: .ex
   extensions:
+  - .ex
   - .exs
 
 Elm:
   type: programming
   lexer: Haskell
-  primary_extension: .elm
+  extensions:
+  - .elm
 
 Emacs Lisp:
   type: programming
@@ -566,17 +599,17 @@ Emacs Lisp:
   aliases:
   - elisp
   - emacs
-  primary_extension: .el
   filenames:
   - .emacs
   extensions:
+  - .el
   - .emacs
 
 Erlang:
   type: programming
   color: "#0faf8d"
-  primary_extension: .erl
   extensions:
+  - .erl
   - .hrl
 
 F#:
@@ -586,25 +619,25 @@ F#:
   search_term: fsharp
   aliases:
   - fsharp
-  primary_extension: .fs
   extensions:
+  - .fs
   - .fsi
   - .fsx
 
 FLUX:
   type: programming
   color: "#33CCFF"
-  primary_extension: .fx
   lexer: Text only
   extensions:
+  - .fx
   - .flux
 
 FORTRAN:
   type: programming
   lexer: Fortran
   color: "#4d41b1"
-  primary_extension: .f90
   extensions:
+  - .f90
   - .F
   - .F03
   - .F08
@@ -624,7 +657,8 @@ FORTRAN:
 Factor:
   type: programming
   color: "#636746"
-  primary_extension: .factor
+  extensions:
+  - .factor
   filenames:
     - .factor-rc
     - .factor-boot-rc
@@ -632,8 +666,8 @@ Factor:
 Fancy:
   type: programming
   color: "#7b9db4"
-  primary_extension: .fy
   extensions:
+  - .fy
   - .fancypack
   filenames:
   - Fakefile
@@ -641,14 +675,15 @@ Fancy:
 Fantom:
   type: programming
   color: "#dbded5"
-  primary_extension: .fan
+  extensions:
+  - .fan
 
 Forth:
   type: programming
-  primary_extension: .fth
   color: "#341708"
   lexer: Text only
   extensions:
+  - .fth
   - .4th
 
 Frege:
@@ -675,15 +710,15 @@ GAP:
 GAS:
   type: programming
   group: Assembly
-  primary_extension: .s
   extensions:
+  - .s
   - .S
 
 GLSL:
   group: C
   type: programming
-  primary_extension: .glsl
   extensions:
+  - .glsl
   - .fp
   - .frag
   - .fshader
@@ -695,32 +730,36 @@ GLSL:
   - .vshader
 
 Genshi:
-  primary_extension: .kid
+  extensions:
+  - .kid
 
 Gentoo Ebuild:
   group: Shell
   lexer: Bash
-  primary_extension: .ebuild
+  extensions:
+  - .ebuild
 
 Gentoo Eclass:
   group: Shell
   lexer: Bash
-  primary_extension: .eclass
+  extensions:
+  - .eclass
 
 Gettext Catalog:
   search_term: pot
   searchable: false
   aliases:
   - pot
-  primary_extension: .po
   extensions:
+  - .po
   - .pot
 
 Glyph:
   type: programming
   color: "#e4cc98"
   lexer: Tcl
-  primary_extension: .glf
+  extensions:
+  - .glf
 
 Gnuplot:
   type: programming
@@ -736,12 +775,14 @@ Gnuplot:
 Go:
   type: programming
   color: "#375eab"
-  primary_extension: .go
+  extensions:
+  - .go
 
 Gosu:
   type: programming
   color: "#82937f"
-  primary_extension: .gs
+  extensions:
+  - .gs
 
 Grammatical Framework:
   type: programming
@@ -754,8 +795,8 @@ Grammatical Framework:
   color: "#ff0000"
 
 Groff:
-  primary_extension: .man
   extensions:
+  - .man
   - '.1'
   - '.2'
   - '.3'
@@ -768,7 +809,8 @@ Groovy:
   type: programming
   ace_mode: groovy
   color: "#e69f56"
-  primary_extension: .groovy
+  extensions:
+  - .groovy
   interpreters:
   - groovy
 
@@ -777,15 +819,16 @@ Groovy Server Pages:
   lexer: Java Server Page
   aliases:
   - gsp
-  primary_extension: .gsp
+  extensions:
+  - .gsp
 
 HTML:
   type: markup
   ace_mode: html
   aliases:
   - xhtml
-  primary_extension: .html
   extensions:
+  - .html
   - .htm
   - .html.hl
   - .st
@@ -795,10 +838,9 @@ HTML+Django:
   type: markup
   group: HTML
   lexer: HTML+Django/Jinja
-  primary_extension: .mustache # TODO: This is incorrect
   extensions:
-  - .jinja
   - .mustache
+  - .jinja
 
 HTML+ERB:
   type: markup
@@ -806,8 +848,8 @@ HTML+ERB:
   lexer: RHTML
   aliases:
   - erb
-  primary_extension: .erb
   extensions:
+  - .erb
   - .erb.deface
   - .html.erb
   - .html.erb.deface
@@ -815,25 +857,27 @@ HTML+ERB:
 HTML+PHP:
   type: markup
   group: HTML
-  primary_extension: .phtml
+  extensions:
+  - .phtml
 
 HTTP:
   type: data
-  primary_extension: .http
+  extensions:
+  - .http
 
 Haml:
   group: HTML
   type: markup
-  primary_extension: .haml
   extensions:
+  - .haml
   - .haml.deface
   - .html.haml.deface
 
 Handlebars:
   type: markup
   lexer: Text only
-  primary_extension: .handlebars
   extensions:
+  - .handlebars
   - .hbs
   - .html.handlebars
   - .html.hbs
@@ -842,21 +886,22 @@ Harbour:
   type: programming
   lexer: Text only
   color: "#0e60e3"
-  primary_extension: .hb
+  extensions:
+  - .hb
 
 Haskell:
   type: programming
   color: "#29b544"
-  primary_extension: .hs
   extensions:
+  - .hs
   - .hsc
 
 Haxe:
   type: programming
   ace_mode: haxe
   color: "#346d51"
-  primary_extension: .hx
   extensions:
+  - .hx
   - .hxsl
 
 Hy:
@@ -864,13 +909,15 @@ Hy:
   lexer: Clojure
   ace_mode: clojure
   color: "#7891b1"
-  primary_extension: .hy
+  extensions:
+  - .hy
 
 IDL:
   type: programming
   lexer: Text only
   color: "#e3592c"
-  primary_extension: .pro
+  extensions:
+  - .pro
 
 INI:
   type: data
@@ -878,7 +925,6 @@ INI:
   - .ini
   - .prefs
   - .properties
-  primary_extension: .ini
 
 Inno Setup:
   primary_extension: .iss
@@ -887,8 +933,8 @@ Inno Setup:
 Idris:
   type: programming
   lexer: Text only
-  primary_extension: .idr
   extensions:
+  - .idr
   - .lidr
 
 Inform 7:
@@ -900,7 +946,8 @@ Inform 7:
   - .i7x
 
 Inno Setup:
-  primary_extension: .iss
+  extensions:
+  - .iss
   lexer: Text only
 
 IRC log:
@@ -908,39 +955,42 @@ IRC log:
   search_term: irc
   aliases:
   - irc
-  primary_extension: .irclog
   extensions:
+  - .irclog
   - .weechatlog
 
 Io:
   type: programming
   color: "#a9188d"
-  primary_extension: .io
+  extensions:
+  - .io
 
 Ioke:
   type: programming
   color: "#078193"
-  primary_extension: .ik
+  extensions:
+  - .ik
 
 J:
   type: programming
   lexer: Text only
-  primary_extension: .ijs
+  extensions:
+  - .ijs
 
 JSON:
   type: data
   group: JavaScript
   ace_mode: json
   searchable: false
-  primary_extension: .json
   extensions:
+  - .json
   - .sublime-keymap
-  - .sublime_metrics
   - .sublime-mousemap
   - .sublime-project
-  - .sublime_session
   - .sublime-settings
   - .sublime-workspace
+  - .sublime_metrics
+  - .sublime_session
   filenames:
   - .jshintrc
   - composer.lock
@@ -948,14 +998,16 @@ JSON:
 JSON5:
   type: data
   lexer: JavaScript
-  primary_extension: .json5
+  extensions:
+  - .json5
 
 JSONLD:
   type: data
   group: JavaScript
   ace_mode: json
   lexer: JavaScript
-  primary_extension: .jsonld
+  extensions:
+  - .jsonld
 
 JSONiq:
   type: programming
@@ -966,13 +1018,15 @@ JSONiq:
 Jade:
   group: HTML
   type: markup
-  primary_extension: .jade
+  extensions:
+  - .jade
 
 Java:
   type: programming
   ace_mode: java
   color: "#b07219"
-  primary_extension: .java
+  extensions:
+  - .java
 
 Java Server Pages:
   group: Java
@@ -980,7 +1034,8 @@ Java Server Pages:
   search_term: jsp
   aliases:
   - jsp
-  primary_extension: .jsp
+  extensions:
+  - .jsp
 
 JavaScript:
   type: programming
@@ -989,8 +1044,8 @@ JavaScript:
   aliases:
   - js
   - node
-  primary_extension: .js
   extensions:
+  - .js
   - ._js
   - .bones
   - .es6
@@ -1010,14 +1065,16 @@ JavaScript:
 
 Julia:
   type: programming
-  primary_extension: .jl
+  extensions:
+  - .jl
   color: "#a270ba"
 
 KRL:
   lexer: Text only
   type: programming
   color: "#f5c800"
-  primary_extension: .krl
+  extensions:
+  - .krl
 
 Kit:
   type: markup
@@ -1027,26 +1084,29 @@ Kit:
 
 Kotlin:
   type: programming
-  primary_extension: .kt
   extensions:
+  - .kt
   - .ktm
   - .kts
 
 LFE:
   type: programming
-  primary_extension: .lfe
+  extensions:
+  - .lfe
   color: "#004200"
   lexer: Common Lisp
   group: Erlang
 
 LLVM:
-  primary_extension: .ll
+  extensions:
+  - .ll
 
 Lasso:
   type: programming
   lexer: Lasso
   color: "#2584c3"
-  primary_extension: .lasso
+  extensions:
+  - .lasso
 
 Latte:
   type: markup
@@ -1059,12 +1119,13 @@ Less:
   type: markup
   group: CSS
   lexer: CSS
-  primary_extension: .less
+  extensions:
+  - .less
 
 LilyPond:
   lexer: Text only
-  primary_extension: .ly
   extensions:
+  - .ly
   - .ily
 
 Liquid:
@@ -1075,9 +1136,8 @@ Liquid:
 Literate Agda:
   type: programming
   group: Agda
-  primary_extension: .lagda
   extensions:
-    - .lagda
+  - .lagda
 
 Literate CoffeeScript:
   type: programming
@@ -1088,7 +1148,8 @@ Literate CoffeeScript:
   search_term: litcoffee
   aliases:
   - litcoffee
-  primary_extension: .litcoffee
+  extensions:
+  - .litcoffee
 
 Literate Haskell:
   type: programming
@@ -1096,7 +1157,8 @@ Literate Haskell:
   search_term: lhs
   aliases:
   - lhs
-  primary_extension: .lhs
+  extensions:
+  - .lhs
 
 LiveScript:
   type: programming
@@ -1104,28 +1166,29 @@ LiveScript:
   color: "#499886"
   aliases:
   - ls
-  primary_extension: .ls
   extensions:
+  - .ls
   - ._ls
   filenames:
   - Slakefile
 
 Logos:
   type: programming
-  primary_extension: .xm
+  extensions:
+  - .xm
 
 Logtalk:
   type: programming
-  primary_extension: .lgt
   extensions:
+  - .lgt
   - .logtalk
 
 Lua:
   type: programming
   ace_mode: lua
   color: "#fa1fa1"
-  primary_extension: .lua
   extensions:
+  - .lua
   - .nse
   - .rbxs
   interpreters:
@@ -1136,8 +1199,8 @@ M:
   lexer: Common Lisp
   aliases:
   - mumps
-  primary_extension: .mumps
   extensions:
+  - .mumps
   - .m
 
 MTML:
@@ -1152,7 +1215,6 @@ Makefile:
   extensions:
   - .mak
   - .mk
-  primary_extension: .mak
   filenames:
   - makefile
   - Makefile
@@ -1161,8 +1223,8 @@ Makefile:
   - make
 
 Mako:
-  primary_extension: .mako
   extensions:
+  - .mako
   - .mao
 
 Markdown:
@@ -1170,8 +1232,8 @@ Markdown:
   lexer: Text only
   ace_mode: markdown
   wrap: true
-  primary_extension: .md
   extensions:
+  - .md
   - .markdown
   - .mkd
   - .mkdown
@@ -1182,7 +1244,8 @@ Mask:
   lexer: SCSS
   color: "#f97732"
   ace_mode: scss
-  primary_extension: .mask
+  extensions:
+  - .mask
 
 Mathematica:
   type: programming
@@ -1192,8 +1255,8 @@ Mathematica:
 Matlab:
   type: programming
   color: "#bb92ac"
-  primary_extension: .matlab
   extensions:
+  - .matlab
   - .m
 
 Max:
@@ -1204,8 +1267,8 @@ Max:
   - max/msp
   - maxmsp
   search_term: max/msp
-  primary_extension: .maxpat
   extensions:
+  - .maxpat
   - .maxhelp
   - .maxproj
   - .mxt
@@ -1215,7 +1278,8 @@ MediaWiki:
   type: prose
   lexer: Text only
   wrap: true
-  primary_extension: .mediawiki
+  extensions:
+  - .mediawiki
 
 Mercury:
   type: programming
@@ -1232,15 +1296,16 @@ Mercury:
 
 MiniD: # Legacy
   searchable: false
-  primary_extension: .minid # Dummy extension
+  extensions:
+  - .minid # Dummy extension
 
 Mirah:
   type: programming
   lexer: Ruby
   search_term: ruby
   color: "#c7a938"
-  primary_extension: .druby
   extensions:
+  - .druby
   - .duby
   - .mir
   - .mirah
@@ -1248,44 +1313,52 @@ Mirah:
 Monkey:
   type: programming
   lexer: Monkey
-  primary_extension: .monkey
+  extensions:
+  - .monkey
 
 Moocode:
   type: programming
   lexer: MOOCode
-  primary_extension: .moo
+  extensions:
+  - .moo
 
 MoonScript:
   type: programming
-  primary_extension: .moon
+  extensions:
+  - .moon
 
 Myghty:
-  primary_extension: .myt
+  extensions:
+  - .myt
 
 NSIS:
-  primary_extension: .nsi
+  extensions:
+  - .nsi
 
 Nemerle:
   type: programming
   color: "#0d3c6e"
-  primary_extension: .n
+  extensions:
+  - .n
 
 NetLogo:
   type: programming
   lexer: Common Lisp
   color: "#ff2b2b"
-  primary_extension: .nlogo
+  extensions:
+  - .nlogo
 
 Nginx:
   type: markup
   lexer: Nginx configuration file
-  primary_extension: .nginxconf
+  extensions:
+  - .nginxconf
 
 Nimrod:
   type: programming
   color: "#37775b"
-  primary_extension: .nim
   extensions:
+  - .nim
   - .nimrod
 
 Nu:
@@ -1294,14 +1367,15 @@ Nu:
   color: "#c9df40"
   aliases:
   - nush
-  primary_extension: .nu
+  extensions:
+  - .nu
   filenames:
   - Nukefile
 
 NumPy:
   group: Python
-  primary_extension: .numpy
   extensions:
+  - .numpy
   - .numpyw
   - .numsc
 
@@ -1309,8 +1383,8 @@ OCaml:
   type: programming
   ace_mode: ocaml
   color: "#3be133"
-  primary_extension: .ml
   extensions:
+  - .ml
   - .eliomi
   - .ml4
   - .mli
@@ -1320,7 +1394,8 @@ OCaml:
 ObjDump:
   type: data
   lexer: objdump
-  primary_extension: .objdump
+  extensions:
+  - .objdump
 
 Objective-C:
   type: programming
@@ -1328,7 +1403,8 @@ Objective-C:
   aliases:
   - obj-c
   - objc
-  primary_extension: .m
+  extensions:
+  - .m
 
 Objective-C++:
   type: programming
@@ -1336,33 +1412,36 @@ Objective-C++:
   aliases:
   - obj-c++
   - objc++
-  primary_extension: .mm
+  extensions:
+  - .mm
 
 Objective-J:
   type: programming
   color: "#ff0c5a"
   aliases:
   - obj-j
-  primary_extension: .j
   extensions:
+  - .j
   - .sj
 
 Omgrofl:
   type: programming
-  primary_extension: .omgrofl
+  extensions:
+  - .omgrofl
   color: "#cabbff"
   lexer: Text only
 
 Opa:
   type: programming
-  primary_extension: .opa
+  extensions:
+  - .opa
 
 OpenCL:
   type: programming
   group: C
   lexer: C
-  primary_extension: .cl
   extensions:
+  - .cl
   - .opencl
 
 OpenEdge ABL:
@@ -1371,32 +1450,36 @@ OpenEdge ABL:
   - progress
   - openedge
   - abl
-  primary_extension: .p
+  extensions:
+  - .p
 
 Org:
   type: prose
   lexer: Text only
   wrap: true
-  primary_extension: .org
+  extensions:
+  - .org
 
 Oxygene:
   type: programming
   lexer: Text only
   color: "#5a63a3"
-  primary_extension: .oxygene
+  extensions:
+  - .oxygene
 
 PAWN:
   type: programming
   lexer: C++
   color: "#dbb284"
-  primary_extension: .pwn
+  extensions:
+  - .pwn
 
 PHP:
   type: programming
   ace_mode: php
   color: "#6e03c1"
-  primary_extension: .php
   extensions:
+  - .php
   - .aw
   - .ctp
   - .php3
@@ -1410,7 +1493,8 @@ Parrot:
   type: programming
   color: "#f3ca0a"
   lexer: Text only
-  primary_extension: .parrot # Dummy extension
+  extensions:
+  - .parrot # Dummy extension
 
 Parrot Internal Representation:
   group: Parrot
@@ -1418,7 +1502,8 @@ Parrot Internal Representation:
   lexer: Text only
   aliases:
   - pir
-  primary_extension: .pir
+  extensions:
+  - .pir
 
 Parrot Assembly:
   group: Parrot
@@ -1426,14 +1511,15 @@ Parrot Assembly:
   lexer: Text only
   aliases:
   - pasm
-  primary_extension: .pasm
+  extensions:
+  - .pasm
 
 Pascal:
   type: programming
   lexer: Delphi
   color: "#b0ce4e"
-  primary_extension: .pas
   extensions:
+  - .pas
   - .dfm
   - .lpr
 
@@ -1441,8 +1527,8 @@ Perl:
   type: programming
   ace_mode: perl
   color: "#0298c3"
-  primary_extension: .pl
   extensions:
+  - .pl
   - .PL
   - .perl
   - .ph
@@ -1456,8 +1542,8 @@ Perl:
 Perl6:
   type: programming
   color: "#0298c3"
-  primary_extension: .p6
   extensions:
+  - .p6
   - .6pl
   - .6pm
   - .nqp
@@ -1470,8 +1556,8 @@ Pike:
   type: programming
   color: "#066ab2"
   lexer: C
-  primary_extension: .pike
   extensions:
+  - .pike
   - .pmod
 
 Pod:
@@ -1479,18 +1565,20 @@ Pod:
   lexer: Text only
   ace_mode: perl
   wrap: true
-  primary_extension: .pod
+  extensions:
+  - .pod
 
 PogoScript:
   type: programming
   color: "#d80074"
   lexer: Text only
-  primary_extension: .pogo
+  extensions:
+  - .pogo
 
 PostScript:
   type: markup
-  primary_extension: .ps
   extensions:
+  - .ps
   - .eps
 
 PowerShell:
@@ -1498,8 +1586,8 @@ PowerShell:
   ace_mode: powershell
   aliases:
   - posh
-  primary_extension: .ps1
   extensions:
+  - .ps1
   - .psd1
   - .psm1
 
@@ -1507,13 +1595,14 @@ Processing:
   type: programming
   lexer: Java
   color: "#2779ab"
-  primary_extension: .pde
+  extensions:
+  - .pde
 
 Prolog:
   type: programming
   color: "#74283c"
-  primary_extension: .prolog
   extensions:
+  - .prolog
   - .ecl
   - .pl
 
@@ -1522,12 +1611,12 @@ Protocol Buffer:
   aliases:
   - protobuf
   - Protocol Buffers
-  primary_extension: .proto
+  extensions:
+  - .proto
 
 Puppet:
   type: programming
   color: "#cc5555"
-  primary_extension: .pp
   extensions:
   - .pp
   filenames:
@@ -1537,7 +1626,8 @@ Pure Data:
   type: programming
   color: "#91de79"
   lexer: Text only
-  primary_extension: .pd
+  extensions:
+  - .pd
 
 PureScript:
   type: programming
@@ -1549,8 +1639,8 @@ Python:
   type: programming
   ace_mode: python
   color: "#3581ba"
-  primary_extension: .py
   extensions:
+  - .py
   - .gyp
   - .lmi
   - .pyt
@@ -1569,12 +1659,14 @@ Python traceback:
   group: Python
   lexer: Python Traceback
   searchable: false
-  primary_extension: .pytb
+  extensions:
+  - .pytb
 
 QML:
   type: markup
   color: "#44a51c"
-  primary_extension: .qml
+  extensions:
+  - .qml
 
 R:
   type: programming
@@ -1582,8 +1674,8 @@ R:
   lexer: S
   aliases:
   - R
-  primary_extension: .r
   extensions:
+  - .r
   - .R
   - .rsx
   filenames:
@@ -1596,13 +1688,14 @@ RDoc:
   lexer: Text only
   ace_mode: rdoc
   wrap: true
-  primary_extension: .rdoc
+  extensions:
+  - .rdoc
 
 REALbasic:
   type: programming
   lexer: VB.net
-  primary_extension: .rbbas
   extensions:
+  - .rbbas
   - .rbfrm
   - .rbmnu
   - .rbres
@@ -1612,23 +1705,24 @@ REALbasic:
 RHTML:
   type: markup
   group: HTML
-  primary_extension: .rhtml
+  extensions:
+  - .rhtml
 
 RMarkdown:
   type: prose
   lexer: Text only
   wrap: true
   ace_mode: markdown
-  primary_extension: .rmd
   extensions:
+  - .rmd
   - .Rmd
 
 Racket:
   type: programming
   lexer: Racket
   color: "#ae17ff"
-  primary_extension: .rkt
   extensions:
+  - .rkt
   - .rktd
   - .rktl
 
@@ -1636,32 +1730,35 @@ Ragel in Ruby Host:
   type: programming
   lexer: Ragel in Ruby Host
   color: "#ff9c2e"
-  primary_extension: .rl
+  extensions:
+  - .rl
 
 Raw token data:
   search_term: raw
   aliases:
   - raw
-  primary_extension: .raw
+  extensions:
+  - .raw
 
 Rebol:
   type: programming
   lexer: REBOL
   color: "#358a5b"
-  primary_extension: .reb
   extensions:
+  - .reb
   - .r
   - .r2
   - .r3
   - .rebol
 
 Redcode:
-  primary_extension: .cw
+  extensions:
+  - .cw
 
 RobotFramework:
   type: programming
-  primary_extension: .robot
-  # extensions:
+  extensions:
+  - .robot
   # - .txt
 
 Rouge:
@@ -1669,7 +1766,8 @@ Rouge:
   lexer: Clojure
   ace_mode: clojure
   color: "#cc0088"
-  primary_extension: .rg
+  extensions:
+  - .rg
 
 Ruby:
   type: programming
@@ -1681,8 +1779,8 @@ Ruby:
   - rake
   - rb
   - rbx
-  primary_extension: .rb
   extensions:
+  - .rb
   - .builder
   - .gemspec
   - .god
@@ -1712,20 +1810,22 @@ Ruby:
 Rust:
   type: programming
   color: "#dea584"
-  primary_extension: .rs
+  extensions:
+  - .rs
 
 SCSS:
   type: markup
   group: CSS
   ace_mode: scss
-  primary_extension: .scss
+  extensions:
+  - .scss
 
 SQL:
   type: data
   ace_mode: sql
   searchable: false
-  primary_extension: .sql
   extensions:
+  - .sql
   - .prc
   - .tab
   - .udf
@@ -1735,31 +1835,34 @@ Sage:
   type: programming
   lexer: Python
   group: Python
-  primary_extension: .sage
+  extensions:
+  - .sage
 
 Sass:
   type: markup
   group: CSS
-  primary_extension: .sass
+  extensions:
+  - .sass
 
 Scala:
   type: programming
   ace_mode: scala
   color: "#7dd3b0"
-  primary_extension: .scala
   extensions:
+  - .scala
   - .sc
 
 Scaml:
   group: HTML
   type: markup
-  primary_extension: .scaml
+  extensions:
+  - .scaml
 
 Scheme:
   type: programming
   color: "#1e4aec"
-  primary_extension: .scm
   extensions:
+  - .scm
   - .sld
   - .sls
   - .ss
@@ -1771,13 +1874,15 @@ Scheme:
 
 Scilab:
   type: programming
-  primary_extension: .sci
+  extensions:
+  - .sci
 
 Self:
   type: programming
   color: "#0579aa"
   lexer: Text only
-  primary_extension: .self
+  extensions:
+  - .self
 
 Shell:
   type: programming
@@ -1788,8 +1893,8 @@ Shell:
   - sh
   - bash
   - zsh
-  primary_extension: .sh
   extensions:
+  - .sh
   - .bats
   - .tmux
   interpreters:
@@ -1808,20 +1913,24 @@ Shen:
   type: programming
   color: "#120F14"
   lexer: Text only
-  primary_extension: .shen
+  extensions:
+  - .shen
 
 Slash:
   type: programming
   color: "#007eff"
-  primary_extension: .sl
+  extensions:
+  - .sl
 
 Smalltalk:
   type: programming
   color: "#596706"
-  primary_extension: .st
+  extensions:
+  - .st
 
 Smarty:
-  primary_extension: .tpl
+  extensions:
+  - .tpl
 
 SourcePawn:
   type: programming
@@ -1833,15 +1942,16 @@ SourcePawn:
 Squirrel:
   type: programming
   lexer: C++
-  primary_extension: .nut
+  extensions:
+  - .nut
 
 Standard ML:
   type: programming
   color: "#dc566d"
   aliases:
   - sml
-  primary_extension: .sml
   extensions:
+  - .sml
   - .fun
 
 Stata:
@@ -1861,13 +1971,15 @@ Stylus:
   type: markup
   group: CSS
   lexer: Text only
-  primary_extension: .styl
+  extensions:
+  - .styl
 
 SuperCollider:
   type: programming
   color: "#46390b"
   lexer: Text only
-  primary_extension: .scd
+  extensions:
+  - .scd
 
 SystemVerilog:
   type: programming
@@ -1880,26 +1992,28 @@ SystemVerilog:
 
 TOML:
   type: data
-  primary_extension: .toml
+  extensions:
+  - .toml
 
 TXL:
   type: programming
   lexer: Text only
-  primary_extension: .txl
+  extensions:
+  - .txl
 
 Tcl:
   type: programming
   color: "#e4cc98"
-  primary_extension: .tcl
   extensions:
+  - .tcl
   - .adp
   - .tm
 
 Tcsh:
   type: programming
   group: Shell
-  primary_extension: .tcsh
   extensions:
+  - .tcsh
   - .csh
 
 TeX:
@@ -1909,8 +2023,8 @@ TeX:
   wrap: true
   aliases:
   - latex
-  primary_extension: .tex
   extensions:
+  - .tex
   - .aux
   - .bib
   - .cls
@@ -1925,35 +2039,39 @@ TeX:
 
 Tea:
   type: markup
-  primary_extension: .tea
+  extensions:
+  - .tea
 
 Textile:
   type: prose
   lexer: Text only
   ace_mode: textile
   wrap: true
-  primary_extension: .textile
+  extensions:
+  - .textile
 
 Turing:
   type: programming
   color: "#45f715"
   lexer: Text only
-  primary_extension: .t
   extensions:
+  - .t
   - .tu
 
 Twig:
   type: markup
   group: PHP
   lexer: HTML+Django/Jinja
-  primary_extension: .twig
+  extensions:
+  - .twig
 
 TypeScript:
   type: programming
   color: "#31859c"
   aliases:
   - ts
-  primary_extension: .ts
+  extensions:
+  - .ts
 
 Unified Parallel C:
   type: programming
@@ -1961,20 +2079,22 @@ Unified Parallel C:
   lexer: C
   ace_mode: c_cpp
   color: "#755223"
-  primary_extension: .upc
+  extensions:
+  - .upc
 
 UnrealScript:
   type: programming
   color: "#a54c4d"
   lexer: Java
-  primary_extension: .uc
+  extensions:
+  - .uc
 
 VHDL:
   type: programming
   lexer: vhdl
   color: "#543978"
-  primary_extension: .vhdl
   extensions:
+  - .vhdl
   - .vhd
   - .vhf
   - .vhi
@@ -1986,16 +2106,16 @@ VHDL:
 Vala:
   type: programming
   color: "#ee7d06"
-  primary_extension: .vala
   extensions:
+  - .vala
   - .vapi
 
 Verilog:
   type: programming
   lexer: verilog
   color: "#848bf3"
-  primary_extension: .v
   extensions:
+  - .v
   - .veo
 
 VimL:
@@ -2004,7 +2124,8 @@ VimL:
   search_term: vim
   aliases:
   - vim
-  primary_extension: .vim
+  extensions:
+  - .vim
   filenames:
   - .vimrc
   - vimrc
@@ -2014,8 +2135,8 @@ Visual Basic:
   type: programming
   lexer: VB.net
   color: "#945db7"
-  primary_extension: .vb
   extensions:
+  - .vb
   - .bas
   - .frm
   - .frx
@@ -2027,12 +2148,14 @@ Volt:
     type: programming
     lexer: D
     color: "#0098db"
-    primary_extension: .volt
+    extensions:
+    - .volt
 
 XC:
   type: programming
   lexer: C
-  primary_extension: .xc
+  extensions:
+  - .xc
 
 XML:
   type: markup
@@ -2041,8 +2164,8 @@ XML:
   - rss
   - xsd
   - wsdl
-  primary_extension: .xml
   extensions:
+  - .xml
   - .axml
   - .ccxml
   - .clixml
@@ -2097,15 +2220,15 @@ XML:
 XProc:
   type: programming
   lexer: XML
-  primary_extension: .xpl
   extensions:
+  - .xpl
   - .xproc
 
 XQuery:
   type: programming
   color: "#2700e2"
-  primary_extension: .xquery
   extensions:
+  - .xquery
   - .xq
   - .xql
   - .xqm
@@ -2113,26 +2236,28 @@ XQuery:
 
 XS:
   lexer: C
-  primary_extension: .xs
+  extensions:
+  - .xs
 
 XSLT:
   type: programming
   aliases:
   - xsl
-  primary_extension: .xslt
   extensions:
-    - .xsl
+  - .xslt
+  - .xsl
 
 Xtend:
   type: programming
-  primary_extension: .xtend
+  extensions:
+  - .xtend
 
 YAML:
   type: data
   aliases:
   - yml
-  primary_extension: .yml
   extensions:
+  - .yml
   - .reek
   - .rviz
   - .yaml
@@ -2146,8 +2271,8 @@ Zephir:
 eC:
   type: programming
   search_term: ec
-  primary_extension: .ec
   extensions:
+  - .ec
   - .eh
 
 edn:
@@ -2155,28 +2280,33 @@ edn:
   lexer: Clojure
   ace_mode: clojure
   color: "#db5855"
-  primary_extension: .edn
+  extensions:
+  - .edn
 
 fish:
   type: programming
   group: Shell
   lexer: Text only
-  primary_extension: .fish
+  extensions:
+  - .fish
 
 mupad:
   lexer: MuPAD
-  primary_extension: .mu
+  extensions:
+  - .mu
 
 nesC:
   type: programming
   color: "#ffce3b"
-  primary_extension: .nc
+  extensions:
+  - .nc
 
 ooc:
   type: programming
   lexer: Ooc
   color: "#b0b77e"
-  primary_extension: .ooc
+  extensions:
+  - .ooc
 
 reStructuredText:
   type: prose
@@ -2184,8 +2314,8 @@ reStructuredText:
   search_term: rst
   aliases:
   - rst
-  primary_extension: .rst
   extensions:
+  - .rst
   - .rest
 
 wisp:
@@ -2193,10 +2323,12 @@ wisp:
   lexer: Clojure
   ace_mode: clojure
   color: "#7582D1"
-  primary_extension: .wisp
+  extensions:
+  - .wisp
 
 xBase:
   type: programming
   lexer: Text only
   color: "#3a4040"
-  primary_extension: .prg
+  extensions:
+  - .prg

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -22,10 +22,10 @@ class TestPedantic < Test::Unit::TestCase
     file("languages.yml").lines.each do |line|
       if line =~ /^  extensions:$/
         extensions = []
-      elsif extensions && line =~ /^  - \.(\w+)$/
+      elsif extensions && line =~ /^  - \.([\w-]+)( *#.*)?$/
         extensions << $1
       else
-        assert_sorted extensions if extensions
+        assert_sorted extensions[1..-1] if extensions
         extensions = nil
       end
     end


### PR DESCRIPTION
The language attribute is still maintained as the first extension found.

This allows Mercury to be properly detected by Linguist, as per #748.
