### PR TITLE
Added CFC file type to ColdFusion language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -482,6 +482,7 @@ ColdFusion:
   extensions:
   - .cfm
   - .cfml
+  - .cfc
   tm_scope: text.html.cfm
 
 ColdFusion CFC:


### PR DESCRIPTION
Ideally should have removed ColdFusion CFC but some of my projects are going to use CFC files only but dont want them to be listed under ColdFusion CFC would rather have them listed them under ColdFusion.
