### PR TITLE
Add lexers from Pygments

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -353,9 +353,8 @@ ChucK:
 Cirru:
   type: programming
   color: "#aaaaff"
-  # ace_mode: cirru
-  # lexer: Cirru
-  lexer: Text only
+  ace_mode: cirru
+  lexer: Cirru
   extensions:
   - .cirru
 
@@ -589,7 +588,7 @@ Eagle:
 
 Eiffel:
   type: programming
-  lexer: Text only
+  lexer: Eiffel
   color: "#946d57"
   extensions:
   - .e
@@ -933,7 +932,7 @@ Haxe:
 
 Hy:
   type: programming
-  lexer: Clojure
+  lexer: Hy
   ace_mode: clojure
   color: "#7891b1"
   extensions:
@@ -967,7 +966,7 @@ Idris:
 
 Inform 7:
   type: programming
-  lexer: Text only
+  lexer: Inform 7
   wrap: true
   extensions:
   - .ni
@@ -1297,7 +1296,7 @@ Mathematica:
   - .mathematica
   - .m
   - .nb
-  lexer: Text only
+  lexer: Mathematica
 
 Matlab:
   type: programming
@@ -1768,7 +1767,7 @@ R:
 
 RDoc:
   type: prose
-  lexer: Text only
+  lexer: Rd
   ace_mode: rdoc
   wrap: true
   extensions:


### PR DESCRIPTION
This PR adds lexers from the last two versions of Pygments (1.6 and the current 2.0).
