### PR TITLE
Added a more suitable grammar for Mercury

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -422,6 +422,8 @@ https://github.com/wmertens/sublime-nix:
 - source.nix
 https://raw.githubusercontent.com/eregon/oz-tmbundle/master/Syntaxes/Oz.tmLanguage:
 - source.oz
+https://raw.githubusercontent.com/sebgod/mercury-tmlanguage/master/Mercury.tmLanguage:
+- source.mercury
 https://raw.githubusercontent.com/tenbits/sublime-mask/release/Syntaxes/mask.tmLanguage:
 - source.mask
 https://github.com/l15n/fish-tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1789,7 +1789,7 @@ Mercury:
   extensions:
   - .m
   - .moo
-  tm_scope: source.prolog
+  tm_scope: source.mercury
   ace_mode: prolog
 
 MiniD: # Legacy


### PR DESCRIPTION
Changing the grammar used for highlighting Mercury from Prolog to Mercury,
since Mercury defines many additional syntactic constructs.
A [lightshow demonstration](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fsebgod%2Fmercury-tmlanguage%2Fmaster%2FMercury.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2FMercury-Language%2Fmercury%2Fmaster%2Flibrary%2Fsparse_bitset.m&code=) examplifies this.
