### PR TITLE
Consider all minified CSS and JS as vendored

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -15,6 +15,8 @@
 # Dependencies
 - ^[Dd]ependencies/
 
+- (\.|-)min\.(js|css)$
+
 # C deps
 #  https://github.com/joyent/node
 - ^deps/
@@ -36,15 +38,13 @@
 # Go dependencies
 - Godeps/_workspace/
 
-# Bootstrap minified css and js
-- (^|/)bootstrap([^.]*)(\.min)?\.(js|css)$
+# Bootstrap css and js
+- (^|/)bootstrap([^.]*)\.(js|css)$
 
 # Font Awesome
-- font-awesome.min.css
 - font-awesome.css
 
 # Foundation css
-- foundation.min.css
 - foundation.css
 
 # Normalize.css
@@ -56,7 +56,6 @@
 
 # Animate.css
 - animate.css
-- animate.min.css
 
 # Vendored dependencies
 - third[-_]?party/
@@ -73,12 +72,12 @@
 ## Commonly Bundled JavaScript frameworks ##
 
 # jQuery
-- (^|/)jquery([^.]*)(\.min)?\.js$
-- (^|/)jquery\-\d\.\d+(\.\d+)?(\.min)?\.js$
+- (^|/)jquery([^.]*)\.js$
+- (^|/)jquery\-\d\.\d+(\.\d+)?\.js$
 
 # jQuery UI
-- (^|/)jquery\-ui(\-\d\.\d+(\.\d+)?)?(\.\w+)?(\.min)?\.(js|css)$
-- (^|/)jquery\.(ui|effects)\.([^.]*)(\.min)?\.(js|css)$
+- (^|/)jquery\-ui(\-\d\.\d+(\.\d+)?)?(\.\w+)?\.(js|css)$
+- (^|/)jquery\.(ui|effects)\.([^.]*)\.(js|css)$
 
 # Prototype
 - (^|/)prototype(.*)\.js$
@@ -116,21 +115,20 @@
 - (^|/)shLegacy\.js$
 
 # AngularJS
-- (^|/)angular([^.]*)(\.min)?\.js$
+- (^|/)angular([^.]*)\.js$
 
 # D3.js
-- (^|\/)d3(\.v\d+)?([^.]*)(\.min)?\.js$
+- (^|\/)d3(\.v\d+)?([^.]*)\.js$
 
 # React
-- (^|/)react(-[^.]*)?(\.min)?\.js$
+- (^|/)react(-[^.]*)?\.js$
 
 # Modernizr
-- (^|/)modernizr\-\d\.\d+(\.\d+)?(\.min)?\.js$
+- (^|/)modernizr\-\d\.\d+(\.\d+)?\.js$
 - (^|/)modernizr\.custom\.\d+\.js$
 
 # Knockout
 - (^|/)knockout-(\d+\.){3}(debug\.)?js$
-- knockout-min.js
 
 ## Python ##
 
@@ -168,8 +166,8 @@
 - \.intellisense\.js$
 
 # jQuery validation plugin (MS bundles this with asp.net mvc)
-- (^|/)jquery([^.]*)\.validate(\.unobtrusive)?(\.min)?\.js$
-- (^|/)jquery([^.]*)\.unobtrusive\-ajax(\.min)?\.js$
+- (^|/)jquery([^.]*)\.validate(\.unobtrusive)?\.js$
+- (^|/)jquery([^.]*)\.unobtrusive\-ajax\.js$
 
 # Microsoft Ajax
 - (^|/)[Mm]icrosoft([Mm]vc)?([Aa]jax|[Vv]alidation)(\.debug)?\.js$
@@ -196,7 +194,7 @@
 - (^|/)extjs/welcome/
 
 # Html5shiv
-- (^|/)html5shiv(\.min)?\.js$
+- (^|/)html5shiv\.js$
 
 # Samples folders
 - ^[Ss]amples/
@@ -215,8 +213,8 @@
 - ^[Tt]est/fixtures/
 
 # PhoneGap/Cordova
-- (^|/)cordova([^.]*)(\.min)?\.js$
-- (^|/)cordova\-\d\.\d(\.\d)?(\.min)?\.js$
+- (^|/)cordova([^.]*)\.js$
+- (^|/)cordova\-\d\.\d(\.\d)?\.js$
 
 # Foundation js
 - foundation(\..*)?\.js$
@@ -236,7 +234,6 @@
 
 # Octicons
 - octicons.css
-- octicons.min.css
 - sprockets-octicons.scss
 
 # Typesafe Activator

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -451,6 +451,13 @@ class TestBlob < Test::Unit::TestCase
     assert blob("activator.bat").vendored?
     assert blob("subproject/activator").vendored?
     assert blob("subproject/activator.bat").vendored?
+
+    # Minified css and js
+    assert blob("foo.min.js").vendored?
+    assert blob("foo.min.css").vendored?
+    assert blob("foo-min.js").vendored?
+    assert blob("foo-min.css").vendored?
+    refute blob("abdomin.css").vendored?
   end
 
   def test_language


### PR DESCRIPTION
Suggested by @danijar in https://github.com/github/linguist/issues/1619, this considers all minified CSS and JS as vendored. I can't think of a use case where someone would want these to count toward language stats.

/cc @arfon?
