### PR TITLE
MaskLang: Use proper tm scope

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -420,3 +420,5 @@ https://github.com/wmertens/sublime-nix:
 - source.nix
 https://raw.githubusercontent.com/eregon/oz-tmbundle/master/Syntaxes/Oz.tmLanguage:
 - source.oz
+https://raw.githubusercontent.com/tenbits/sublime-mask/release/Syntaxes/mask.tmLanguage:
+- source.mask

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1719,7 +1719,7 @@ Mask:
   ace_mode: mask
   extensions:
   - .mask
-  tm_scope: source.scss
+  tm_scope: source.mask
 
 Mathematica:
   type: programming


### PR DESCRIPTION
Hello Team,

adding here the correct `tm` scope for the Mask syntax and the corresponding grammar. 

Thank you for your time, Alex
