### PR TITLE
Added Windows Registry and Windows Installer language entries

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3060,6 +3060,33 @@ WebIDL:
   tm_scope: none
   ace_mode: text
 
+Windows Registry:
+  type: programming
+  color: "#2672EC"
+  aliases:
+  - reg
+  - registry
+  extensions:
+  - .reg
+  tm_scope: none
+  ace_mode: text
+
+Windows Installer:
+  type: programming
+  color: "#2672EC"
+  aliases:
+  - msi
+  - msp
+  - inf
+  - wix
+  extensions:
+  - .msi
+  - .msp
+  - .inf
+  - .wix
+  tm_scope: none
+  ace_mode: text
+
 XC:
   type: programming
   extensions:


### PR DESCRIPTION
My ContextMenuTools repository, written primarily in .inf (Windows Installer) files, is reporting Visual Basic as the primary source language. I added two language entries, one for Windows Registry (.reg) files, and one for Windows Installer (.inf, .msi, .msp, .wix) files.