### PR TITLE
Supporting .playground extension for Swift

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2279,6 +2279,7 @@ Swift:
   color: "#ffac45"
   extensions:
   - .swift
+  - .playground
 
 SystemVerilog:
   type: programming


### PR DESCRIPTION
playground file extension should also be treated as Swift Code with Gists along with .swift extension. I see playground files to be shared more with gists rather than swift files, which probably will be shared more as regular repos.
