### PR TITLE
Change DOT language type from programming to data (fix #1145)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -468,7 +468,7 @@ DM:
   - byond
 
 DOT:
-  type: programming
+  type: data
   lexer: Text only
   primary_extension: .dot
   extensions:


### PR DESCRIPTION
DOT language is a (graph) description language thus a subset of a data
language.
