### PR TITLE
Disambiguate ObjC from M and Matlab

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -29,7 +29,7 @@ module Linguist
           disambiguate_cl(data, languages)
         end
         if languages.all? { |l| ["Objective-C", "M", "Matlab"].include?(l) }
-          disambiguate_objc(data, languages)
+          disambiguate_m(data, languages)
         end
       end
     end
@@ -76,7 +76,7 @@ module Linguist
       matches
     end
 
-    def self.disambiguate_objc(data, languages)
+    def self.disambiguate_m(data, languages)
       matches = []
 
       if /(#import|@import)/.match(data)

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -85,34 +85,34 @@ class TestHeuristcs < Test::Unit::TestCase
     end
   end
 
-  def test_objc_m_matlab_heuristics
+  def test_m_heuristics
     languages = ["Objective-C", "M", "Matlab"]
     objc, m, matlab = Language["Objective-C"], Language["M"], Language["Matlab"]
 
-    assert_equal [], Heuristics.disambiguate_objc("", languages)
+    assert_equal [], Heuristics.disambiguate_m("", languages)
 
-    assert_equal [objc], Heuristics.disambiguate_objc("#import", languages)
-    assert_equal [objc, matlab], Heuristics.disambiguate_objc("% #import", languages) #Matlab comment
-    assert_equal [objc, matlab], Heuristics.disambiguate_objc("'#import'", languages) #Matlab string
-    assert_equal [objc, matlab], Heuristics.disambiguate_objc("""
+    assert_equal [objc], Heuristics.disambiguate_m("#import", languages)
+    assert_equal [objc, matlab], Heuristics.disambiguate_m("% #import", languages) #Matlab comment
+    assert_equal [objc, matlab], Heuristics.disambiguate_m("'#import'", languages) #Matlab string
+    assert_equal [objc, matlab], Heuristics.disambiguate_m("""
       %{
         #import
       %}
       """.strip, languages) #Matlab multi-line comment
-    assert_equal [objc, m], Heuristics.disambiguate_objc("; #import", languages) #M comment
-    assert_equal [objc, m], Heuristics.disambiguate_objc('"#import"', languages) #M string
-    assert_equal [objc, m], Heuristics.disambiguate_objc("3#import", languages) #M modulo
+    assert_equal [objc, m], Heuristics.disambiguate_m("; #import", languages) #M comment
+    assert_equal [objc, m], Heuristics.disambiguate_m('"#import"', languages) #M string
+    assert_equal [objc, m], Heuristics.disambiguate_m("3#import", languages) #M modulo
 
-    assert_equal [objc, matlab], Heuristics.disambiguate_objc("@import", languages) #Matlab function handle
-    assert_equal [objc], Heuristics.disambiguate_objc("@import Foundation;", languages)
-    assert_equal [objc, matlab], Heuristics.disambiguate_objc("% @import Foundation;", languages) #Matlab comment
-    assert_equal [objc, matlab], Heuristics.disambiguate_objc("'@import Foundation;'", languages) #Matlab string
-    assert_equal [objc, matlab], Heuristics.disambiguate_objc("""
+    assert_equal [objc, matlab], Heuristics.disambiguate_m("@import", languages) #Matlab function handle
+    assert_equal [objc], Heuristics.disambiguate_m("@import Foundation;", languages)
+    assert_equal [objc, matlab], Heuristics.disambiguate_m("% @import Foundation;", languages) #Matlab comment
+    assert_equal [objc, matlab], Heuristics.disambiguate_m("'@import Foundation;'", languages) #Matlab string
+    assert_equal [objc, matlab], Heuristics.disambiguate_m("""
       %{
         @import Foundation;
       %}
       """.strip, languages) #Matlab multi-line comment
-    assert_equal [objc, m], Heuristics.disambiguate_objc("; @import Foundation;", languages) #M comment
-    assert_equal [objc, m], Heuristics.disambiguate_objc('"@import Foundation;"', languages) #M string
+    assert_equal [objc, m], Heuristics.disambiguate_m("; @import Foundation;", languages) #M comment
+    assert_equal [objc, m], Heuristics.disambiguate_m('"@import Foundation;"', languages) #M string
   end
 end


### PR DESCRIPTION
Check if data contains common things found in Obj-C. If it is then also do
some additional checks to make sure it's not possibly Matlab or M. If it is
just add them as a precaution.

This is a solution for https://github.com/github/linguist/issues/1025
