### PR TITLE
add language grammar for Isabelle theorem prover

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -408,3 +408,5 @@ https://github.com/vmg/zephir-sublime:
 - source.php.zephir
 https://github.com/whitequark/llvm.tmbundle:
 - source.llvm
+https://github.com/lsf37/Isabelle.tmbundle:
+- source.isabelle.theory

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1211,7 +1211,7 @@ Isabelle:
   color: "#fdcd00"
   extensions:
   - .thy
-  tm_scope: none
+  tm_scope: source.isabelle.theory
 
 J:
   type: programming


### PR DESCRIPTION
This pull requests adds tmbundle for syntax highlighting of theory files of the Isabelle theorem prover.

The language is already recognised by linguist and has a sample file `/samples/Isabelle/HelloWorld.thy`. Used on github for instance in https://github.com/seL4/l4v or https://github.com/seL4/isabelle
