### PR TITLE
Lexer for Handlebars

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -902,12 +902,10 @@ Haml:
 
 Handlebars:
   type: markup
-  lexer: Text only
+  lexer: Handlebars
   extensions:
   - .handlebars
   - .hbs
-  - .html.handlebars
-  - .html.hbs
 
 Harbour:
   type: programming


### PR DESCRIPTION
This PR adds a lexer for Handlebars as discussed in #903.
I also removed the two file extensions with multiple segments since Linguist doesn't support those (discussed in #1388).
