### PR TITLE
Use TextMate 1 scope for HTML+ERB files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -958,7 +958,7 @@ HTML+Django:
 
 HTML+ERB:
   type: markup
-  tm_scope: text.html.erb
+  tm_scope: text.html.ruby
   group: HTML
   lexer: RHTML
   aliases:


### PR DESCRIPTION
The TextMate 2 scope requires support for injection grammars, which some parsers don't support.

/cc @vmg @arfon
