### PR TITLE
Fix the tm_scope for Less

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1419,7 +1419,7 @@ Less:
   lexer: CSS
   extensions:
   - .less
-  tm_scope: source.css
+  tm_scope: source.css.less
 
 LilyPond:
   lexer: Text only


### PR DESCRIPTION
The `source.css.less` grammar actually understands Less syntax.
