### PR TITLE
Fix detection for invalid shebang

### DIFF
--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -19,7 +19,7 @@ module Linguist
     # Returns a String or nil
     def self.interpreter(data)
       lines = data.lines
-      return unless match = /^#! ?(.*)$/.match(lines.first)
+      return unless match = /^#! ?(.+)$/.match(lines.first)
 
       tokens = match[1].split(' ')
       script = tokens.first.split('/').last

--- a/test/test_shebang.rb
+++ b/test/test_shebang.rb
@@ -16,6 +16,7 @@ class TestShebang < Test::Unit::TestCase
     assert_interpreter nil, "\n\n\n\n\n"
     assert_interpreter nil, " #!/usr/sbin/ruby"
     assert_interpreter nil, "\n#!/usr/sbin/ruby"
+    assert_interpreter nil, "#!"
 
     assert_interpreter "ruby", "#!/usr/sbin/ruby\n# bar"
     assert_interpreter "ruby", "#!/usr/bin/ruby\n# foo"


### PR DESCRIPTION
A file with the first line matching `/^#!$/` currently causes an exception. This fixes the regex to require some other content.

/cc @arfon @jakedouglas 
