### PR TITLE
MATLAB uses .m files not .matlab.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1187,8 +1187,8 @@ Objective-C:
   - objc
   primary_extension: .m
   extensions:
-  - .mm
   - .h
+  - .mm
 
 Objective-J:
   type: programming


### PR DESCRIPTION
My MATLAB project is only showing up as ~46% MATLAB when ~90% of it should be.  I am attempting to fix this the best that I can.
