### PR TITLE
Changes C# to proposed color in #1332

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -283,7 +283,7 @@ C#:
   type: programming
   ace_mode: csharp
   search_term: csharp
-  color: "#5a25a2"
+  color: "#178600"
   aliases:
   - csharp
   extensions:


### PR DESCRIPTION
Gives C# a dark green color instead of a color near identical to CSS, as suggested in #1332.
