### PR TITLE
Heuristic rule to detect AsciiDoc files

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -25,6 +25,9 @@ module Linguist
         if languages.all? { |l| ["Common Lisp", "OpenCL"].include?(l) }
           result = disambiguate_cl(data, languages)
         end
+        if languages.all? { |l| ["AsciiDoc", "AGS Script"].include?(l) }
+          result = disambiguate_asc(data, languages)
+        end
         return result
       end
     end
@@ -85,6 +88,12 @@ module Linguist
       matches = []
       matches << Language["Rebol"] if /\bRebol\b/i.match(data)
       matches << Language["R"] if data.include?("<-")
+      matches
+    end
+
+    def self.disambiguate_asc(data, languages)
+      matches = []
+      matches << Language["AsciiDoc"] if /^=+(\s|\n)/.match(data)
       matches
     end
 

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -77,6 +77,12 @@ class TestHeuristcs < Test::Unit::TestCase
     assert_equal Language["IDL"], results.first
   end
 
+  def test_asc_asciidoc_by_heuristics
+    languages = ["AGS Script", "AsciiDoc"]
+    results = Heuristics.disambiguate_asc(fixture("AsciiDoc/list.asc"), languages)
+    assert_equal Language["AsciiDoc"], results.first
+  end
+
   def test_ts_typescript_by_heuristics
     languages = ["TypeScript", "XML"]
     results = Heuristics.disambiguate_ts(fixture("TypeScript/classes.ts"), languages)


### PR DESCRIPTION
As reported in #1638, there are conflicts between AsciiDoc and AGS Script files on the `.asc` extension.
This pull request adds an heuristic rule to detect AsciiDoc files.
It tries to find title's syntax in AsciiDoc (`===`).

I tested it against two repositories:
- [vasofilipov/wisp-game](https://github.com/vasofilipov/wisp-game) - AGS Script

```
100.00% AGS Script
```
- [progit/progit2](https://github.com/progit/progit2) - AsciiDoc

```
66.73%  CSS
25.16%  XSLT
7.01%   Ruby
1.10%   AGS Script

Ruby:
Gemfile
Rakefile
book/07-git-tools/git-credential-read-only

AGS Script:
LICENSE.asc
book/toc.asc

CSS:
theme/epub/epub.css
theme/html/html.css
theme/mobi/mobi.css
theme/pdf/pdf.css

XSLT:
theme/epub/epub.xsl
theme/html/html.xsl
theme/mobi/mobi.xsl
theme/pdf/pdf.xsl
```

EDIT: The [Travis build](https://travis-ci.org/github/linguist/builds/39160064) is passing.
