### PR TITLE
Add moon interpreter for MoonScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1571,6 +1571,8 @@ MoonScript:
   type: programming
   extensions:
   - .moon
+  interpreters:
+  - moon
 
 Myghty:
   extensions:


### PR DESCRIPTION
This pull request adds `moon` as an interpreter for MoonScript and fixes the issue at #1644.
