### PR TITLE
Use the Logtalk lexer for syntax coloring of Prolog files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1792,6 +1792,7 @@ Processing:
 
 Prolog:
   type: programming
+  lexer: Logtalk
   color: "#74283c"
   extensions:
   - .pl


### PR DESCRIPTION
Logtalk is an extension to Prolog and, as such, subsumes its syntax. This allows the Pygments Logtalk lexer to be used for syntax coloring of Prolog files. Covered Prolog syntax includes both official (ISO) and de facto standard constructs, including core Prolog module directives.
