### PR TITLE
Set a sort order for the samples.json file's content

### DIFF
--- a/lib/linguist/samples.rb
+++ b/lib/linguist/samples.rb
@@ -28,7 +28,7 @@ module Linguist
     #
     # Returns nothing.
     def self.each(&block)
-      Dir.entries(ROOT).each do |category|
+      Dir.entries(ROOT).sort!.each do |category|
         next if category == '.' || category == '..'
 
         # Skip text and binary for now


### PR DESCRIPTION
This PR sets the sort order of the `samples.json` file's content once and for all.
The order of results from [Dir.entries()](http://ruby-doc.org/core-2.1.2/Dir.html#glob-method) depends on the system. This results in the `samples.json` file being considered as completely changed by git.

Thus, this PR should reduce the number of changes made to `samples.json` in future PR and the number of conflicts on this file.
