### PR TITLE
Add highlighting for Igor Pro procedures

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -996,6 +996,12 @@ IDL:
   - .pro
   - .dlm
 
+IGOR Pro:
+  type: programming
+  lexer: Igor
+  extensions:
+  - .ipf
+
 INI:
   type: data
   extensions:

--- a/samples/IGOR Pro/functions.ipf
+++ b/samples/IGOR Pro/functions.ipf
@@ -1,0 +1,38 @@
+#pragma rtGlobals=3
+
+Function FooBar()
+	return 0
+End
+
+Function FooBarSubType() : ButtonControl
+	return 0
+End
+
+Function/D FooBarVar()
+	return 0
+End
+
+static Function FooBarStatic()
+	return 0
+End
+
+threadsafe static Function FooBarStaticThreadsafe()
+	return 0
+End
+
+threadsafe Function FooBarThread()
+	return 0
+End
+
+Function CallOperationsAndBuiltInFuncs(string var)
+
+	string someDQString = "abcd"
+
+	Make/N=(1,2,3,4) myWave
+	Redimension/N=(-1,-1,-1,5) myWave
+
+	print strlen(someDQString)
+
+	return 0
+End
+

--- a/samples/IGOR Pro/generic.ipf
+++ b/samples/IGOR Pro/generic.ipf
@@ -1,0 +1,21 @@
+#pragma rtGlobals=3
+
+StrConstant myConstString="abcd"
+// some comment
+constant myConst=123
+
+Structure struct1
+	string str
+	variable var
+EndStructure
+
+static Structure struct2
+	string str
+	variable var
+EndStructure
+
+#include "someFile"
+
+#ifdef NOT_DEFINED
+	// conditional compilation
+#endif


### PR DESCRIPTION
Available in pygments since 5ceb7533e214.
For a background of IGOR Pro see www.wavemetrics.com and www.igorexchange.com.

Repositories with igor procedure files:
- https://github.com/stakahama/igorlib
- https://github.com/yamad/igorutils
- https://github.com/dleifohcs/srs-igor
- https://github.com/david-hoffman/Igor-Data-Analysis
- https://github.com/bmcguyer/DAQ_Procedures_for_Igor_Pro

Pygments has a special style for igor pro. Is there a way I can force a specific pygments style? 

``` sh
pygmentize -L styles | grep -A1 igor
* igor:
    Pygments version of the official colors for Igor Pro procedures.
```
