### PR TITLE
[Vendor Files]: Ignore 'example' directory (For Dart)

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -12,6 +12,9 @@
 # Caches
 - (^|/)cache/
 
+# Dart
+- (^|/)example/
+
 # Dependencies
 - ^[Dd]ependencies/
 


### PR DESCRIPTION
This ignores the example directory which is used in Dart for demos, and other such things, which are not the actual code.
