### PR TITLE
Exclude minified JavaScript and CSS

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -36,9 +36,8 @@
 # Go dependencies
 - Godeps/_workspace/
 
-# Exclude minified JavaScript and CSS
-- \.min\.(js|css)$
-- -min\.js$
+# Minified JavaScript and CSS
+- (\.|-)min\.(js|css)$
 
 # Bootstrap css and js
 - (^|/)bootstrap([^.]*)\.(js|css)$

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -304,6 +304,14 @@ class TestBlob < Test::Unit::TestCase
     # Debian packaging
     assert blob("debian/cron.d").vendored?
 
+    # Minified JavaScript and CSS
+    assert blob("foo.min.js").vendored?
+    assert blob("foo.min.css").vendored?
+    assert blob("foo-min.js").vendored?
+    assert blob("foo-min.css").vendored?
+    assert !blob("foomin.css").vendored?
+    assert !blob("foo.min.txt").vendored?
+
     # Prototype
     assert !blob("public/javascripts/application.js").vendored?
     assert blob("public/javascripts/prototype.js").vendored?


### PR DESCRIPTION
Those files are either external libraries or builds of the repository itself. In any case they are generated automatically and shouldn't count in the language statistics. This also simplifies some of the rules that had to exclude both minified and normal dependencies.
