### PR TITLE
PHP can also use an .inc extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1551,6 +1551,7 @@ PHP:
   - .php4
   - .php5
   - .phpt
+  - .inc
   filenames:
   - Phakefile
   interpreters:


### PR DESCRIPTION
This was breaking include files for PHP and listing them as Assembly.

cc @arfon 
