### PR TITLE
Add build.xml.dist to XML filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2568,6 +2568,7 @@ XML:
   filenames:
   - .classpath
   - .project
+  - build.xml.dist
   - phpunit.xml.dist
 
 XProc:


### PR DESCRIPTION
Ant uses `build.xml` for it's configuration, but [many projects](https://github.com/search?utf8=%E2%9C%93&q=filename%3Abuild.xml.dist+project&type=Code&ref=searchresults) including my own commit a `build.xml.dist` file and ignore a `build.xml` file, allowing for a custom configuration if necessary.

I've added `build.xml.dist` to the `languages.yml` file to enable syntax highlighting on GitHub for `build.xml.dist` files.
