### PR TITLE
Added Bourbon SCSS mixin directory to be ignored

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -44,7 +44,8 @@
 - normalize.css
 
 # Bourbon SCSS
-- (^|/)[Bb]ourbon/
+- (^|/)[Bb]ourbon/*\.css
+- (^|/)[Bb]ourbon/*\.scss
 
 # Vendored dependencies
 - thirdparty/


### PR DESCRIPTION
Ignore [Bourbon SCSS](http://bourbon.io) mixin library. When this goes un-ignored, projects tend to have an extremely high percentage of CSS listed as the language used due to the sheer amount of it in the library itself. This is erroneous because the project developer(s) almost never touch this much CSS, and normal web development projects shouldn't be labeled as CSS projects just because they use the library alone.
