### PR TITLE
Disambiguate StringTemplate from Smalltalk

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -48,6 +48,16 @@ module Linguist
       matches
     end
 
+    def self.disambiguate_st(data, languages)
+      matches = []
+      if (data.include?("self"))
+        matches << Language["Smalltalk"]
+      else
+        matches << Language["StringTemplate"]
+      end
+      matches
+    end
+
     def self.disambiguate_ts(data, languages)
       matches = []
       if (data.include?("</translation>"))

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2251,6 +2251,12 @@ Stata:
   - .matah
   - .sthlp
 
+StringTemplate:
+  type: data
+  lexer: Text only
+  extensions:
+  - .st
+
 Stylus:
   type: markup
   group: CSS

--- a/samples/StringTemplate/decl.st
+++ b/samples/StringTemplate/decl.st
@@ -1,0 +1,1 @@
+decl(type, name, value) ::= "<type> <name><init(value)>;"

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -65,6 +65,18 @@ class TestHeuristcs < Test::Unit::TestCase
     assert_equal Language["ECL"], results.first
   end
 
+  def test_st_smalltalk_by_heuristics
+    languages = ["Smalltalk", "StringTemplate"]
+    results = Heuristics.disambiguate_st(fixture("Smalltalk/Dinner.st"), languages)
+    assert_equal Language["Smalltalk"], results.first
+  end
+
+  def test_st_stringtemplate_by_heuristics
+    languages = ["Smalltalk", "StringTemplate"]
+    results = Heuristics.disambiguate_st(fixture("StringTemplate/decl.st"), languages)
+    assert_equal Language["StringTemplate"], results.first
+  end
+
   def test_ts_typescript_by_heuristics
     languages = ["TypeScript", "XML"]
     results = Heuristics.disambiguate_ts(fixture("TypeScript/classes.ts"), languages)


### PR DESCRIPTION
StringTemplate templates get identified as "Smalltalk" files. This should fix that. I simply added a heuristic that looks for the `self` keyword that seems to be common in Smalltalk.
