### PR TITLE
lib/linguist/heuristics.rb: Disambiguate Mercury-M

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -181,5 +181,13 @@ module Linguist
         Language["Text"]
       end
     end
+
+    disambiguate "Mercury", "M" do |data|
+      if data.include?(":- module")
+        Language["Mercury"]
+      else
+        Language["M"]
+      end
+    end
   end
 end


### PR DESCRIPTION
In the [Mercury repository](http://github.com/Mercury-Language/mercury)
75 files have been classified as 'M', this patch tries to rectify that,
using the fact that Mercury modules must contain a ':- module'
directive.