### PR TITLE
Add spport for RAML language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2043,6 +2043,15 @@ R:
   interpreters:
   - Rscript
 
+RAML:
+  type: data
+  lexer: YAML
+  ace_mode: yaml
+  tm_scope: source.yaml
+  color: "#77d9fb"
+  extensions:
+    - .raml
+
 RDoc:
   type: prose
   lexer: Rd

--- a/samples/RAML/api.raml
+++ b/samples/RAML/api.raml
@@ -1,0 +1,39 @@
+#%RAML 0.8
+
+title: World Music API
+baseUri: http://example.api.com/{version}
+version: v1
+traits:
+  - paged:
+      queryParameters:
+        pages:
+          description: The number of pages to return
+          type: number
+  - secured: !include http://raml-example.com/secured.yml
+/songs:
+  is: [ paged, secured ]
+  get:
+    queryParameters:
+      genre:
+        description: filter the songs by genre
+  post:
+  /{songId}:
+    get:
+      responses:
+        200:
+          body:
+            application/json:
+              schema: |
+                { "$schema": "http://json-schema.org/schema",
+                  "type": "object",
+                  "description": "A canonical song",
+                  "properties": {
+                    "title":  { "type": "string" },
+                    "artist": { "type": "string" }
+                  },
+                  "required": [ "title", "artist" ]
+                }
+            application/xml:
+    delete:
+      description: |
+        This method will *delete* an **individual song**


### PR DESCRIPTION
RAML is an API specification language based upon the YAML syntax. More information is on RAML itself can be viewed at http://raml.org.
