### PR TITLE
Ignore minified JavaScript and minified CSS

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -69,6 +69,9 @@
 
 ## Commonly Bundled JavaScript frameworks ##
 
+# Minified JavaScript and CSS
+- .*(\-|\.)min\.(css|js)$
+
 # jQuery
 - (^|/)jquery([^.]*)(\.min)?\.js$
 - (^|/)jquery\-\d\.\d+(\.\d+)?(\.min)?\.js$


### PR DESCRIPTION
Minified CSS and JavaScript are most likely to be double counted in the project; they should be treated as "binary" like file.
