### PR TITLE
Add Cheat Engine's .ct as an XML extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2212,6 +2212,7 @@ XML:
   - .clixml
   - .cproject
   - .csproj
+  - .ct
   - .dita
   - .ditamap
   - .ditaval


### PR DESCRIPTION
Add .ct as an XML extension instead of its own language, as [recommended](https://github.com/github/linguist/pull/1199#issuecomment-44695601) by @arfon in #1199
