### PR TITLE
Support for Graph Modeling Language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -891,6 +891,12 @@ Grammatical Framework:
   searchable: true
   color: "#ff0000"
 
+Graph Modeling Language:
+  type: data
+  lexer: Text only
+  extensions:
+  - .gml
+
 Groff:
   extensions:
   - .man

--- a/samples/Graph Modeling Language/sample.gml
+++ b/samples/Graph Modeling Language/sample.gml
@@ -1,0 +1,21 @@
+graph
+[
+  directed 0
+  node
+  [
+    id 0
+    label "Node 1"
+    value 100
+  ]
+  node
+  [
+    id 1
+    label "Node 2"
+    value 200
+  ]
+  edge
+  [
+    source 1
+    target 0
+  ]
+]


### PR DESCRIPTION
This PR adds support for the Graph Modeling Language as requested at #1559.
There are many [users of GML on GitHub](https://github.com/search?p=5&q=extension%3Agml+graph&ref=searchresults&type=Code&utf8=%E2%9C%93).

It uses the `.gml` file extension which conflicts with Game Maker Language.
The Bayesian classifier seems to do a pretty good job at distinguishing the two.
I tested my PR on:
- [branjbar/compat_modeling](https://github.com/branjbar/compat_modeling)
- [gephi/gephi-toolkit-demos](https://github.com/gephi/gephi-toolkit-demos)
- [h3rb/gml-pro](https://github.com/h3rb/gml-pro)
- [graphstream/gs-algo](https://github.com/graphstream/gs-algo)
- [sujitpal/mlia-examples](https://github.com/sujitpal/mlia-examples)
