### PR TITLE
Add knockout.js library as vendor file

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -112,6 +112,10 @@
 - (^|/)modernizr\-\d\.\d+(\.\d+)?(\.min)?\.js$
 - (^|/)modernizr\.custom\.\d+\.js$
 
+# Knockout
+- (^|/)knockout-(\d+\.){3}(debug\.)?js$
+- knockout-min.js
+
 ## Python ##
 
 # django


### PR DESCRIPTION
As discussed in #1427, this PR adds [knockout.js](http://knockoutjs.com/) to the vendor list.
I tested it on the [EdgeFiles repository](https://github.com/AultCare/EdgeFiles).
