### PR TITLE
Extend linguist command to work with multiple arguments

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -8,17 +8,14 @@ require 'linguist/language'
 require 'linguist/repository'
 require 'rugged'
 
-path = ARGV[0] || Dir.pwd
-
-# special case if not given a directory but still given the --breakdown option
-if path == "--breakdown"
-  path = Dir.pwd
+if ARGV.include? "--breakdown"
   breakdown = true
+  ARGV.delete("--breakdown")
 end
 
-ARGV.shift
-breakdown = true if ARGV[0] == "--breakdown"
+ARGV.push << Dir.pwd if ARGV.empty?
 
+ARGV.each { |path|
 if File.directory?(path)
   rugged = Rugged::Repository.new(path)
   repo = Linguist::Repository.new(rugged, rugged.head.target_id)
@@ -65,5 +62,6 @@ elsif File.file?(path)
     puts "  appears to be a vendored file"
   end
 else
-  abort "usage: linguist <path>"
+  abort "usage: linguist [--breakdown] <path> [<path> ...]"
 end
+}


### PR DESCRIPTION
This change modifies the command line interface of linguist to accept more than one argument. It simply loops over the arguments and treats them individually. In combination with e.g. `find` and `xargs`, this makes it very convenient to e.g. check all files matching a certain pattern inside a given repository. And much more efficient: Invoking `bundle exec linguist FILENAME` on my machine takes 2 (!) seconds (despite my SSD). Invoking it on a dozen files takes about the same time...

This is a very simple hack, and I won't be surprised if you'll want refinements before accepting it (if at all), but it was enough to scratch an itch of mine (namely testing only the .tst files in a big repo, see PR #1523), and I thought perhaps others might benefit from it.

I am not quite happy with it myself; e.g. I think --breakdown should only be accepted once, and as first parameter (but that change would have been incompatible with current behaviour). On the other hand, it should accept any previously valid invocation. 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/github/linguist/1527)
<!-- Reviewable:end -->
