### PR TITLE
Add orange color to Apple Swift language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2048,7 +2048,7 @@ SuperCollider:
 
 Swift:
   type: programming
-  color: "#f59A37"
+  color: "#ffac45"
   lexer: Text only
   extensions:
   - .swift


### PR DESCRIPTION
The self-explanatory title is self-explanatory.

How would it look like beside Objective-C (I cropped those bars a little bit):

![zrzut ekranu 2014-06-03 o 16 01 22](https://cloud.githubusercontent.com/assets/565231/3161314/932b393a-eb2a-11e3-941c-9be01bb4d4f4.png)
![zrzut ekranu 2014-06-03 o 16 01 13](https://cloud.githubusercontent.com/assets/565231/3161319/97f0e32a-eb2a-11e3-8f09-2a2aad662a80.png)

Why orange? Because [it's the color of Swift](https://developer.apple.com/swift/)! :smiley:
