### PR TITLE
Programming type for Makefile

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1462,6 +1462,7 @@ MTML:
   tm_scope: text.html.basic
 
 Makefile:
+  type: programming
   aliases:
   - bsdmake
   - make


### PR DESCRIPTION
This pull request changes the type of Makefile from `nil` to `programming` as discussed in #1719.
