### PR TITLE
Starting work on Linguist overrides

### DIFF
--- a/.linguist
+++ b/.linguist
@@ -1,0 +1,3 @@
+\.blah         Assembly
+benchmark\/*   ignore
+\.linguist     ignore

--- a/bin/linguist
+++ b/bin/linguist
@@ -5,6 +5,7 @@
 
 require 'linguist/file_blob'
 require 'linguist/language'
+require 'linguist/overrides'
 require 'linguist/repository'
 require 'rugged'
 

--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'json'
   s.add_development_dependency 'mocha'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'yajl-ruby'
 end

--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -300,9 +300,19 @@ module Linguist
     #
     # May load Blob#data
     #
-    # Return true or false
+    # Returns true or false
     def generated?
       @_generated ||= Generated.generated?(name, lambda { data })
+    end
+
+    # Public: Is the blob an ignored file?
+    #
+    # Files that match regular expressions defined in '.linguist'
+    # are matched in overrides.rb
+    #
+    # Returns true or false
+    def ignored?
+      @_ignored ||= Overrides.ignored?(name)
     end
 
     # Public: Detects the Language of the blob.
@@ -311,7 +321,13 @@ module Linguist
     #
     # Returns a Language or nil if none is detected
     def language
-      @language ||= Language.detect(self)
+      if @language = Overrides.language_for?(name)
+        @language
+      else
+        @language ||= Language.detect(self)
+      end
+
+      return @language
     end
 
     # Internal: Get the lexer of the blob.

--- a/lib/linguist/overrides.rb
+++ b/lib/linguist/overrides.rb
@@ -1,0 +1,77 @@
+require 'linguist/language'
+require 'pry'
+module Linguist
+  class Overrides
+
+    def self.ignored?(name)
+      new(name).ignored_path?
+    end
+
+    def self.language_for?(name)
+      new(name).language
+    end
+
+    def initialize(file_with_path)
+      @name = file_with_path
+
+      @override_definitions = File.new('.linguist')
+
+      if File.exists?(@override_definitions)
+        ignored_paths = []
+        language_paths = Hash.new()
+
+        File.open('.linguist', 'r').each do |line|
+          regex, command = line.split(' ').map(&:strip)
+
+          if command == 'ignore'
+            ignored_paths << regex
+          elsif Language[command] # is this a known language to Linguist?
+            language_paths[command] = [] unless language_paths.has_key?(command)
+            language_paths[command] << regex
+          else
+            # warn about this not be a recognised statement
+          end
+        end
+
+        @ignore_regex = Regexp.new(ignored_paths.join('|'))
+        @language_regexes = language_paths
+      end
+    end
+
+    attr_reader :name
+    attr_reader :ignore_regex
+    attr_reader :language_regexes
+
+    # Internal: Is this file ignored?
+    #
+    # Does this file match one of the ignore regular expressions?
+    #
+    # Returns true or false
+    def ignored_path?
+      name.match(self.ignore_regex) ? true : false
+    end
+
+    # Internal: Is there a language override for this file?
+    #
+    # Returns a Language
+    def language
+      override_language
+    end
+
+    def override_language
+      language_candidates = []
+
+      self.language_regexes.each do |lang, regexes|
+        if name.match(Regexp.new(regexes.join('|')))
+          language_candidates << Language[lang]
+        end
+      end
+
+      if language_candidates.any?
+        return language_candidates.first
+      else
+        return nil
+      end
+    end
+  end
+end

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -264,6 +264,10 @@ class TestBlob < Test::Unit::TestCase
     assert Linguist::Generated.generated?("node_modules/grunt/lib/grunt.js", nil)
   end
 
+  def test_ignored
+    assert FileBlob.new('../../.linguist').ignored?
+  end
+
   def test_vendored
     assert !blob("Text/README").vendored?
     assert !blob("ext/extconf.rb").vendored?

--- a/test/test_overrides.rb
+++ b/test/test_overrides.rb
@@ -1,0 +1,27 @@
+require 'linguist/overrides'
+
+class TestOverrides < Test::Unit::TestCase
+  include Linguist
+
+  # Note this is loading the .linguist file in the root path
+  def test_ignored_presence
+    overrides = Overrides.new("blah.rb")
+    assert !overrides.ignore_regex.nil?
+  end
+
+  def test_language_presence
+    overrides = Overrides.new("blah.m")
+    assert overrides.language_regexes.any?
+  end
+
+  def test_language
+    assert_equal Language['Assembly'], Overrides.language_for?('test.blah')
+  end
+
+  def test_ignored
+    should_be_ignored = Overrides.new("benchmark/samples/Ruby/foo.rb")
+    should_not_be_ignored = Overrides.new("lib/linguist/classifier.rb")
+    assert should_be_ignored.ignored_path?
+    assert !should_not_be_ignored.ignored_path?
+  end
+end


### PR DESCRIPTION
This is pretty rough but `Linguist::Overrides` reads a `.linguist` file (composed of regular expressions and commands) and uses this to both ignore files but also override the language identification.

One major thing to be addressed is that currently Linguist picks up _it's own_ `.linguist` file rather than one for a target test repo/directory.

Some :eyes: on this, especially from @bkeepers would be :sparkles: 
