### PR TITLE
ProGuard config files as vendored

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -242,3 +242,7 @@
 # Typesafe Activator
 - (^|/)activator$
 - (^|/)activator\.bat$
+
+# ProGuard
+- proguard.pro
+- proguard-rules.pro


### PR DESCRIPTION
ProGuard config files have a `.pro` extension. Thus there are detected by Linguist as QMake, Prolog or IDL.
These incorrect results can be seen here: https://github.com/search?q=extension%3Apro+proguard&ref=reposearch&utf8=%E2%9C%93
This pull request adds these files to the vendored files.

EDIT: [Travis build](https://travis-ci.org/github/linguist/builds/38969971) is passing.
