### PR TITLE
use syntax hilighting for uncompilable codeblocks

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2300,6 +2300,8 @@ Ruby:
 Rust:
   type: programming
   color: "#dea584"
+  aliases:
+  - rust,ignore
   extensions:
   - .rs
 


### PR DESCRIPTION
the rust test-suite compiles all code examples in the documentation. Since some examples are not compilable, the docs often have {rust,ignore} as language for codeblocks. Syntax hilighting should still work for those docs