### PR TITLE
add pants BUILD file highlighting to languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1993,6 +1993,7 @@ Python:
   - wscript
   - SConstruct
   - SConscript
+  - BUILD
   interpreters:
   - python
 


### PR DESCRIPTION
the pants build tool uses python files named BUILD. This adds highlighting for them.
