### PR TITLE
Use Pygments Pan lexer

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1637,7 +1637,7 @@ PHP:
 
 Pan:
   type: programming
-  lexer: Text only
+  lexer: Pan
   color: '#cc0000'
   extensions:
   - .pan


### PR DESCRIPTION
The upstream pygments patches seem to have landed at GitHub as Pan code blocks
are being correctly highlighted, we should extend this to files in repositories as well.

Here is a Pan code block:

``` pan
variable e = error('I am Pan!');
```
