### PR TITLE
That new green shell, fixes #1640

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2296,7 +2296,7 @@ Shell:
   type: programming
   lexer: Bash
   search_term: bash
-  color: "#2aff0b"
+  color: "#89e051"
   aliases:
   - sh
   - bash


### PR DESCRIPTION
The blue/purple color of Shell files was close to that of Golang and the two could likely be paired together often. This updates Shell to a bright green [inspired by the terminal](https://github.com/github/linguist/issues/1640#issuecomment-61296290) and @bkeepers :green_heart: 

Fixes #1640 

cc @samlambert @arfon 
