### PR TITLE
Exclude codemirror

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -110,6 +110,9 @@
 # MathJax
 - (^|/)MathJax/
 
+# Codemirror
+- (^|/)[Cc]ode[Mm]irror/(lib|mode|theme|addon|keymap)
+
 # SyntaxHighlighter - http://alexgorbatchev.com/
 - (^|/)shBrush([^.]*)\.js$
 - (^|/)shCore\.js$


### PR DESCRIPTION
Codemirror is a very popular on the browser editor, bundle with many other projects. 
An example of a wrong detection due to codemirror is my project.  https://github.com/mgaitan/waliki
