### PR TITLE
Improve FORTRAN heuristic.

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -129,7 +129,7 @@ module Linguist
     disambiguate "FORTRAN", "Forth" do |data|
       if /^: /.match(data)
         Language["Forth"]
-      elsif /^([c*][^a-z]|      subroutine\s)/i.match(data)
+      elsif /^([c*][^a-z]|      (subroutine|program)\s|!)/i.match(data)
         Language["FORTRAN"]
       end
     end


### PR DESCRIPTION
Minor tweak for the FORTRAN heuristic.  Misidentified files can be found with searches like these:

http://github.com/search?q=language%3Aforth+program+integer&type=Code
http://github.com/search?q=language%3Aforth+subroutine&type=Code
