### PR TITLE
Add a bunch of C header samples for the Bayesian classifier

### DIFF
--- a/samples/C/bitmap.h
+++ b/samples/C/bitmap.h
@@ -1,0 +1,47 @@
+#pragma once
+
+/* Copyright © 2010 Christoph Sünderhauf
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "generic.h"
+
+typedef struct {
+	uint32_t numbits;
+	/* an array large enough for numbits to fit in. Might 
+	 * (if numbits%8!=0) have some spare bits at the end
+	 */
+	uint32_t* bits;
+} bitmap_t;
+
+
+// creates a new bitmap.
+// CONTENT IS RANDOM!  - use bitmap_clearall() to clear the bitmap.
+bitmap_t bitmap_init(uint32_t numbits);
+
+// returns 1 or 0
+uint8_t bitmap_get(bitmap_t bitmap, uint32_t bitnum);
+// sets a bit (to 1)
+void bitmap_set(bitmap_t bitmap, uint32_t bitnum);
+// clears a bit (to 0)
+void bitmap_clear(bitmap_t bitmap, uint32_t bitnum);
+
+// clears every bit to 0
+void bitmap_clearAll(bitmap_t bitmap);
+
+// finds the first bit set to 0    returns 0 if no cleared bit found (0 is also returned if the first bit is cleared)
+uint32_t bitmap_findFirstClear(bitmap_t bitmap);

--- a/samples/C/color.h
+++ b/samples/C/color.h
@@ -1,0 +1,44 @@
+#pragma once
+
+/* Copyright © 2011 Fritz Grimpen
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+
+typedef struct {
+	uint32_t background;
+	uint32_t foreground;
+} console_color_t;
+
+#define CONSOLE_COLOR_BLACK    0x0
+#define CONSOLE_COLOR_BLUE     0x1
+#define CONSOLE_COLOR_GREEN    0x2
+#define CONSOLE_COLOR_CYAN     0x3
+#define CONSOLE_COLOR_RED      0x4
+#define CONSOLE_COLOR_MAGENTA  0x5
+#define CONSOLE_COLOR_BROWN    0x6
+#define CONSOLE_COLOR_LGREY    0x7
+#define CONSOLE_COLOR_DGREY    0x8
+#define CONSOLE_COLOR_LBLUE    0x9
+#define CONSOLE_COLOR_LGREEN   0xa
+#define CONSOLE_COLOR_LCYAN    0xb
+#define CONSOLE_COLOR_LRED     0xc
+#define CONSOLE_COLOR_LMAGENTA 0xd
+#define CONSOLE_COLOR_YELLOW   0xe
+#define CONSOLE_COLOR_WHITE    0xf
+

--- a/samples/C/driver.h
+++ b/samples/C/driver.h
@@ -1,0 +1,52 @@
+#pragma once
+
+/* Copyright © 2011 Fritz Grimpen
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <console/info.h>
+
+#define CONSOLE_DRV_CAP_CLEAR 0x01
+#define CONSOLE_DRV_CAP_SCROLL  0x02
+#define CONSOLE_DRV_CAP_SET_CURSOR 0x04
+
+// Input modifier keys
+typedef struct {
+	bool shift_left:1;
+	bool shift_right:1;
+	bool control_left:1;
+	bool control_right:1;
+	bool alt:1;
+	bool super:1;
+} console_modifiers_t;
+
+typedef struct {
+	char character;
+	console_modifiers_t* modifiers;
+} console_read_t;
+
+typedef struct {
+	int (*write)(console_info_t*, char);
+	console_read_t* (*read)(console_info_t*);
+
+	int capabilities;
+
+	int (*_clear)(console_info_t*);
+	int (*scroll)(console_info_t*, int32_t);
+	void (*setCursor)(console_info_t*, uint32_t, uint32_t);
+} console_driver_t;

--- a/samples/C/elf.h
+++ b/samples/C/elf.h
@@ -1,0 +1,70 @@
+#pragma once
+
+/* Copyright © 2011 Lukas Martini
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <tasks/scheduler.h>
+
+#define ELF_TYPE_NONE 0
+#define ELF_TYPE_REL 1
+#define ELF_TYPE_EXEC 2
+#define ELF_TYPE_DYN 3
+#define ELF_TYPE_CORE 4
+
+#define ELF_ARCH_NONE 0
+#define ELF_ARCH_386 3
+
+#define ELF_VERSION_CURRENT 1
+
+typedef struct {
+	unsigned char magic[4];
+	/* Note: There _is_ other stuff in here, but we don't need it */
+	unsigned char pad[12]; 
+} __attribute__((packed)) elf_ident_t;
+
+typedef struct {
+	uint32_t    type;
+	uint32_t    offset;
+	void*		virtaddr;
+	void*		physaddr;
+	uint32_t    filesize;
+	uint32_t    memsize;
+	uint32_t    flags;
+	uint32_t    alignment;
+} __attribute__((packed)) elf_program_t;
+
+typedef struct {
+	elf_ident_t ident;
+	uint16_t	type;		/* Object file type */
+	uint16_t	machine;	/* Architecture */
+	uint32_t	version;	/* Object file version */
+	void*		entry;		/* Entry point virtual address */
+	uint32_t	phoff;		/* Program header table file offset */
+	uint32_t	shoff;		/* Section header table file offset */
+	uint32_t	flags;		/* Processor-specific flags */
+	uint16_t	ehsize;		/* ELF header size in bytes */
+	uint16_t	phentsize;	/* Program header table entry size */
+	uint16_t	phnum;		/* Program header table entry count */
+	uint16_t	shentsize;	/* Section header table entry size */
+	uint16_t	shnum;		/* Section header table entry count */
+	uint16_t	shstrndx;	/* Section header string table index */
+} __attribute__((packed)) elf_t;
+
+task_t* elf_load(elf_t* bin, char* name, char** environ, char** argv, int argc);
+task_t* elf_load_file(char* path, char** environ, char** argv, int argc);

--- a/samples/C/filter.h
+++ b/samples/C/filter.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/* Copyright © 2011 Fritz Grimpen
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <console/info.h>
+#include <console/driver.h>
+
+struct console_filter {
+	// General callback for all actions etc.
+	// Preferred prototype:
+	// char <name>(char c, console_info_t *info, console_driver_t *input, console_driver_t *output);
+	char (*callback)(char, console_info_t*, console_driver_t*, console_driver_t*);
+
+	// Specific callbacks for read and write
+	// Preferred prototype:
+	// char <name>(char c, console_info_t *info, console_driver_t *input);
+	char (*read_callback)(char, console_info_t*, console_driver_t*);
+
+	// Preferred prototype:
+	// char <name>(char c, console_info_t *info, console_driver_t *output);
+	char (*write_callback)(char, console_info_t*, console_driver_t*);
+
+	// The next filter in the filter chain
+	struct console_filter* next;
+};
+
+typedef struct console_filter console_filter_t;
+

--- a/samples/C/info.h
+++ b/samples/C/info.h
@@ -1,0 +1,44 @@
+#pragma once
+
+/* Copyright © 2011 Fritz Grimpen
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <console/color.h>
+
+typedef struct {
+	uint32_t cursor_x;
+	uint32_t cursor_y;
+
+	uint32_t rows;
+	uint32_t columns;
+
+	uint32_t tabstop;
+
+	console_color_t default_color;
+	console_color_t current_color;
+
+	uint8_t nonblocking;
+	uint8_t reverse_video;
+	uint8_t bold;
+	uint8_t blink;
+	uint8_t underline;
+	uint8_t newline_mode;
+	uint8_t auto_echo;
+	uint8_t handle_backspace;
+} console_info_t;

--- a/samples/C/interface.h
+++ b/samples/C/interface.h
@@ -1,0 +1,47 @@
+#pragma once
+
+/* Copyright © 2011 Fritz Grimpen
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <console/info.h>
+#include <console/filter.h>
+#include <console/driver.h>
+
+typedef struct {
+	console_info_t info;
+
+	console_filter_t* input_filter;
+	console_filter_t* output_filter;
+
+	console_driver_t* input_driver;
+	console_driver_t* output_driver;
+} console_t;
+
+console_t* default_console;
+
+// Generate raw console, connected to the Display, Keyboard and the
+// ECMA-48-Filter
+void console_init();
+
+size_t console_write(console_t* console, const char* buffer, int32_t length);
+#define console_write2(console, buffer) console_write(console, buffer, strlen(buffer))
+size_t console_read(console_t* console, char* buffer, size_t length);
+size_t console_scroll(console_t* console, int32_t pages);
+
+void console_clear(console_t* console);

--- a/samples/C/ip4.h
+++ b/samples/C/ip4.h
@@ -1,0 +1,50 @@
+#pragma once
+
+/* Copyright © 2011 Lukas Martini
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <net/net.h>
+
+#define IP4_TOS_ICMP 0
+
+typedef uint32_t ip4_addr_t;
+
+typedef struct {
+	unsigned int hl:4; /* both fields are 4 bits */
+	unsigned int version:4;
+	uint8_t	tos;
+	uint16_t len;
+	uint16_t id;
+	uint16_t off;
+	uint8_t ttl;
+	uint8_t p;
+	uint16_t checksum;
+	ip4_addr_t src;
+	ip4_addr_t dst;
+} ip4_header_t;
+
+typedef struct {
+	uint8_t type;
+	uint8_t code;
+	uint16_t checksum;
+	uint16_t id;
+	uint16_t sequence;
+} ip4_icmp_header_t;
+
+void ip4_receive(net_device_t* origin, net_l2proto_t proto, size_t size, void* raw);

--- a/samples/C/multiboot.h
+++ b/samples/C/multiboot.h
@@ -1,0 +1,110 @@
+#pragma once
+
+/* Copyright © 2010, 2011 Lukas Martini
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+
+#define MULTIBOOT_KERNELMAGIC 0x2BADB002
+
+#define MULTIBOOT_FLAG_MEM	 0x001
+#define MULTIBOOT_FLAG_DEVICE  0x002
+#define MULTIBOOT_FLAG_CMDLINE 0x004
+#define MULTIBOOT_FLAG_MODS	0x008
+#define MULTIBOOT_FLAG_AOUT	0x010
+#define MULTIBOOT_FLAG_ELF	 0x020
+#define MULTIBOOT_FLAG_MMAP	0x040
+#define MULTIBOOT_FLAG_CONFIG  0x080
+#define MULTIBOOT_FLAG_LOADER  0x100
+#define MULTIBOOT_FLAG_APM	 0x200
+#define MULTIBOOT_FLAG_VBE	 0x400
+
+// The symbol table for a.out.
+typedef struct
+{
+	uint32_t	 tabSize;
+	uint32_t 	strSize;
+	uint32_t 	addr;
+	uint32_t 	reserved;
+} __attribute__((packed)) multiboot_aoutSymbolTable_t;
+     
+// The section header table for ELF.
+typedef struct
+{
+	uint32_t	 num;
+	uint32_t	 size;
+	uint32_t 	addr;
+	uint32_t	 shndx;
+} __attribute__((packed)) multiboot_elfSectionHeaderTable_t;
+
+typedef struct
+{
+	uint32_t	size;
+	uint64_t	addr;
+	uint64_t	length;
+	uint32_t	type;
+} __attribute__((packed)) multiboot_memoryMap_t;
+
+typedef struct
+{
+	uint32_t	start;
+	uint32_t	end;
+	char*		cmdLine;
+	uint32_t	reserved;
+} __attribute__((packed)) multiboot_module_t;
+
+typedef struct
+{
+	uint32_t	flags;
+	uint32_t	memLower;
+	uint32_t	memUpper;
+	uint32_t	bootDevice;
+	char*	cmdLine;
+	uint32_t	modsCount;
+	multiboot_module_t*	modsAddr;
+
+	union
+	{
+		multiboot_aoutSymbolTable_t aoutSym;
+		multiboot_elfSectionHeaderTable_t elfSec;
+	} u;
+	
+	uint32_t	mmapLength;
+	uint32_t	mmapAddr;
+	
+	uint32_t drivesLength;
+	uint32_t drivesAddr;
+	
+	// ROM configuration table
+	uint32_t configTable;
+	
+	char* bootLoaderName;
+	uint32_t apmTable;
+	
+	// Video
+	uint32_t vbeControlInfo;
+	uint32_t vbeModeInfo;
+	uint16_t vbeMode;
+	uint16_t vbeInterfaceSeg;
+	uint16_t vbeInterfaceOff;
+	uint16_t vbeInterfaceLen;
+} __attribute__((packed)) multiboot_info_t;
+
+multiboot_info_t* multiboot_info;
+
+void arch_multiboot_printInfo();

--- a/samples/C/portio.h
+++ b/samples/C/portio.h
@@ -1,0 +1,43 @@
+#pragma once
+
+/* Copyright © 2011 Lukas Martini
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <lib/stdint.h>
+
+// Legacy
+#define outb(args...) portio_out8(args)
+#define outw(args...) portio_out16(args)
+#define outl(args...) portio_out32(args)
+#define outq(args...) portio_out64(args)
+
+#define inb(args...) portio_in8(args)
+#define inw(args...) portio_in16(args)
+#define inl(args...) portio_in32(args)
+#define inq(args...) portio_in64(args)
+
+void portio_out8(uint16_t port, uint8_t value);
+void portio_out16(uint16_t port, uint16_t value);
+void portio_out32(uint16_t port, uint32_t value);
+void portio_out64(uint16_t port, uint64_t value);
+
+uint8_t portio_in8(uint16_t port);
+uint16_t portio_in16(uint16_t port);
+uint32_t portio_in32(uint16_t port);
+uint64_t portio_in64(uint16_t port);

--- a/samples/C/scheduler.h
+++ b/samples/C/scheduler.h
@@ -1,0 +1,69 @@
+#pragma once
+
+/* Copyright © 2011 Lukas Martini
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <hw/cpu.h>
+#include <memory/vmem.h>
+
+#define SCHEDULER_MAXNAME 256
+#define SCHEDULER_TASK_PATH_MAX 256
+
+// Single linked list
+typedef struct task {
+	uint32_t pid;
+	char name[SCHEDULER_MAXNAME];
+	struct task *parent;
+	cpu_state_t* state;
+	struct task* next;
+	struct task* previous;
+
+	void* stack;
+	void* entry;
+	struct vmem_context *memory_context;
+
+	// Current task state
+	enum {
+		TASK_STATE_KILLED,
+		TASK_STATE_TERMINATED,
+		TASK_STATE_BLOCKING,
+		TASK_STATE_STOPPED,
+		TASK_STATE_RUNNING
+	} task_state;
+
+	char** environ;
+	char** argv;
+	int argc;
+
+	// TODO Is this actually the same as PATH_MAX in our toolchain?
+	char cwd[SCHEDULER_TASK_PATH_MAX + 1];
+} task_t;
+
+int scheduler_state;
+
+task_t* scheduler_new(void* entry, task_t* parent, char name[SCHEDULER_MAXNAME],
+	char** environ, char** argv, int argc, struct vmem_context* memory_context, bool map_structs);
+void scheduler_add(task_t *task);
+void scheduler_terminate_current();
+task_t* scheduler_get_current();
+task_t* scheduler_select(cpu_state_t* lastRegs);
+void scheduler_init();
+void scheduler_yield();
+void scheduler_remove(task_t *t);
+task_t* scheduler_fork(task_t* to_fork, cpu_state_t* state);

--- a/samples/C/syscalls.h
+++ b/samples/C/syscalls.h
@@ -1,0 +1,95 @@
+#pragma once
+
+/* Copyright © 2011 Fritz Grimpen
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+#include <tasks/syscall.h>
+
+#include "syscalls/write.h"
+#include "syscalls/exit.h"
+#include "syscalls/getpid.h"
+#include "syscalls/getppid.h"
+#include "syscalls/read.h"
+#include "syscalls/brk.h"
+#include "syscalls/mmap.h"
+#include "syscalls/munmap.h"
+#include "syscalls/test.h"
+#include "syscalls/hostname.h"
+#include "syscalls/uname.h"
+#include "syscalls/open.h"
+#include "syscalls/execve.h"
+#include "syscalls/seek.h"
+#include "syscalls/opendir.h"
+#include "syscalls/readdir.h"
+#include "syscalls/kill.h"
+#include "syscalls/getexecdata.h"
+#include "syscalls/cwd.h"
+#include "syscalls/fork.h"
+
+syscall_t syscall_table[] = {
+	NULL,
+	sys_exit,			// 1
+	sys_read,			// 2
+	sys_write,			// 3
+	sys_getpid,			// 4
+	sys_brk,			// 5
+	sys_getppid,		// 6
+	sys_mmap,			// 7
+	sys_munmap,			// 8
+	sys_test,			// 9
+	sys_get_hostname,	// 10
+	sys_set_hostname,	// 11
+	sys_uname,			// 12
+	sys_open,			// 13
+	sys_execve,			// 14
+	sys_seek,			// 15
+	sys_opendir,		// 16
+	sys_readdir,		// 17
+	sys_kill,			// 18
+	sys_getexecdata,	// 19
+	sys_chdir,			// 20
+	sys_getcwd,			// 21
+	sys_fork,			// 22
+};
+
+char* syscall_name_table[] = {
+	NULL,
+	"exit",			// 1
+	"read",			// 2
+	"write",		// 3
+	"getpid",		// 4
+	"brk",			// 5
+	"getppid",		// 6
+	"mmap",			// 7
+	"munmap",		// 8
+	"test",			// 9
+	"get_hostname",	// 10
+	"set_hostname",	// 11
+	"uname",		// 12
+	"open",			// 13
+	"execve",		// 14
+	"seek",			// 15
+	"opendir",		// 16
+	"readdir",		// 17
+	"kill",			// 18
+	"getexecdata",	// 19
+	"chdir",		// 20
+	"getcwd",		// 21
+	"fork",			// 22
+};

--- a/samples/C/vfs.h
+++ b/samples/C/vfs.h
@@ -1,0 +1,56 @@
+#pragma once
+
+/* Copyright © 2010, 2011 Lukas Martini
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+
+#define VFS_SEEK_SET 0
+#define VFS_SEEK_CUR 1
+#define VFS_SEEK_END 2
+
+typedef struct {
+   uint64_t num;
+   char path[512];
+   char mount_path[512];
+   uint32_t offset;
+   uint32_t mountpoint;
+} vfs_file_t;
+
+typedef struct {
+   uint64_t num;
+   char path[512];
+   char mount_path[512];
+   uint32_t mountpoint;
+} vfs_dir_t;
+
+typedef void* (*vfs_read_callback_t)(char* path, uint32_t offset, uint32_t size);
+typedef char* (*vfs_read_dir_callback_t)(char* path, uint32_t offset);
+
+
+// Used to always store the last read/write attempt (used for kernel panic debugging)
+char vfs_last_read_attempt[512];
+
+vfs_file_t* vfs_get_from_id(uint32_t id);
+vfs_dir_t* vfs_get_dir_from_id(uint32_t id);
+void* vfs_read(vfs_file_t* fp, uint32_t size);
+char* vfs_dir_read(vfs_dir_t* dir, uint32_t offset);
+void vfs_seek(vfs_file_t* fp, uint32_t offset, int origin);
+vfs_file_t* vfs_open(char* path);
+vfs_dir_t* vfs_dir_open(char* path);
+int vfs_mount(char* path, vfs_read_callback_t read_callback, vfs_read_dir_callback_t read_dir_callback);

--- a/samples/C/vmem.h
+++ b/samples/C/vmem.h
@@ -1,0 +1,94 @@
+#pragma once
+
+/* Copyright © 2011 Fritz Grimpen
+ * Copyright © 2013 Lukas Martini
+ *
+ * This file is part of Xelix.
+ *
+ * Xelix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Xelix is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Xelix. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lib/generic.h>
+
+struct vmem_context;
+
+struct vmem_page
+{
+	enum
+	{
+		VMEM_SECTION_STACK,   /* Initial stack */
+		VMEM_SECTION_CODE,    /* Contains program code and is read-only */
+		VMEM_SECTION_DATA,    /* Contains static data */
+		VMEM_SECTION_HEAP,    /* Allocated by brk(2) at runtime */
+		VMEM_SECTION_MMAP,    /* Allocated by mmap(2) at runtime */
+		VMEM_SECTION_KERNEL,  /* Contains kernel-internal data */
+		VMEM_SECTION_UNMAPPED /* Unmapped */
+	} section;
+
+	bool readonly:1;
+	bool cow:1; /* Copy-on-Write mechanism */
+	bool allocated:1;
+
+	void *cow_src_addr;
+	void *virt_addr;
+	void *phys_addr;
+};
+
+typedef void (*vmem_iterator_t)(struct vmem_context *, struct vmem_page *, uint32_t);
+
+/* Initialize vmem_kernelContext for paging_init() */
+void vmem_init();
+struct vmem_context *vmem_kernelContext;
+struct vmem_context *vmem_currentContext;
+struct vmem_context *vmem_processContext;
+void *vmem_faultAddress;
+
+/* Some callbacks for magic functions */
+void (*vmem_applyPage)(struct vmem_context *, struct vmem_page *);
+
+/* Generate new page context */
+struct vmem_context *vmem_new();
+struct vmem_page *vmem_new_page();
+
+int vmem_add_page(struct vmem_context *ctx, struct vmem_page *pg);
+
+struct vmem_page *vmem_get_page_phys(struct vmem_context *ctx, void *phys_addr);
+struct vmem_page *vmem_get_page_virt(struct vmem_context *ctx, void *virt_addr);
+struct vmem_page *vmem_get_page(struct vmem_context *ctx, uint32_t offset);
+
+/* Remove pages in a specific context by physical or virtual address */
+struct vmem_page *vmem_rm_page_phys(struct vmem_context *ctx, void *phys_addr);
+struct vmem_page *vmem_rm_page_virt(struct vmem_context *ctx, void *virt_addr);
+
+/* Iterator */
+int vmem_iterate(struct vmem_context *ctx, vmem_iterator_t callback);
+
+uint32_t vmem_count_pages(struct vmem_context *ctx);
+void vmem_dump_page(struct vmem_page *pg);
+void vmem_dump(struct vmem_context *ctx);
+void vmem_handle_fault(uint32_t code, void *addr, void *instruction);
+
+/* Get/Set cached paging context */
+void vmem_set_cache(struct vmem_context *ctx, void *cache);
+void *vmem_get_cache(struct vmem_context *ctx);
+
+#ifdef __i386__
+	#define PAGE_SIZE 4096
+	#define VMEM_ALIGN(x) (typeof(x))(((intptr_t)(x) & 0xFFFFF000) + 0x1000)
+	#define VMEM_ALIGN_DOWN(x) (typeof(x))( \
+		((intptr_t)(x) - ((intptr_t)(x) % PAGE_SIZE)))
+#else
+	#define PAGE_SIZE 0
+	#define VMEM_ALIGN(x) (x)
+#endif


### PR DESCRIPTION
This pull request is a result of the discussion in #1626. It contains a whole bunch of C header files taken from https://github.com/lutoma/xelix. As it's a kernel, the headers tend to be a bit unconventional. Also, they contain a lot of structs and typedefs which were previously very underrepresented in the samples.

I know its a lot of files, but it was the only set that managed to push the misdetections as C++ down to 3.15% (from the previous 12.8%). But I'd be glad to remove some of them if you think it's too much.
