### PR TITLE
Bump charlock_holmes to 0.7.0

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*']
   s.executables << 'linguist'
 
-  s.add_dependency 'charlock_holmes', '~> 0.7.0'
+  s.add_dependency 'charlock_holmes', '~> 0.7.1'
   s.add_dependency 'escape_utils',    '~> 1.0.1'
   s.add_dependency 'mime-types',      '~> 1.19'
   s.add_dependency 'pygments.rb',     '~> 0.5.4'


### PR DESCRIPTION
This bumps charlock_holmes to it's latest version, which removes it's dependency on libmagic. Fixing a ton of compile-time issues people were having as well as removing a lot of false-positives with binary detection.
