### PR TITLE
Use source.fortran.modern TM scope for FORTRAN

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -788,6 +788,7 @@ FORTRAN:
   - .f95
   - .for
   - .fpp
+  tm_scope: source.fortran.modern
 
 Factor:
   type: programming


### PR DESCRIPTION
This is technically only for FORTRAN 90 and newer, but seems to do just fine with older variants.
