### PR TITLE
Don't suppress Gemfile.lock changes

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -51,8 +51,7 @@ module Linguist
     #
     # Return true or false
     def generated?
-      name == 'Gemfile.lock' ||
-        minified_files? ||
+      minified_files? ||
         compiled_coffeescript? ||
         xcode_project_file? ||
         generated_parser? ||

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -156,9 +156,6 @@ class TestBlob < Test::Unit::TestCase
     assert blob("Binary/MainMenu.nib").generated?
     assert blob("XML/project.pbxproj").generated?
 
-    # Gemfile.locks
-    assert blob("Gemfile.lock").generated?
-
     # Generated .NET Docfiles
     assert blob("XML/net_docfile.xml").generated?
 


### PR DESCRIPTION
Changes to this file are important and should be reviewed as a matter of
course when reviewing pull requests. While `Gemfile.lock` is generated,
in part, from `Gemfile`, the `Gemfile.lock` file can (and frequently
does) change irrespective of `Gemfile` changes.

With this file suppressed it's too easy to miss otherwise unwanted or
even dangerous dependency changes in reviews. Suppressing the file
encourages it to be ignored in reviews and it most certainly should not be.
