### PR TITLE
Ignore Bourbon SCSS mixin library to avoid high CSS percentages

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -44,8 +44,8 @@
 - normalize.css
 
 # Bourbon SCSS
-- (^|/)[Bb]ourbon/*\.css
-- (^|/)[Bb]ourbon/*\.scss
+- (^|/)[Bb]ourbon/.*\.css$
+- (^|/)[Bb]ourbon/.*\.scss$
 
 # Vendored dependencies
 - thirdparty/


### PR DESCRIPTION
Ignore [Bourbon SCSS](http://bourbon.io) mixin library. When this goes un-ignored, projects tend to have an extremely high percentage of CSS listed as the language used due to the sheer amount of it in the library itself. This is erroneous because the project developer(s) almost never touch this much CSS, and normal web development projects shouldn't be labeled as CSS projects just because they use the library alone.

Re-submitting pull request to [squash commits](https://github.com/github/linguist/pull/1407) and force Travis to re-run tests.
