### PR TITLE
Allow mime-types 2.x to be used with Linguist

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'charlock_holmes', '~> 0.7.3'
   s.add_dependency 'escape_utils',    '~> 1.0.1'
-  s.add_dependency 'mime-types',      '~> 1.19'
+  s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '~> 0.22.0b1'
 
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
The API is compatible for our purposes, and this allows Linguist to be used in apps that pull in newer versions of mime-types through other gems.

/cc @arfon @bkeepers 
