### PR TITLE
Updated vendor.yml for Rails project

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -217,7 +217,4 @@
 - sprockets-octicons.scss
 
 # Rails assets
-- (^|/)app/assets/*
-- (^|/)lib/assets/*
-- (^|/)public/assets/*
-- (^|/)vendor/assets/*
+- (^|/)(app|lib|public|vendor)/assets/(images|javascripts|stylesheets)/.*

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -430,10 +430,10 @@ class TestBlob < Test::Unit::TestCase
     assert blob("public/octicons/sprockets-octicons.scss").vendored?
 
     # Rails assets
-    assert blob("app/assets/sample.js").vendored?
-    assert blob("lib/assets/sample.min.js").vendored?
-    assert blob("public/assets/sample.css").vendored?
-    assert blob("vendor/assets/sample.min.css").vendored?
+    assert blob("app/assets/javascripts/sample.js").vendored?
+    assert blob("lib/assets/javascripts/sample.min.js").vendored?
+    assert blob("public/assets/stylesheets/sample.css").vendored?
+    assert blob("vendor/assets/images/sample.jpg").vendored?
   end
 
   def test_language


### PR DESCRIPTION
Hi

I have updated vendor.yml file for Rails project. Linguist will ignore assets dir and will detect the language correctly.
I have updated test_blob.rb
I have tested linguist locally. Works great and now detects the language correctly (there are a lot of javascripts files in my assets folders and before this fix Linguist detected language as JavaScript, not Ruby)

Before commit I run test:
bundle exec rake test
# Running tests:

Finished tests in 26.923862s, 3.7885 tests/s, 218.0965 assertions/s.  
102 tests, 5872 assertions, 0 failures, 0 errors, 0 skips
ruby -v: ruby 2.1.1p76 (2014-02-24 revision 45161) [x86_64-linux]

![linguist1](https://cloud.githubusercontent.com/assets/2852169/3699108/9ce96f74-13ce-11e4-8891-37c592a91ac9.JPG)

Thanks,
Siarhei Kavaliou
