### PR TITLE
Add .mm as an XML extension

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -34,9 +34,6 @@ module Linguist
         if languages.all? { |l| ["AsciiDoc", "AGS Script"].include?(l) }
           result = disambiguate_asc(data, languages)
         end
-        if languages.all? { |l| ["XML", "Objective-C++"].include?(l) }
-          result = disambiguate_mm(data, languages)
-        end
         return result
       end
     end
@@ -124,16 +121,6 @@ module Linguist
     def self.disambiguate_asc(data, languages)
       matches = []
       matches << Language["AsciiDoc"] if /^=+(\s|\n)/.match(data)
-      matches
-    end
-
-    def self.disambiguate_mm(data, languages)
-      matches = []
-      if /<map version="[^"]+">/.match(data)
-        matches << Language["XML"]
-      else
-        matches << Language["Objective-C++"]
-      end
       matches
     end
 

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -122,16 +122,4 @@ class TestHeuristcs < Test::Unit::TestCase
     results = Heuristics.disambiguate_sc(fixture("Scala/node11.sc"), languages)
     assert_equal Language["Scala"], results.first
   end
-
-  def test_mm_objective_cpp_by_heuristics
-    languages = ["XML", "Objective-C++"]
-    results = Heuristics.disambiguate_mm(fixture("Objective-C++/objsql.mm"), languages)
-    assert_equal Language["Objective-C++"], results.first
-  end
-
-  def test_mm_xml_by_heuristics
-    languages = ["XML", "Objective-C++"]
-    results = Heuristics.disambiguate_mm(fixture("XML/some-ideas.mm"), languages)
-    assert_equal Language["XML"], results.first
-  end
 end


### PR DESCRIPTION
This pull request adds `.mm` as a file extension for XML as requested in #1690.
This conflicts with Objective-C++. I added a new heuristic rules to solve this.
All XML `.mm` files start with `<map version="[^"]+">`.

I tested  it on the following repositories:
- https://github.com/coolfluid/documents
- https://github.com/ArchieT/ingressmedal
- https://github.com/dokinkon/LecturePlayer
- https://github.com/wybosys/nnt
- https://github.com/roikr/openFrameworks007
- https://github.com/dmentre/re-demexp
- https://github.com/js-scala/samples
- https://github.com/sos-berlin/scheduler-engine-doc

All files were correctly detected.
