### PR TITLE
Added Buildr 'Buildfile' and 'buildfile'

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1544,12 +1544,14 @@ Ruby:
   filenames:
   - Appraisals
   - Berksfile
+  - Buildfile
   - Gemfile
   - Gemfile.lock
   - Guardfile
   - Podfile
   - Thorfile
   - Vagrantfile
+  - buildfile
 
 Rust:
   type: programming


### PR DESCRIPTION
The Java build system 'Buildr' uses a Ruby build file, similar to Rake.  This change adds syntax highlighting for `Buildfile` and `buildfile`, the primary name(s) of the Buildr file.

All other Buildr filename options (as listed at https://github.com/apache/buildr/blob/master/lib/buildr/core/application.rb#L110) are already covered by other things here.
