### PR TITLE
SuperCollider has two extension types

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2106,6 +2106,7 @@ SuperCollider:
   color: "#46390b"
   lexer: Text only
   extensions:
+  - .sc
   - .scd
 
 Swift:


### PR DESCRIPTION
.sc is class files, .scd are documents

reference: https://github.com/supercollider/language-supercollider/blob/master/grammars/supercollider.cson
