### PR TITLE
Use text.html.erb scope for HTML+ERB files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1001,7 +1001,7 @@ HTML+Django:
 
 HTML+ERB:
   type: markup
-  tm_scope: text.html.ruby
+  tm_scope: text.html.erb
   group: HTML
   lexer: RHTML
   aliases:


### PR DESCRIPTION
This grammar does a better job highlighting than the text.html.ruby grammar does. It requires injection grammar support, but there's no getting around that.
