### PR TITLE
Set a sort order for the samples.json file's content 2

### DIFF
--- a/lib/linguist/classifier.rb
+++ b/lib/linguist/classifier.rb
@@ -26,7 +26,7 @@ module Linguist
       db['language_tokens'] ||= {}
       db['languages'] ||= {}
 
-      tokens.each do |token|
+      tokens.sort!.each do |token|
         db['tokens'][language] ||= {}
         db['tokens'][language][token] ||= 0
         db['tokens'][language][token] += 1

--- a/lib/linguist/samples.rb
+++ b/lib/linguist/samples.rb
@@ -36,11 +36,11 @@ module Linguist
         next if category == 'Text' || category == 'Binary'
 
         dirname = File.join(ROOT, category)
-        Dir.entries(dirname).each do |filename|
+        Dir.entries(dirname).sort!.each do |filename|
           next if filename == '.' || filename == '..'
 
           if filename == 'filenames'
-            Dir.entries(File.join(dirname, filename)).each do |subfilename|
+            Dir.entries(File.join(dirname, filename)).sort!.each do |subfilename|
               next if subfilename == '.' || subfilename == '..'
 
               yield({


### PR DESCRIPTION
This PR follows #1313.
It appears that the change made in #1313 wasn't sufficient.
This PR contains three others `sort!` instructions (for the files inside the language directories and for the tokens).

This time I checked using several system that the `samples.json` doesn't change from one generation to the other. @arfon If this works, if you regenerate the `samples.json` file after this PR, it shouldn't change at all.
