### PR TITLE
Use atom/language-gfm’s Markdown grammar.

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -424,4 +424,3 @@ https://raw.githubusercontent.com/eregon/oz-tmbundle/master/Syntaxes/Oz.tmLangua
 - source.oz
 https://raw.githubusercontent.com/tenbits/sublime-mask/release/Syntaxes/mask.tmLanguage:
 - source.mask
-m


### PR DESCRIPTION
We render [GitHub Flavoured Markdown](https://help.github.com/articles/github-flavored-markdown/) on the site. We can use Atom’s grammar to ensure that syntax highlighting uses the same dialect.
