### PR TITLE
Use atom/language-atom for the YAML grammar

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -98,6 +98,8 @@ https://github.com/atom/language-sass:
 https://github.com/atom/language-shellscript:
 - source.shell
 - text.shell-session
+https://github.com/atom/language-yaml:
+- source.yaml
 https://github.com/austinwagner/sublime-sourcepawn:
 - source.sp
 https://github.com/bfad/Sublime-Lasso:
@@ -406,8 +408,6 @@ https://github.com/textmate/verilog.tmbundle:
 https://github.com/textmate/xml.tmbundle:
 - text.xml
 - text.xml.xsl
-https://github.com/textmate/yaml.tmbundle:
-- source.yaml
 https://github.com/tomas-stefano/smalltalk-tmbundle:
 - source.smalltalk
 https://github.com/vic/ioke-outdated/raw/master/share/TextMate/Ioke.tmbundle/Syntaxes/Ioke.tmLanguage:


### PR DESCRIPTION
@github/docs uses YAML heavily for some of its data file definitions. 

Previously both Atom and GitHub.com handled multiline YAML strings poorly. Here's [a PR into Atom](https://github.com/atom/language-yaml/pull/19) that fixed the issue there. I also made [the same fix upstream](https://github.com/textmate/yaml.tmbundle/pull/6), plus other updates to the grammar. 

While the Atom syntax is now correct, the same tmbundle changes were not merged (they stalled). It would be nice if we could switch to using the Atom syntax to resolve this on .com.
