### PR TITLE
Fix RHTML's tm_scope

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2066,7 +2066,7 @@ RHTML:
   group: HTML
   extensions:
   - .rhtml
-  tm_scope: text.html.ruby
+  tm_scope: text.html.erb
   aliases:
   - html+ruby
 


### PR DESCRIPTION
I missed this back in 9595e2ba7e63b584e2a32cdee3c86ad9ffccf261.
