### PR TITLE
Ensure samples are not binary

### DIFF
--- a/test/test_samples.rb
+++ b/test/test_samples.rb
@@ -57,7 +57,7 @@ class TestSamples < Test::Unit::TestCase
   Samples.each do |sample|
     define_method "test_#{sample[:path]}_not_binary" do
       blob = blob(sample[:path])
-      assert !blob.binary_mime_type? && !blob.binary?, "#{sample[:path]} is a binary file"
+      assert !blob.likely_binary? && !blob.binary?, "#{sample[:path]} is a binary file"
     end
   end
 


### PR DESCRIPTION
This is a work in progress to fix #1118.  There are currently 10 sample files currently identified as binary.

```
[157/709] TestSamples#test_/Users/brandon/github/linguist/samples/Cuda/vectorAdd.cu_not_binary = 0.00 s                                              
  1) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/Cuda/vectorAdd.cu_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/Cuda/vectorAdd.cu is a binary file

[446/709] TestSamples#test_/Users/brandon/github/linguist/samples/Nimrod/foo.nim_not_binary = 0.00 s                                       
  2) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/Nimrod/foo.nim_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/Nimrod/foo.nim is a binary file

[575/709] TestSamples#test_/Users/brandon/github/linguist/samples/SQL/AvailableInSearchSel.prc_not_binary = 0.00 s                    
  3) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/SQL/AvailableInSearchSel.prc_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/SQL/AvailableInSearchSel.prc is a binary file

[584/709] TestSamples#test_/Users/brandon/github/linguist/samples/Scala/node11.sc_not_binary = 0.00 s                         
  4) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/Scala/node11.sc_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/Scala/node11.sc is a binary file

[587/709] TestSamples#test_/Users/brandon/github/linguist/samples/Scheme/asteroids.sps_not_binary = 0.00 s       
  5) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/Scheme/asteroids.sps_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/Scheme/asteroids.sps is a binary file

[638/709] TestSamples#test_/Users/brandon/github/linguist/samples/Standard ML/Foo.sig_not_binary = 0.00 s                        
  6) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/Standard ML/Foo.sig_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/Standard ML/Foo.sig is a binary file

[662/709] TestSamples#test_/Users/brandon/github/linguist/samples/TypeScript/classes.ts_not_binary = 0.00 s                         
  7) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/TypeScript/classes.ts_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/TypeScript/classes.ts is a binary file

[663/709] TestSamples#test_/Users/brandon/github/linguist/samples/TypeScript/empty.ts_not_binary = 0.00 s          
  8) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/TypeScript/empty.ts_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/TypeScript/empty.ts is a binary file

[664/709] TestSamples#test_/Users/brandon/github/linguist/samples/TypeScript/hello.ts_not_binary = 0.00 s        
  9) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/TypeScript/hello.ts_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/TypeScript/hello.ts is a binary file

[695/709] TestSamples#test_/Users/brandon/github/linguist/samples/XSLT/test.xslt_not_binary = 0.00 s                       
 10) Failure:
TestSamples#test_/Users/brandon/github/linguist/samples/XSLT/test.xslt_not_binary [test/test_samples.rb:60]:
/Users/brandon/github/linguist/samples/XSLT/test.xslt is a binary file
```

/cc @pchaigno @brianmario @arfon @rick
