### PR TITLE
Add Verilog and SystemVerilog Syntax Highlighting to GitHub

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -414,7 +414,7 @@ F#:
   - .fsi
   - .fsx
 
-FORTRAN:
+Fortran:
   type: programming
   lexer: Fortran
   color: "#4d41b1"


### PR DESCRIPTION
See https://bitbucket.org/birkenfeld/pygments-main/issue/491/verilog-lexer for the Verilog and SystemVerilog lexer.
