### PR TITLE
Added ignore for static files in django project.

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -102,6 +102,7 @@
 
 # django
 - (^|/)admin_media/
+- (^|/)static/
 
 # Fabric
 - ^fabfile\.py$


### PR DESCRIPTION
Since a lot of .js and .css files are used in the main static folder of a django project, I believe a static/ folder ignore is required to avoid the project as being detected as a Javascript project.

I added the static folder ignore under Django project to avoid Django apps from being labeled a Javascript project. Could you please merge the changes.
