### PR TITLE
Use MaskLexer for *.mask

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1490,7 +1490,7 @@ Markdown:
 
 Mask:
   type: markup
-  lexer: SCSS
+  lexer: Mask
   color: "#f97732"
   ace_mode: scss
   extensions:


### PR DESCRIPTION
Hello Team, 

it seems `pygments.rb` was updated, and the `MaskLexer` is included ([mapping](https://github.com/tmm1/pygments.rb/blob/master/vendor/pygments-main/pygments/lexers/_mapping.py#L214)), so this pr changes the lexer. 

Thank you, Alex
