### PR TITLE
Add PostBuildScripts for NuGet

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -138,6 +138,7 @@
 
 # NuGet
 - ^[Pp]ackages/
+- ^[Pp]ost[Bb]uild[Ss]cripts/
 
 # ExtJS
 - (^|/)extjs/.*?\.js$


### PR DESCRIPTION
Add PostBuildScripts folder which the commonly used convention for adding PowerShellScripts post-build.

Note: This solves .NET projects being mistaken as Powershell projects.
