### PR TITLE
add .bundle/ and vendor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+.bundle/
+vendor/


### PR DESCRIPTION
When invoking bundle package,
These two files are added to the root directory, IMO can be safely ignored.
