### PR TITLE
Update PHP colour to reflect php.net

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1394,7 +1394,7 @@ PAWN:
 PHP:
   type: programming
   ace_mode: php
-  color: "#6e03c1"
+  color: "#4F5D95"
   primary_extension: .php
   extensions:
   - .aw


### PR DESCRIPTION
Currently the PHP colour is very similar to C#, and seems to have been pulled from thin air. PHP has a perfectly nice distinctive purple, used on [php.net](http://php.net) since forever. This pull request changes PHP's colour to a dark shade of that purple.

| Before | After |
| --- | --- |
| ![](http://www.colorhexa.com/6e03c1.png) | ![](http://www.colorhexa.com/4f5d95.png) |
