### PR TITLE
Add a tm_scope for GAS

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -869,6 +869,7 @@ GAS:
   extensions:
   - .s
   - .S
+  tm_scope: source.asm.x86
 
 GDScript:
   type: programming


### PR DESCRIPTION
The `source.asm.x86` grammar does a decent job of parsing this.
