### PR TITLE
Require "bundler/setup" in rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'json'
 require 'rake/clean'
 require 'rake/testtask'


### PR DESCRIPTION
This ensures that the Rake task will use bundler to manage dependencies and print a warning to run `bundle install` if dependencies are missing.

This also allows you to be lazy and just run `rake test` without the `bundle exec`.

/cc @arfon 
