### PR TITLE
Ignore files related to Cocoapods.

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -125,7 +125,7 @@
 ## Obj-C ##
 
 # Cocoapods
-- ^Pods/$
+- ^Pods/
 
 # Sparkle
 - (^|/)Sparkle/


### PR DESCRIPTION
These include Podfile, Podfile.lock, and Pods/.
