### PR TITLE
Cheat Engine Table definition

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -309,6 +309,12 @@ C2hs Haskell:
   extensions:
   - .chs
 
+Cheat Engine Table:
+  type: data
+  lexer: XML
+  extensions:
+  - .ct
+
 CLIPS:
   type: programming
   lexer: Text only


### PR DESCRIPTION
Cheat Engine is a live memory editor, mainly used to cheat in games, but it's also handy tool to live edit data structures in running programs, to debug and or test them.
