### PR TITLE
Use a SQF grammar for SQF files

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -38,6 +38,8 @@ https://github.com/Drako/SublimeBrainfuck/raw/master/Brainfuck.tmLanguage:
 - source.bf
 https://github.com/JohnNilsson/awk-sublime/raw/master/AWK.tmLanguage:
 - source.awk
+https://github.com/JonBons/Sublime-SQF-Language:
+- source.sqf
 https://github.com/MarioRicalde/SCSS.tmbundle:
 - source.scss
 https://github.com/Oldes/Sublime-REBOL:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2214,7 +2214,7 @@ SQF:
   extensions:
   - .sqf
   - .hqf
-  tm_scope: source.c++
+  tm_scope: source.sqf
 
 SQL:
   type: data


### PR DESCRIPTION
This produces better highlighting than using the C++ grammar.

The grammar is licensed under the Apache 2.0 license.

/cc @vmg @bkeepers 
