### PR TITLE
SQL -> data

### DIFF
--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -214,7 +214,7 @@ class TestLanguage < Test::Unit::TestCase
   def test_searchable
     assert Language['Ruby'].searchable?
     assert !Language['Gettext Catalog'].searchable?
-    assert !Language['SQL'].searchable?
+    assert Language['SQL'].searchable?
   end
 
   def test_find_by_name


### PR DESCRIPTION
Changing SQL language definition back to `data`. A bunch of repos are being wildly misrepresented e.g. https://github.com/linkedin/sensei https://github.com/postgis/postgis https://github.com/TrinityCore/TrinityCore as they're storing SQL data exports in their repositories.

Until we have a better (repo-specific) ignore option such as a `.linguistignore` this needs to be reverted to `data`
