### PR TITLE
Add a TextMate scope for .pytb files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2099,6 +2099,7 @@ Python traceback:
   searchable: false
   extensions:
   - .pytb
+  tm_scope: text.python.traceback
 
 QML:
   type: markup


### PR DESCRIPTION
This is the scope that Atom uses for these files. See https://github.com/atom/language-python/blob/master/grammars/python-traceback.cson

/cc @vmg @bkeepers 
