### PR TITLE
Does not display java programming language for my java programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The actual syntax highlighting is handled by our Pygments wrapper, [pygments.rb]
 
 ### Stats
 
-The Language stats bar that you see on every repository is built by aggregating the languages of each file in that repository. The top language in the graph determines the project's primary language. Collectively, these stats make up the [Top Languages](https://github.com/languages) page.
+The Language stats bar that you see on every repository is built by aggregating the languages of each file in that repository. The top language in the graph determines the project's primary language.
 
 The repository stats API, accessed through `#languages`, can be used on a directory:
 


### PR DESCRIPTION
I have written my code using Netbeans and some of my java programs have been directly updated. However github does not recognize my java programs at all. Request github to fix it by adding java as programming language in my repositories. 
