### PR TITLE
Javascript and LESS being labeled as 100% "shell"

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -148,7 +148,7 @@
 - (^|/)[Mm]icrosoft([Mm]vc)?([Aa]jax|[Vv]alidation)(\.debug)?\.js$
 
 # NuGet
-- ^[Pp]ackages/
+- ^[Pp]ackages\/.+\.\d+\/
 
 # ExtJS
 - (^|/)extjs/.*?\.js$


### PR DESCRIPTION
My repo [fraction/fraction](/fraction/fraction) is being labeled as 100% shell, whereas the [language search](https://github.com/fraction/fraction/search?l=javascript) shows that it's almost all Javascript and LESS. What steps should I take to troubleshoot? Thanks!
