### PR TITLE
Modifying $LOAD_PATH for easier local testing

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -3,6 +3,9 @@
 # linguist — detect language type for a file, or, given a directory, determine language breakdown
 #     usage: linguist <path> [<--breakdown>]
 
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require 'linguist/file_blob'
 require 'linguist/repository'
 require 'rugged'


### PR DESCRIPTION
Right now it's kinda hard to test local changes as the require statements in `bin/linguist` pick up the installed gem first so testing changes can be a pain.

There may be a better way to do this - modifying `$LOAD_PATH` felt a bit weird.

/ cc @tnm @josh for some Ruby prowess.
