### PR TITLE
Add hbs alias for Handlebars

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -989,7 +989,7 @@ Haml:
 Handlebars:
   type: markup
   lexer: Handlebars
- aliases:
+  aliases:
   - hbs
   extensions:
   - .handlebars


### PR DESCRIPTION
Adds a `hbs` alias for `Handlebars`. It's very commonly used and would make adding hbs code blocks easier in github comments.
