### PR TITLE
Match js/libs/

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -47,6 +47,7 @@
 - thirdparty/
 - vendors?/
 - extern(al)?/
+- js/libs/
 
 # Debian packaging
 - ^debian/


### PR DESCRIPTION
js/libs/ is another common pattern for JS vendor path. I feel it should be included.
