### PR TITLE
Add dependency on Rugged to gemspec

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'escape_utils',    '~> 1.0.1'
   s.add_dependency 'mime-types',      '~> 1.19'
   s.add_dependency 'pygments.rb',     '~> 0.6.0'
+  s.add_dependency 'rugged'
 
   s.add_development_dependency 'json'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
This is option 2. Opening a parallel pull request to not
`require 'linguist/repository'`.

This approach means that all 3rd party apps using Linguist but not needing to
work with repositories (including [html-pipeline](https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/syntax_highlight_filter.rb#L2))
also need to add a dependency on Rugged, which is unrelated to their goal.

The reason for this change is that a 3rd-party with "require 'linguist'" gets a
load error for Rugged being missing since it is required in linguist/repository.
