### PR TITLE
Added support for Mono .dll.config XML files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3106,6 +3106,7 @@ XML:
   - .dita
   - .ditamap
   - .ditaval
+  - .dll.config
   - .filters
   - .fsproj
   - .glade

--- a/samples/XML/libsomething.dll.config
+++ b/samples/XML/libsomething.dll.config
@@ -1,0 +1,6 @@
+<configuration>
+  <dllmap dll="libsomething">
+    <dllentry dll="libdifferent.so" name="somefunction" target="differentfunction" />
+    <dllentry os="solaris,freebsd" dll="libanother.so" name="somefunction" target="differentfunction" />
+  </dllmap>
+</configuration> 


### PR DESCRIPTION
Reference: http://www.mono-project.com/docs/advanced/pinvoke/dllmap/#example

Example: https://github.com/OpenRA/OpenRA/blob/release-20141029/thirdparty/SharpFont.dll.config