### PR TITLE
Changed tokenizer number literals to be more encompassing

### DIFF
--- a/lib/linguist/tokenizer.rb
+++ b/lib/linguist/tokenizer.rb
@@ -94,7 +94,7 @@ module Linguist
           end
 
         # Skip number literals
-        elsif s.scan(/(0x)?\d(\d|\.)*/)
+        elsif s.scan(/(0x\h(\h|\.)*|\d(\d|\.)*)([uU][lL]{0,2}|([eE][-+]\d*)?[fFlL]*)/)
 
         # SGML style brackets
         elsif token = s.scan(/<[^\s<>][^<>]*>/)

--- a/test/test_tokenizer.rb
+++ b/test/test_tokenizer.rb
@@ -25,6 +25,10 @@ class TestTokenizer < Minitest::Test
     assert_equal %w(add \( \)), tokenize('add(123, 456)')
     assert_equal %w(|), tokenize('0x01 | 0x10')
     assert_equal %w(*), tokenize('500.42 * 1.0')
+    assert_equal %w(), tokenize('1.23e-04')
+    assert_equal %w(), tokenize('1.0f')
+    assert_equal %w(), tokenize('1234ULL')
+    assert_equal %w(G1 X55 Y5 F2000), tokenize('G1 X55 Y5 F2000')
   end
 
   def test_skip_comments


### PR DESCRIPTION
This is a solution to https://github.com/github/linguist/issues/1025

The new number literal matching regex will skip hexadecimal and C style literals. It is not perfect, but to keep it simple I didn't worry about it.