### PR TITLE
Added .workflow as an extension to Applescript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -114,6 +114,7 @@ AppleScript:
   extensions:
   - .applescript
   - .scpt
+  - .workflow
   interpreters:
   - osascript
 


### PR DESCRIPTION
I recently realized that .workflow files aren't recognized by Linguist and I think they need to be :D
