### PR TITLE
LookML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1225,6 +1225,14 @@ Logtalk:
   - .lgt
   - .logtalk
 
+LookML:
+  type: programming
+  lexer: YAML
+  ace_mode: yaml
+  color: "#652B81"
+  extensions:
+  - .lookml
+
 Lua:
   type: programming
   ace_mode: lua

--- a/samples/LookML/comments.view.lookml
+++ b/samples/LookML/comments.view.lookml
@@ -1,0 +1,43 @@
+- view: comments
+  fields:
+
+  - dimension: id
+    primary_key: true
+    type: int
+    sql: ${TABLE}.id
+
+  - dimension: body
+    sql: ${TABLE}.body
+
+  - dimension_group: created
+    type: time
+    timeframes: [time, date, week, month]
+    sql: ${TABLE}.created_at
+
+  - dimension: headline_id
+    type: int
+    hidden: true
+    sql: ${TABLE}.headline_id
+
+  - dimension_group: updated
+    type: time
+    timeframes: [time, date, week, month]
+    sql: ${TABLE}.updated_at
+
+  - dimension: user_id
+    type: int
+    hidden: true
+    sql: ${TABLE}.user_id
+
+  - measure: count
+    type: count
+    detail: detail*
+
+
+  # ----- Detail ------
+  sets:
+    detail:
+      - id
+      - headlines.id
+      - headlines.name
+      - users.id


### PR DESCRIPTION
Add support for LookML, the language component of [Looker](http://looker.com).

I expect the majority use of LookML is in private repositories. Looker generally pushes directly to private repos on GitHub since this code can contain proprietary information. Nevertheless, there's quite a bit of LookML floating around in public:
- https://github.com/snowplow/snowplow/tree/master/5-analytics/looker-analytics/lookml
- https://github.com/wilg/headlinesmasher.lookml
- [A search for LookML files on GitHub](https://github.com/search?q=dimension+extension%3Alookml&ref=searchresults&type=Code)
