### PR TITLE
Update the URL for the source.pike grammar

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -1,6 +1,4 @@
 ---
-http://hww3.riverweb.com/dist/Pike_TextMate.tar.gz:
-- source.pike
 http://svn.edgewall.org/repos/genshi/contrib/textmate/Genshi.tmbundle/Syntaxes/Markup%20Template%20%28XML%29.tmLanguage:
 - text.xml.genshi
 http://svn.textmate.org/trunk/Review/Bundles/BlitzMax.tmbundle:
@@ -137,6 +135,8 @@ https://github.com/guillermooo/dart-sublime-bundle/raw/master/Dart.tmLanguage:
 - source.dart
 https://github.com/harrism/sublimetext-cuda-cpp/raw/master/cuda-c%2B%2B.tmLanguage:
 - source.cuda-c++
+https://github.com/hww3/pike-textmate:
+- source.pike
 https://github.com/jeancharles-roger/ceylon-sublimetext/raw/master/Ceylon.tmLanguage:
 - source.ceylon
 https://github.com/jfairbank/Sublime-Text-2-OpenEdge-ABL:


### PR DESCRIPTION
It's now hosted on GitHub and has a clearer license.

/cc @vmg
