### PR TITLE
Make it safe to pass nil to Language.find_by_name/alias again

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -164,7 +164,7 @@ module Linguist
     #
     # Returns the Language or nil if none was found.
     def self.find_by_name(name)
-      @name_index[name.downcase]
+      name && @name_index[name.downcase]
     end
 
     # Public: Look up Language by one of its aliases.
@@ -178,7 +178,7 @@ module Linguist
     #
     # Returns the Lexer or nil if none was found.
     def self.find_by_alias(name)
-      @alias_index[name.downcase]
+      name && @alias_index[name.downcase]
     end
 
     # Public: Look up Languages by filename.
@@ -243,7 +243,7 @@ module Linguist
     #
     # Returns the Language or nil if none was found.
     def self.[](name)
-      @index[name.downcase]
+      name && @index[name.downcase]
     end
 
     # Public: A List of popular languages

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -119,6 +119,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['VimL'], Language.find_by_alias('viml')
     assert_equal Language['reStructuredText'], Language.find_by_alias('rst')
     assert_equal Language['YAML'], Language.find_by_alias('yml')
+    assert_nil Language.find_by_alias(nil)
   end
 
   def test_groups
@@ -221,6 +222,7 @@ class TestLanguage < Test::Unit::TestCase
   end
 
   def test_find_by_name
+    assert_nil Language.find_by_name(nil)
     ruby = Language['Ruby']
     assert_equal ruby, Language.find_by_name('Ruby')
   end
@@ -317,6 +319,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal 'C#', Language['c#'].name
     assert_equal 'C#', Language['csharp'].name
     assert_nil Language['defunkt']
+    assert_nil Language[nil]
   end
 
   def test_find_ignores_case


### PR DESCRIPTION
This restores compatibility with v3.4.x.

/cc #1675
