### PR TITLE
Change PureScript colour to avoid clash with JavaScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1545,7 +1545,7 @@ Pure Data:
 
 PureScript:
   type: programming
-  color: "#f3ce45"
+  color: "#bcdc53"
   lexer: Haskell
   primary_extension: .purs
 


### PR DESCRIPTION
JavaScript's colour was changed in the same batch of PRs that PureScript was added in, and now they have almost identical colours (see https://github.com/purescript/purescript-control for an example). Since both languages will almost always appear together in a project this isn't totally ideal!

Apologies if this is too frivolous a change.
