### PR TITLE
vendor.yml: improved & added more regex for auto-generated stylesheets

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -42,7 +42,7 @@
 
 # Bootstrap css and js
 - (^|/)bootstrap([^.]*)\.(js|css)$
-- (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|)$
+- (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
 
 # Font Awesome
 - font-awesome.css

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -40,10 +40,12 @@
 # Minified JavaScript and CSS
 - (\.|-)min\.(js|css)$
 
+#Stylesheets imported from packages
+- ([^\s]*)import\.(css|less|scss|styl)$
+
 # Bootstrap css and js
 - (^|/)bootstrap([^.]*)\.(js|css|less|scss|styl)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
-- (^|/)bootstrap/([^\s]*)import\.(css|less|scss|styl)$
 
 # Font Awesome
 - (^|/)font-awesome\.(css|less|scss|styl)$
@@ -54,7 +56,7 @@
 # Normalize.css
 - (^|/)normalize\.(css|less|scss|styl)$
 
-# Bourbon SCSS
+# Bourbon css
 - (^|/)[Bb]ourbon/.*\.(css|less|scss|styl)$
 
 # Animate.css

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -41,25 +41,24 @@
 - (\.|-)min\.(js|css)$
 
 # Bootstrap css and js
-- (^|/)bootstrap([^.]*)\.(js|css)$
+- (^|/)bootstrap([^.]*)\.(js|css|less|scss|styl)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
 - (^|/)bootstrap/([^\s]*)import\.(css|less|scss|styl)$
 
 # Font Awesome
-- font-awesome.css
+- (^|/)font-awesome\.(css|less|scss|styl)$
 
 # Foundation css
-- foundation.css
+- (^|/)foundation\.(css|less|scss|styl)$
 
 # Normalize.css
-- normalize.css
+- (^|/)normalize\.(css|less|scss|styl)$
 
 # Bourbon SCSS
-- (^|/)[Bb]ourbon/.*\.css$
-- (^|/)[Bb]ourbon/.*\.scss$
+- (^|/)[Bb]ourbon/.*\.(css|less|scss|styl)$
 
 # Animate.css
-- animate.css
+- (^|/)animate\.(css|less|scss|styl)$
 
 # Vendored dependencies
 - third[-_]?party/

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -43,6 +43,7 @@
 # Bootstrap css and js
 - (^|/)bootstrap([^.]*)\.(js|css)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
+- (^|/)bootstrap/([^\s]*)import\.(css|less|scss|styl)$
 
 # Font Awesome
 - font-awesome.css

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -42,6 +42,7 @@
 
 # Bootstrap css and js
 - (^|/)bootstrap([^.]*)\.(js|css)$
+- (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|)$
 
 # Font Awesome
 - font-awesome.css


### PR DESCRIPTION
Many repos (especially Meteor repos) are being mistakenly marked as CSS due to innumerable lines of supposedly excluded auto-generated CSS code not being excluded from statistics.
Here are some examples:
https://github.com/Differential/meteor-boilerplate
https://github.com/Urigo/angular-meteor
https://github.com/yogiben/meteor-starter
https://github.com/0a-/0a.io