### PR TITLE
ffa500 to ef2929

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -139,7 +139,14 @@ Arc:
   lexer: Text only
   extensions:
   - .arc
-
+  
+Arendelle:
+  type: programming
+  color: "#ef2929"
+  lexer: Text only
+  extensions:
+  - .arendelle
+  
 Arduino:
   type: programming
   color: "#bd79d1"


### PR DESCRIPTION
File detection for Arendelle Language files.
The language is new so a file detection for GitHub was needed.

> This is the second pull request I'm sending, Sorry for that I acidently sent you the color of the langauge as ffa500 but it's ef2929, So sorry anyway!
