### PR TITLE
Add support for Turtle and SPARQL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -546,3 +546,6 @@
 [submodule "vendor/grammars/Racket"]
 	path = vendor/grammars/Racket
 	url = https://github.com/soegaard/racket-highlight-for-github
+[submodule "vendor/grammars/turtle.tmbundle"]
+	path = vendor/grammars/turtle.tmbundle
+	url = https://github.com/peta/turtle.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -452,6 +452,9 @@ vendor/grammars/thrift.tmbundle:
 - source.thrift
 vendor/grammars/toml.tmbundle:
 - source.toml
+vendor/grammars/turtle.tmbundle:
+- source.sparql
+- source.turtle
 vendor/grammars/verilog.tmbundle:
 - source.verilog
 vendor/grammars/x86-assembly-textmate-bundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2613,6 +2613,14 @@ SCSS:
   extensions:
   - .scss
 
+SPARQL:
+  type: data
+  tm_scope: source.sparql
+  ace_mode: text
+  extensions:
+  - .sparql
+  - .rq
+
 SQF:
   type: programming
   color: "#FFCB1F"
@@ -2968,6 +2976,13 @@ Turing:
   - .t
   - .tu
   tm_scope: none
+  ace_mode: text
+
+Turtle:
+  type: data
+  extensions:
+  - .ttl
+  tm_scope: source.turtle
   ace_mode: text
 
 Twig:

--- a/samples/SPARQL/foaf.sparql
+++ b/samples/SPARQL/foaf.sparql
@@ -1,0 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?name ?email
+WHERE {
+  ?person a foaf:Person.
+  ?person foaf:name ?name.
+  ?person foaf:mbox ?email.
+}

--- a/samples/SPARQL/string-matching.sparql
+++ b/samples/SPARQL/string-matching.sparql
@@ -1,0 +1,40 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?s ?label
+WHERE {
+  SERVICE <http://api.finto.fi/sparql>
+  {
+    SELECT DISTINCT ?s ?label ?plabel ?alabel ?hlabel (GROUP_CONCAT(DISTINCT STR(?type)) as ?types)
+    WHERE {
+      GRAPH <http://www.yso.fi/onto/kauno/>
+      {
+      ?s rdf:type <http://www.w3.org/2004/02/skos/core#Concept>
+      {
+       ?s rdf:type ?type .
+       ?s ?prop ?match .
+       FILTER (
+        strstarts(lcase(str(?match)), "test") && !(?match != ?label && strstarts(lcase(str(?label)), "test"))
+       )
+       OPTIONAL {
+        ?s skos:prefLabel ?label .
+        FILTER (langMatches(lang(?label), "en"))
+       }
+       OPTIONAL { # in case previous OPTIONAL block gives no labels
+         ?s ?prop ?match .
+         ?s skos:prefLabel ?label .
+         FILTER (langMatches(lang(?label), lang(?match))) }
+      }
+      FILTER NOT EXISTS { ?s owl:deprecated true }
+     }
+     BIND(IF(?prop = skos:prefLabel && ?match != ?label, ?match, "") as ?plabel)
+     BIND(IF(?prop = skos:altLabel, ?match, "") as ?alabel)
+     BIND(IF(?prop = skos:hiddenLabel, ?match, "") as ?hlabel)
+     VALUES (?prop) { (skos:prefLabel) (skos:altLabel) (skos:hiddenLabel) }
+    }
+    GROUP BY ?match ?s ?label ?plabel ?alabel ?hlabel ?prop
+    ORDER BY lcase(str(?match)) lang(?match)
+    LIMIT 10
+  }
+}

--- a/samples/Turtle/gnd-record.ttl
+++ b/samples/Turtle/gnd-record.ttl
@@ -1,0 +1,183 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix gndo: <http://d-nb.info/standards/elementset/gnd#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://d-nb.info/gnd/118514768>
+  a <http://d-nb.info/standards/elementset/gnd#Pseudonym> ;
+  foaf:page <http://de.wikipedia.org/wiki/Bertolt_Brecht> ;
+  owl:sameAs <http://dbpedia.org/resource/Bertolt_Brecht>, <http://viaf.org/viaf/2467372>, <http://www.filmportal.de/person/261E2D3A93D54134BF8AB5F21F0B2399> ;
+  gndo:gndIdentifier "118514768" ;
+  gndo:oldAuthorityNumber "(DE-588)1022091077", "(DE-588a)118514768", "(DE-588a)141399074", "(DE-588a)139089691", "(DE-588a)141300248", "(DE-588a)136949541", "(DE-588a)134336232", "(DE-588a)12794544X", "(DE-588a)12736630X", "(DE-588a)12722811X", "(DE-588a)127228098", "(DE-588a)127228101" ;
+  gndo:variantNameForThePerson "Brêcht, Becton", "Brecht, Bert", "Brecht, Bertolʹ", "Brecht, Berthold", "Brecht, Bertholt", "Brecht, Bertold", "Brecht, B.", "Brecht, Eugen Berthold Friedrich", "Brecht, ...", "Brecht-Eisler, ...", "Becht, Bertolt", "Beituo'erte-Bulaixite", "Berchito, B.", "Brechtas, B.", "Brechts, Bertolts", "Brehd, Berd", "Breht, Bertolt", "Brehts, Bertolts", "Breḳhṭ, Bārṭolṭ", "Brekt, Berṭolṭ", "Brekṭ, Berṭōlṭ", "Breḳṭ, Berṭôlṭ", "Breśṭ, Berṭalṭa", "Breṣṭa, Barṭolṭa", "Brišt, Bartūlt", "Brišt, Birtūld", "Brišt, Birtult", "Buchito, Berutorutu", "Bulaixite, Beituo'erte", "Bulaixite, ...", "Burehito, Berutoruto", "Burehito, ...", "B. B.", "Larsen, Berthold", "Mprecht, Mpertolt", "Mprecht, ...", "Pulaihsit'ê, Peit'oĉrht'ê", "Pulaihsit'ê, ...", "Pŭrehit'ŭ, Peŏt'olt'ŭ", "Bŭrehit'ŭ, Beŏt'olt'ŭ", "برشت، برتولد", "브레히트, 베르톨트", "ברכט, ברטולט", "贝·布莱希特", "布莱希特, 贝", "ブレヒト, ベルトルト" ;
+  gndo:variantNameEntityForThePerson [
+    gndo:forename "Becton" ;
+    gndo:surname "Brêcht"
+  ], [
+    gndo:forename "Bert" ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "Bertolʹ" ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "Berthold" ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "Bertholt" ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "Bertold" ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "B." ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "Eugen Berthold Friedrich" ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "..." ;
+    gndo:surname "Brecht"
+  ], [
+    gndo:forename "..." ;
+    gndo:surname "Brecht-Eisler"
+  ], [
+    gndo:forename "Bertolt" ;
+    gndo:surname "Becht"
+  ], [ gndo:personalName "Beituo'erte-Bulaixite" ], [
+    gndo:forename "B." ;
+    gndo:surname "Berchito"
+  ], [
+    gndo:forename "B." ;
+    gndo:surname "Brechtas"
+  ], [
+    gndo:forename "Bertolts" ;
+    gndo:surname "Brechts"
+  ], [
+    gndo:forename "Berd" ;
+    gndo:surname "Brehd"
+  ], [
+    gndo:forename "Bertolt" ;
+    gndo:surname "Breht"
+  ], [
+    gndo:forename "Bertolts" ;
+    gndo:surname "Brehts"
+  ], [
+    gndo:forename "Bārṭolṭ" ;
+    gndo:surname "Breḳhṭ"
+  ], [
+    gndo:forename "Berṭolṭ" ;
+    gndo:surname "Brekt"
+  ], [
+    gndo:forename "Berṭōlṭ" ;
+    gndo:surname "Brekṭ"
+  ], [
+    gndo:forename "Berṭôlṭ" ;
+    gndo:surname "Breḳṭ"
+  ], [
+    gndo:forename "Berṭalṭa" ;
+    gndo:surname "Breśṭ"
+  ], [
+    gndo:forename "Barṭolṭa" ;
+    gndo:surname "Breṣṭa"
+  ], [
+    gndo:forename "Bartūlt" ;
+    gndo:surname "Brišt"
+  ], [
+    gndo:forename "Birtūld" ;
+    gndo:surname "Brišt"
+  ], [
+    gndo:forename "Birtult" ;
+    gndo:surname "Brišt"
+  ], [
+    gndo:forename "Berutorutu" ;
+    gndo:surname "Buchito"
+  ], [
+    gndo:forename "Beituo'erte" ;
+    gndo:surname "Bulaixite"
+  ], [
+    gndo:forename "..." ;
+    gndo:surname "Bulaixite"
+  ], [
+    gndo:forename "Berutoruto" ;
+    gndo:surname "Burehito"
+  ], [
+    gndo:forename "..." ;
+    gndo:surname "Burehito"
+  ], [ gndo:personalName "B. B." ], [
+    gndo:forename "Berthold" ;
+    gndo:surname "Larsen"
+  ], [
+    gndo:forename "Mpertolt" ;
+    gndo:surname "Mprecht"
+  ], [
+    gndo:forename "..." ;
+    gndo:surname "Mprecht"
+  ], [
+    gndo:forename "Peit'oĉrht'ê" ;
+    gndo:surname "Pulaihsit'ê"
+  ], [
+    gndo:forename "..." ;
+    gndo:surname "Pulaihsit'ê"
+  ], [
+    gndo:forename "Peŏt'olt'ŭ" ;
+    gndo:surname "Pŭrehit'ŭ"
+  ], [
+    gndo:forename "Beŏt'olt'ŭ" ;
+    gndo:surname "Bŭrehit'ŭ"
+  ], [ gndo:personalName "برشت، برتولد" ], [
+    gndo:forename "베르톨트" ;
+    gndo:surname "브레히트"
+  ], [
+    gndo:forename "ברטולט" ;
+    gndo:surname "ברכט"
+  ], [ gndo:personalName "贝·布莱希特" ], [
+    gndo:forename "贝" ;
+    gndo:surname "布莱希特"
+  ], [
+    gndo:forename "ベルトルト" ;
+    gndo:surname "ブレヒト"
+  ] ;
+  gndo:preferredNameForThePerson "Brecht, Bertolt" ;
+  gndo:preferredNameEntityForThePerson [
+    gndo:forename "Bertolt" ;
+    gndo:surname "Brecht"
+  ] ;
+  gndo:familialRelationship <http://d-nb.info/gnd/121608557>, <http://d-nb.info/gnd/119056011>, <http://d-nb.info/gnd/118738348>, <http://d-nb.info/gnd/137070411>, <http://d-nb.info/gnd/118809849>, <http://d-nb.info/gnd/119027615>, <http://d-nb.info/gnd/118940163>, <http://d-nb.info/gnd/118630091>, <http://d-nb.info/gnd/123783283>, <http://d-nb.info/gnd/118940155>, <http://d-nb.info/gnd/110005449>, <http://d-nb.info/gnd/13612495X>, <http://d-nb.info/gnd/123757398>, <http://d-nb.info/gnd/1030496250>, <http://d-nb.info/gnd/1030496366> ;
+  gndo:professionOrOccupation <http://d-nb.info/gnd/4185053-1>, <http://d-nb.info/gnd/4140241-8>, <http://d-nb.info/gnd/4052154-0>, <http://d-nb.info/gnd/4168391-2>, <http://d-nb.info/gnd/4053309-8>, <http://d-nb.info/gnd/4049050-6>, <http://d-nb.info/gnd/4294338-3> ;
+  gndo:playedInstrument <http://d-nb.info/gnd/4057587-1> ;
+  gndo:gndSubjectCategory <http://d-nb.info/standards/vocab/gnd/gnd-sc#12.2p>, <http://d-nb.info/standards/vocab/gnd/gnd-sc#15.1p>, <http://d-nb.info/standards/vocab/gnd/gnd-sc#15.3p> ;
+  gndo:geographicAreaCode <http://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+  gndo:languageCode <http://id.loc.gov/vocabulary/iso639-2/ger> ;
+  gndo:placeOfBirth <http://d-nb.info/gnd/4003614-5> ;
+  gndo:placeOfDeath <http://d-nb.info/gnd/4005728-8> ;
+  gndo:placeOfExile <http://d-nb.info/gnd/4010877-6>, <http://d-nb.info/gnd/4077258-5> ;
+  gndo:gender <http://d-nb.info/standards/vocab/gnd/Gender#male> ;
+  gndo:dateOfBirth "1898-02-10"^^xsd:date ;
+  gndo:dateOfDeath "1956-08-14"^^xsd:date .
+
+<http://d-nb.info/gnd/121608557> gndo:preferredNameForThePerson "Brecht, Berthold Friedrich" .
+<http://d-nb.info/gnd/119056011> gndo:preferredNameForThePerson "Banholzer, Paula" .
+<http://d-nb.info/gnd/118738348> gndo:preferredNameForThePerson "Neher, Carola" .
+<http://d-nb.info/gnd/137070411> gndo:preferredNameForThePerson "Banholzer, Frank" .
+<http://d-nb.info/gnd/118809849> gndo:preferredNameForThePerson "Berlau, Ruth" .
+<http://d-nb.info/gnd/119027615> gndo:preferredNameForThePerson "Steffin, Margarete" .
+<http://d-nb.info/gnd/118940163> gndo:preferredNameForThePerson "Zoff, Marianne" .
+<http://d-nb.info/gnd/118630091> gndo:preferredNameForThePerson "Weigel, Helene" .
+<http://d-nb.info/gnd/123783283> gndo:preferredNameForThePerson "Reichel, Käthe" .
+<http://d-nb.info/gnd/118940155> gndo:preferredNameForThePerson "Hiob, Hanne" .
+<http://d-nb.info/gnd/110005449> gndo:preferredNameForThePerson "Brecht, Stefan" .
+<http://d-nb.info/gnd/13612495X> gndo:preferredNameForThePerson "Brecht-Schall, Barbara" .
+<http://d-nb.info/gnd/123757398> gndo:preferredNameForThePerson "Schall, Ekkehard" .
+<http://d-nb.info/gnd/1030496250> gndo:preferredNameForThePerson "Brezing, Joseph Friedrich" .
+<http://d-nb.info/gnd/1030496366> gndo:preferredNameForThePerson "Brezing, Friederike" .
+<http://d-nb.info/gnd/4185053-1> gndo:preferredNameForTheSubjectHeading "Theaterregisseur" .
+<http://d-nb.info/gnd/4140241-8> gndo:preferredNameForTheSubjectHeading "Dramatiker" .
+<http://d-nb.info/gnd/4052154-0> gndo:preferredNameForTheSubjectHeading "Schauspieler" .
+<http://d-nb.info/gnd/4168391-2> gndo:preferredNameForTheSubjectHeading "Lyriker" .
+<http://d-nb.info/gnd/4053309-8> gndo:preferredNameForTheSubjectHeading "Schriftsteller" .
+<http://d-nb.info/gnd/4049050-6> gndo:preferredNameForTheSubjectHeading "Regisseur" .
+<http://d-nb.info/gnd/4294338-3> gndo:preferredNameForTheSubjectHeading "Drehbuchautor" .
+<http://d-nb.info/gnd/4003614-5> gndo:preferredNameForThePlaceOrGeographicName "Augsburg" .
+<http://d-nb.info/gnd/4005728-8> gndo:preferredNameForThePlaceOrGeographicName "Berlin" .
+<http://d-nb.info/gnd/4010877-6> gndo:preferredNameForThePlaceOrGeographicName "Dänemark" .
+<http://d-nb.info/gnd/4077258-5> gndo:preferredNameForThePlaceOrGeographicName "Schweden" .

--- a/samples/Turtle/rdf-syntax-grammar.ttl
+++ b/samples/Turtle/rdf-syntax-grammar.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix ex: <http://example.org/stuff/1.0/> .
+
+<http://www.w3.org/TR/rdf-syntax-grammar>
+  dc:title "RDF/XML Syntax Specification (Revised)" ;
+  ex:editor [
+    ex:fullname "Dave Beckett";
+    ex:homePage <http://purl.org/net/dajobe/>
+  ] .


### PR DESCRIPTION
Tried adding support for [Turtle](http://www.w3.org/TR/turtle/) and [SPARQL](http://www.w3.org/TR/sparql11-overview/). Got 3 errors when running the test suite both before and after adding my changes – at least the number of errors didn't increase :)

Extensions:
- [.ttl](https://github.com/search?utf8=%E2%9C%93&q=title+extension%3Attl&type=Code&ref=searchresults)
- [.sparql](https://github.com/search?utf8=%E2%9C%93&q=title+extension%3Asparql&type=Code&ref=searchresults)
- [.rq](https://github.com/search?utf8=%E2%9C%93&q=title+extension%3Arq&type=Code&ref=searchresults)