### PR TITLE
Change lexer for Emacs Lisp from Scheme to Common Lisp

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -647,7 +647,7 @@ Elm:
 
 Emacs Lisp:
   type: programming
-  lexer: Scheme
+  lexer: Common Lisp
   color: "#c065db"
   aliases:
   - elisp

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -46,7 +46,6 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Lexer['Ruby'], Language['Mirah'].lexer
     assert_equal Lexer['Ruby'], Language['Ruby'].lexer
     assert_equal Lexer['S'], Language['R'].lexer
-    assert_equal Lexer['Scheme'], Language['Emacs Lisp'].lexer
     assert_equal Lexer['Scheme'], Language['Nu'].lexer
     assert_equal Lexer['Racket'], Language['Racket'].lexer
     assert_equal Lexer['Scheme'], Language['Scheme'].lexer


### PR DESCRIPTION
As reported in #1494, the Common Lisp lexer is more appropriate to highlight Emacs Lisp code.
