### PR TITLE
Add '3rdparty' as a vendor directory.

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -44,6 +44,7 @@
 - normalize.css
 
 # Vendored dependencies
+- 3rdparty/
 - thirdparty/
 - vendors?/
 - extern(al)?/


### PR DESCRIPTION
I'd be happy if '3rdparty' was recognized as a directory for vendored libs/sources.

It's the convention we use in our various repos on https://github.com/mumble-voip, such as:

https://github.com/mumble-voip/mumble/tree/master/3rdparty
https://github.com/mumble-voip/libmumble/tree/master/3rdparty
https://github.com/mumble-voip/mumblekit/tree/master/3rdparty

It's also the convention used by Qt:

https://github.com/mumble-voip/mumble-developers-qt/tree/4.8-mumble/src/3rdparty

It's very bad on the 'libmumble' repo: https://github.com/mumble-voip/libmumble/tree/master/3rdparty
In that source tree, we have pre-generated OpenSSL assembly files for various OS/arch combinations living in 3rdparty/opensslbuild/asm (https://github.com/mumble-voip/libmumble/tree/master/3rdparty/opensslbuild/asm).
This causes linguist to detect the repo as "82.95% Assembly".

Thanks for the consideration!
