### PR TITLE
Use atom/language-sass's Sass grammar

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -9,8 +9,6 @@ http://svn.textmate.org/trunk/Review/Bundles/Forth.tmbundle:
 - source.forth
 http://svn.textmate.org/trunk/Review/Bundles/Parrot.tmbundle:
 - source.parrot.pir
-http://svn.textmate.org/trunk/Review/Bundles/Ruby%20Sass.tmbundle:
-- source.sass
 http://svn.textmate.org/trunk/Review/Bundles/SecondLife%20LSL.tmbundle:
 - source.lsl
 http://svn.textmate.org/trunk/Review/Bundles/VHDL.tmbundle:
@@ -92,6 +90,9 @@ https://github.com/atom/language-python:
 - source.python
 - source.regexp.python
 - text.python.traceback
+https://github.com/atom/language-sass:
+- source.css.scss
+- source.sass
 https://github.com/atom/language-shellscript:
 - source.shell
 - text.shell-session
@@ -170,6 +171,7 @@ https://github.com/lavrton/sublime-better-typescript:
 https://github.com/leafo/moonscript-tmbundle:
 - source.moonscript
 https://github.com/lsf37/Isabelle.tmbundle:
+- source.isabelle.root
 - source.isabelle.theory
 https://github.com/lunixbochs/x86-assembly-textmate-bundle:
 - source.asm.x86


### PR DESCRIPTION
This works better than the old Ruby Sass.tmbundle we were pulling from svn.textmate.org.

atom/language-sass also contains an SCSS grammar, but I didn't switch to using that grammar because it isn't obviously better than our current one and I'm not an SCSS expert.

/cc @pzi https://github.com/github/linguist/pull/1852
