### PR TITLE
Add Movable Type Markup Language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1106,6 +1106,12 @@ M:
   extensions:
   - .m
 
+MTML:
+  type: markup
+  lexer: HTML
+  color: "#0095d9"
+  primary_extension: .mtml
+
 Makefile:
   aliases:
   - make

--- a/samples/MTML/categories_to_columns.mtml
+++ b/samples/MTML/categories_to_columns.mtml
@@ -1,0 +1,35 @@
+<$mt:Var name="num_cols" value="6"$>
+<$mt:Var name="index" value="0"$>
+<mt:Categories>
+  <$mt:Var name="index" op="++" setvar="index"$>
+  <mt:SetVarBlock name="categories{$index}">
+    <a href="<$mt:CategoryArchiveLink$>"><$mt:CategoryLabel remove_html="1"$></a>
+  </mt:SetVarBlock>
+</mt:Categories>
+<$mt:Var name="categories" function="count" setvar="cat_count"$>
+<$mt:Var name="cat_count" op="%" value="$num_cols" setvar="modulus"$>
+<mt:If name="modulus" gt="0">
+  <$mt:Var name="cat_count" op="-" value="$modulus" setvar="cat_count_minus_mod"$>
+  <$mt:Var name="cat_count_minus_mod" op="/" value="$num_cols" setvar="cats_per_col"$>
+  <$mt:Var name="cats_per_col" op="+" value="1" setvar="cats_per_col"$>
+<mt:Else>
+  <$mt:Var name="cat_count" op="/" value="$num_cols" setvar="cats_per_col"$>
+</mt:If>
+<mt:SetVarTemplate name="for_inner">
+  <$mt:Var name="index" op="++" setvar="index"$>
+  <mt:Unless name="index" gt="$cat_count">
+    <$mt:Var name="categories{$index}"$>
+  </mt:Unless>
+</mt:SetVarTemplate>
+
+<$mt:Var name="index" value="0"$>
+<$mt:Var name="col_num" value="1"$>
+<mt:For from="1" to="$num_cols">
+  <div class="col<$mt:Var name="col_num"$>">
+    <mt:For from="1" to="$cats_per_col">
+      <$mt:Var name="for_inner"$>
+    </mt:For>
+  </div>
+  <$mt:Var name="col_num" op="++" setvar="col_num"$>
+</mt:For>
+


### PR DESCRIPTION
[Movable Type](http://movabletype.org/), the content management system started more than a decade ago, commonly uses the `.mtml` extension to represent files written in its template language, based on XML and commonly intertwined with HTML.

There are [almost 10K](https://github.com/search?q=mt+extension%3Amtml&type=Code&ref=searchresults) such files on Github.
