### PR TITLE
Use Java lexer for Apex

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -119,7 +119,7 @@ ApacheConf:
 
 Apex:
   type: programming
-  lexer: Text only
+  lexer: Java
   extensions:
   - .cls
 


### PR DESCRIPTION
This PR sets Java as the lexer for the Apex language.
This was requested in #1526.
[This Pygments demo](http://pygments.org/demo/665782/) shows the result. It is really good except for some issues with the single quotes (see middle of the demo file).

[A request for an Apex lexer](https://bitbucket.org/birkenfeld/pygments-main/issue/1029/apex-not-supported-for-highlighting) was opened on Pygments' repository. In the meantime, using the Java lexer would be better than nothing :-)
