### PR TITLE
Fixing cache vendor regex

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -10,7 +10,7 @@
 ## Vendor Conventions ##
 
 # Caches
-- cache/
+- (^|/)cache/
 
 # Dependencies
 - ^[Dd]ependencies/


### PR DESCRIPTION
- Fixes #1051
- Any folder with "cache" in it was being ignored. This fixes it.
