### PR TITLE
Bumping to 2.11.0

### DIFF
--- a/lib/linguist/version.rb
+++ b/lib/linguist/version.rb
@@ -1,3 +1,3 @@
 module Linguist
-  VERSION = "2.10.15"
+  VERSION = "2.11.0"
 end


### PR DESCRIPTION
New version of Charlock Holmes, removal of `primary_extension`.
