### PR TITLE
Exclude doc / docs folder(s)

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -12,6 +12,9 @@
 # Caches
 - (^|/)cache/
 
+# Documentation
+- (^|/)docs?/
+
 # Dependencies
 - ^[Dd]ependencies/
 


### PR DESCRIPTION
To avoid the documentation being detected as the main project part/language
