### PR TITLE
Test that all popular languages exist

### DIFF
--- a/lib/linguist/popular.yml
+++ b/lib/linguist/popular.yml
@@ -3,7 +3,6 @@
 # This file should only be edited by GitHub staff
 
 - ActionScript
-- Bash
 - C
 - C#
 - C++
@@ -27,3 +26,4 @@
 - SQL
 - Scala
 - Scheme
+- Shell

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -375,4 +375,13 @@ class TestLanguage < Test::Unit::TestCase
     message << missing.map { |language| sprintf("%-#{width}s %s", language.name, language.ace_mode) }.sort.join("\n")
     assert missing.empty?, message
   end
+
+  def test_all_popular_languages_exist
+    popular = YAML.load(File.read(File.expand_path("../../lib/linguist/popular.yml", __FILE__)))
+
+    missing = popular - Language.all.map(&:name)
+    message = "The following languages are listed in lib/linguist/popular.yml but not in lib/linguist/languages.yml.\n"
+    message << missing.sort.join("\n")
+    assert missing.empty?, message
+  end
 end


### PR DESCRIPTION
`popular.yml` listed "Bash" but should have been listing "Shell" instead. There is no "Bash" language. Now CI will fail if this happens again.

/cc @bkeepers @arfon 
