### PR TITLE
Added files generated by Typesafe Activator to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -235,3 +235,7 @@
 - octicons.css
 - octicons.min.css
 - sprockets-octicons.scss
+
+# Typesafe Activator
+- (^|/)activator$
+- (^|/)activator\.bat$

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -437,6 +437,12 @@ class TestBlob < Test::Unit::TestCase
     assert blob("octicons.css").vendored?
     assert blob("public/octicons.min.css").vendored?
     assert blob("public/octicons/sprockets-octicons.scss").vendored?
+
+    # Typesafe Activator
+    assert blob("activator").vendored?
+    assert blob("activator.bat").vendored?
+    assert blob("subproject/activator").vendored?
+    assert blob("subproject/activator.bat").vendored?
   end
 
   def test_language


### PR DESCRIPTION
The files **activator** and **activator.bat** are generated by [https://typesafe.com/activator](Typesafe Activator) when creating a new project.
This can cause the language statistics for a repository to reported as **Shell**.

This pull-request adds these files to **vendor.yml** and to the tests.
