### PR TITLE
SaltStack state files use the same extension as old scheme library source files

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -156,5 +156,9 @@ module Linguist
       end
     end
 
+    disambiguate "Scheme", "YAML+Jinja" do |data|
+      Language["Scheme"] if /^\(/.match(data)
+    end
+
   end
 end

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2893,6 +2893,14 @@ YAML:
   - .rviz
   - .yaml
 
+YAML+Jinja:
+  type: data
+  tm_scope: source.yaml
+  aliases:
+    - saltstate
+  extensions:
+    - .sls
+
 Zephir:
   type: programming
   color: "#118f9e"


### PR DESCRIPTION
Add support for detecting the difference between scheme library source files
and SaltStack state files (which are technically YAML+Jinja).

Add languages entry and a disambiguation entry that should work in 99% of cases
(at least I can't think of a better way).