### PR TITLE
Add .command as a Shell file extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2202,6 +2202,7 @@ Shell:
   - .bash
   - .bats
   - .cgi
+  - .command
   - .fcgi
   - .tmux
   - .zsh

--- a/samples/Shell/build.command
+++ b/samples/Shell/build.command
@@ -1,0 +1,30 @@
+set -e
+
+echo "/************/"
+echo "/* BUILDING */"
+echo "/************/"
+echo ""
+
+cd `dirname $0`
+
+cd build
+
+cmake ..
+
+make
+
+echo ""
+echo "/***********/"
+echo "/* TESTING */"
+echo "/***********/"
+echo ""
+
+# ctest ..
+
+make Experimental
+
+echo ""
+echo "/***********/"
+echo "/* SUCCESS */"
+echo "/***********/"
+echo ""


### PR DESCRIPTION
This pull request adds `.command` as a Shell file extension as requested in #966.
Many undetected Bash files can be found on GitHub:
https://github.com/search?utf8=%E2%9C%93&q=extension%3Acommand+echo&type=Code&ref=searchresults

EDIT: [Travis build](https://travis-ci.org/github/linguist/builds/38660201)
