### PR TITLE
Programming type added to Cuda

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -434,6 +434,7 @@ Cucumber:
   primary_extension: .feature
 
 Cuda:
+  type: programming
   lexer: CUDA
   primary_extension: .cu
   extensions:


### PR DESCRIPTION
Cuda was first added to linguist in #758 without a type.
Because of this, it doesn't appear in the statistics bar.
This PR sets the type to programming.
