### PR TITLE
ignore files in inst/extdata within subdirectories

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -208,8 +208,8 @@
 - Mercury/
 
 # R packages
-- ^vignettes/
-- ^inst/extdata/
+- vignettes/
+- inst/extdata/
 
 # Octicons
 - octicons.css


### PR DESCRIPTION
(discussed in gh-1042 and commit f66ffe305fa539369a2a95c12cf3c91532a2d489)

Currently, vendor/yml ignores files in  '- ^inst/extdata', (line 212)

But the `^` requires these be in the top level directory, and was added in commit f66ffe305fa539369a2a95c12cf3c91532a2d489

I propose removing this requirement so that it works on subdirectories, as in this repository containing a large number of R packages at different levels of heirarchy. 

I assume that the proposed file change do what I want, w
