### PR TITLE
Adding 'erlang.mk' to vendor.yml exclusion list.

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -32,6 +32,7 @@
 
 # Erlang bundles
 - ^rebar$
+- erlang.mk
 
 # Go dependencies
 - Godeps/_workspace/


### PR DESCRIPTION
Adding 'erlang.mk' to list of erlang bundles; it's seeing some adoption in the Erlang community for building Erlang apps, and at 1k lines of code at present can dominate an initial check-in, project skeleton, or small library.

See https://github.com/ninenines/erlang.mk for further details.
