### PR TITLE
Python syntax highlighting for Snakemake files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2320,7 +2320,7 @@ Python:
   - BUILD
   - SConscript
   - SConstruct
-  - Snakemake
+  - Snakefile
   - wscript
   interpreters:
   - python


### PR DESCRIPTION
Files 'Snakefile' should have Python highlighting. These files are used by Snakemake (https://bitbucket.org/johanneskoester/snakemake), a Make-like build software which uses Python syntax. 
