### PR TITLE
Add jQuery IntelliSense files to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -128,6 +128,7 @@
 
 # Visual Studio IntelliSense
 - -vsdoc\.js$
+- \.intellisense\.js$
 
 # jQuery validation plugin (MS bundles this with asp.net mvc)
 - (^|/)jquery([^.]*)\.validate(\.unobtrusive)?(\.min)?\.js$


### PR DESCRIPTION
This pull request adds jQuery IntelliSense files for Visual Studio to vendor.yml.
It has been requested in #1024 and it's used in this repo for example:
https://github.com/dejancaric/dibs-aspnetmvc-demo/search?l=javascript
