### PR TITLE
Add .osm extension for XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1858,6 +1858,7 @@ XML:
   - .kml
   - .launch
   - .mxml
+  - .osm
   - .plist
   - .pluginspec
   - .ps1xml


### PR DESCRIPTION
The OpenStreetMap project (openstreetmap.org) uses the .osm extension for the OSM XML format (http://wiki.openstreetmap.org/wiki/OSM_XML).

Full “real-world” OSM files are usually too big to put in a repository, but small sample files may be used to test applications that process OSM files, for example [here](https://github.com/routeKIT/routeKIT/tree/master/test/edu/kit/pse/ws2013/routekit/precalculation).
