### PR TITLE
Use all languages returned by heuristics not just the first

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -134,7 +134,7 @@ module Linguist
           result.first
         # No shebang. Still more work to do. Try to find it with our heuristics.
         elsif (determined = Heuristics.find_by_heuristics(data, possible_language_names)) && !determined.empty?
-          determined.first
+          determined.length == 1 ? determined.first : Language[Classifier.classify(Samples.cache, data, possible_language_names.delete_if { |l| !determined.find { |d| d.name == l } }).first[0]]
         # Lastly, fall back to the probabilistic classifier.
         elsif classified = Classifier.classify(Samples.cache, data, possible_language_names).first
           # Return the actual Language object based of the string language name (i.e., first element of `#classify`)


### PR DESCRIPTION
Solution for issue https://github.com/github/linguist/issues/1656 

No accompanying tests, unsure what the best way to test this would be. Maybe the test could be setup by replacing Heuristics.find_by_heuristics with our test one, and setting up the Classifier with made up fixtures or something. And then just testing the correct language is returned. 

Code: Check if there is only one language returned by the heuristics, if so return that language (this behaves the same way it would in previous versions). If there are multiple filter out those which are not found in the possible language names array and use the classifier to determine which one it most likely is.
