### PR TITLE
Support for .jsig files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1186,6 +1186,12 @@ JavaScript:
   interpreters:
   - node
 
+Jsig:
+  type: markup
+  lexer: OCaml
+  extensions:
+  - .jsig
+
 Julia:
   type: programming
   extensions:

--- a/samples/Jsig/error.jsig
+++ b/samples/Jsig/error.jsig
@@ -1,0 +1,25 @@
+type OptionError<T> : {
+    option: T | null,
+    message: String,
+    type: "OptionError"
+}
+
+type TypedError<T> : {
+    message: String,
+    type: T
+}
+
+type ValidationError : {
+    errors: Array<Error>,
+    message: String,
+    type: "ValidationError"
+}
+
+error/option : (String, T) => OptionError<T>
+
+error/typed : (args: {
+    message: String,
+    type: String
+}) => (opts: Object) => TypedError<String>
+
+error/validation : (Array<Error>) => ValidationError

--- a/samples/Jsig/frp-keyboard.jsig
+++ b/samples/Jsig/frp-keyboard.jsig
@@ -1,0 +1,33 @@
+import { Observ } from "observ"
+import { Delegator } from "dom-delegator"
+
+type KeyCode : Number
+type Direction : "left" | "right" | "up" | "down" | "void"
+type Coord : {
+    x: Number,
+    y: Number,
+    lastPressed: Direction
+}
+
+type NativeKeyboard : {
+    isDown: (keyCode: KeyCode) => Observ<Boolean>,
+    keysDown: Observ<Array<keyCode: KeyCode>>,
+    keyDown: Observ<keyCode: KeyCode>,
+    lastPressed: Observ<keyCode: KeyCode>,
+    directions: (
+        up: KeyCode, down: KeyCode, left: KeyCode, right: KeyCode
+    ) => Observ<Coord>
+}
+
+type Keyboard : NativeKeyboard & {
+    arrows: Observ<Coord>,
+    wasd: Observ<Coord>,
+    ctrl: Observ<Boolean>,
+    shift: Observ<Boolean>
+}
+
+frp-keyboard : () => cachedKeyboard: Keyboard
+
+frp-keyboard/keyboard : (Delegator) => Keyboard
+
+frp-keyboard/native : (Delegator) => NativeKeyboard

--- a/samples/Jsig/jsig.jsig
+++ b/samples/Jsig/jsig.jsig
@@ -1,0 +1,137 @@
+type GenericE : {
+    type: "genericLiteral",
+    value: TypeExpression,
+    generics: Array<TypeExpression>,
+    label: String | null,
+    optional: Boolean
+}
+
+type FunctionE : {
+    type: "function",
+    args: Array<TypeExpression>,
+    result: TypeExpression,
+    thisArg: TypeExpression | null,
+    label: String | null,
+    optional: Boolean
+}
+
+type ValueE : {
+    type: "valueLiteral",
+    value: String,
+    name: String,
+    label: String | null,
+    optional: Boolean
+}
+
+type LiteralE : {
+    type: "typeLiteral",
+    name: String,
+    builtin: Boolean,
+    label: String | null,
+    optional: Boolean
+}
+
+type UnionE : {
+    type: "unionType",
+    unions: Array<TypeExpression>,
+    label: String | null,
+    optional: Boolean
+}
+
+type IntersectionE : {
+    type: "intersectionType",
+    intersections: Array<TypeExpression>,
+    label: String | null,
+    optional: Boolean
+}
+
+type KeyValue : {
+    type: "keyValue",
+    key: String,
+    value: TypeExpression,
+    optional: Boolean
+}
+
+type ObjectE : {
+    type: "object",
+    keyValues: Array<KeyValue>,
+    label: String | null,
+    optional: Boolean
+}
+
+type TupleE : {
+    type: "tuple",
+    values: Array<TypeExpression>,
+    label: String | null,
+    optional: Boolean
+}
+
+type TypeExpression : ObjectE | UnionE | LiteralE | FunctionE |
+    ValueE | GenericE | TupleE | IntersectionE
+
+type Assignment : {
+    type: "assignment",
+    identifier: String,
+    typeExpression: TypeExpression
+}
+
+type TypeDeclaration : {
+    type: "typeDeclaration",
+    identifier: String,
+    typeExpression: TypeExpression,
+    generics: Array<LiteralE>
+}
+
+type Import : {
+    type: "import",
+    dependency: String,
+    types: Array<LiteralE>
+}
+
+type Statement : Import | TypeDeclaration | Assignment
+
+type Program : {
+    type: "program",
+    statements: Array<Statement>
+}
+
+type AST : {
+    program: (Array<Statement>) => Program,
+    typeDeclaration: (String, TypeExpression) => TypeDeclaration,
+    assignment: (String, TypeExpression) => Assignment,
+    importStatement: (String, Array<LiteralE>) => Import,
+    object: (
+        keyValues: Array<KeyValue> | Object<String, TypeExpression>,
+        label?: String
+    ) => ObjectE,
+    union: (Array<TypeExpression>, label?: String, opts?: {
+        optional: Boolean
+    }) => UnionE,
+    intersection: (Array<TypeExpression>, label?: String, opts?: {
+        optional: Boolean
+    }) => IntersectionE,
+    literal: (String, builtin?: String, opts?: {
+        optional: Boolean
+    }) => LiteralE,
+    keyValue: (String, TypeExpression) => KeyValue,
+    value: (String, name: String, label?: String) => ValueE,
+    functionType: (opts: {
+        args?: Array<TypeExpression>,
+        result: TypeExpression,
+        thisArg?: TypeExpression,
+        label?: String,
+        optional?: Boolean
+    }) => FunctionE,
+    generic: (
+        value: TypeExpression,
+        generics: Array<TypeExpression>,
+        label?: String
+    ) => GenericE,
+    tuple: (Array<TypeExpression>, label?: String, opts?: {
+        optional: Boolean
+    }) => TupleE
+}
+
+jsig/ast : AST
+
+jsig/parser : (content: String) => Program


### PR DESCRIPTION
JSig is a type documentation format for JavaScript (
  https://github.com/jden/jsig ). It can be considered
  somethign similar to typescript definition files or
  to jsdoc.

The documentation format would be a lot nicer to read
  if it had syntax highlighting. Rather then adding
  a full jsig lexer, i've set the lexer to OCaml as its
  a close approximation.

You can find examples of jsig in the wild here:
- https://github.com/Raynos/dom-delegator/blob/master/docs.mli#L1
- https://github.com/jden/node-random-revisitor#randomrevisitor--functionerror-serviceurlstring--void
- https://github.com/Matt-Esch/virtual-dom/blob/master/docs.mli#L1
- https://github.com/grncdr/node-any-db-transaction#apix

Let me know if I can do anything to make this PR easier
  to review or merge!
