### PR TITLE
Add a TextMate scope for .sh-session files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2431,6 +2431,7 @@ ShellSession:
   aliases:
   - bash session
   - console
+  tm_scope: text.shell-session
 
 Shen:
   type: programming


### PR DESCRIPTION
Coming soon to Atom. See https://github.com/atom/language-shellscript/pull/3

/cc @vmg @bkeepers 
