### PR TITLE
Treat .sketchcs/.sketchfs files as markdown

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1711,6 +1711,8 @@ Markdown:
   - .mkdn
   - .mkdown
   - .ron
+  - .sketchcs
+  - .sketchfs
   tm_scope: text.html.markdown
 
 Mask:


### PR DESCRIPTION
Xamarin sketch files are interactive coding documents for C# and F#,
serialized as markdown files.

An example is available here: https://github.com/xamarin/sketches/blob/monodevelop-5.7-branch/Basics/basics.sketchcs
