### PR TITLE
Switch to Minitest::Test instead of Test::Unit::TestCase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 gemspec :name => "github-linguist"
 gemspec :name => "github-linguist-grammars"
-gem 'test-unit', require: false if RUBY_VERSION >= '2.2'
 gem 'byebug' if RUBY_VERSION >= '2.0'

--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '~> 0.22.0b4'
 
+  s.add_development_dependency 'minitest', '>= 5.0'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,4 @@
 require "bundler/setup"
-require "test/unit"
+require "minitest/autorun"
 require "mocha/setup"
 require "linguist"

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestBlob < Test::Unit::TestCase
+class TestBlob < Minitest::Test
   include Linguist
 
   def setup

--- a/test/test_classifier.rb
+++ b/test/test_classifier.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestClassifier < Test::Unit::TestCase
+class TestClassifier < Minitest::Test
   include Linguist
 
   def samples_path

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -1,5 +1,4 @@
-require 'linguist/file_blob'
-require 'test/unit'
+require_relative "./helper"
 
 class TestFileBlob < Test::Unit::TestCase
   def test_extensions

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestFileBlob < Test::Unit::TestCase
+class TestFileBlob < Minitest::Test
   def test_extensions
     assert_equal [".gitignore"], Linguist::FileBlob.new(".gitignore").extensions
     assert_equal [".xml"],  Linguist::FileBlob.new("build.xml").extensions

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestGenerated < Test::Unit::TestCase
+class TestGenerated < Minitest::Test
   include Linguist
 
   def samples_path
@@ -11,14 +11,16 @@ class TestGenerated < Test::Unit::TestCase
 
   def generated_without_loading_data(name)
     blob = File.join(samples_path, name)
-    assert_nothing_raised(DataLoadedError, "Data was loaded when calling generated? on #{name}") do
+    begin
       Generated.generated?(blob, lambda { raise DataLoadedError.new })
+    rescue DataLoadedError
+      assert false, "Data was loaded when calling generated? on #{name}"
     end
   end
 
   def generated_loading_data(name)
     blob = File.join(samples_path, name)
-    assert_raise(DataLoadedError, "Data wasn't loaded when calling generated? on #{name}") do
+    assert_raises(DataLoadedError, "Data wasn't loaded when calling generated? on #{name}") do
       Generated.generated?(blob, lambda { raise DataLoadedError.new })
     end
   end

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -12,7 +12,7 @@ class TestGenerated < Minitest::Test
   def generated_without_loading_data(name)
     blob = File.join(samples_path, name)
     begin
-      Generated.generated?(blob, lambda { raise DataLoadedError.new })
+      assert Generated.generated?(blob, lambda { raise DataLoadedError.new }), "#{name} was not recognized as a generated file"
     rescue DataLoadedError
       assert false, "Data was loaded when calling generated? on #{name}"
     end

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestGrammars < Test::Unit::TestCase
+class TestGrammars < Minitest::Test
   ROOT = File.expand_path("../..", __FILE__)
 
   def setup

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestHeuristcs < Test::Unit::TestCase
+class TestHeuristcs < Minitest::Test
   include Linguist
 
   def samples_path

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestLanguage < Test::Unit::TestCase
+class TestLanguage < Minitest::Test
   include Linguist
 
   def test_find_by_alias
@@ -198,7 +198,7 @@ class TestLanguage < Test::Unit::TestCase
   def test_find_all_by_extension
     Language.all.each do |language|
       language.extensions.each do |extension|
-        assert_include Language.find_by_extension(extension), language
+        assert_includes Language.find_by_extension(extension), language
       end
     end
   end
@@ -283,7 +283,7 @@ class TestLanguage < Test::Unit::TestCase
   end
 
   def test_error_without_name
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       Language.new :name => nil
     end
   end

--- a/test/test_md5.rb
+++ b/test/test_md5.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestMD5 < Test::Unit::TestCase
+class TestMD5 < Minitest::Test
   include Linguist
 
   def test_hexdigest_string
@@ -12,28 +12,28 @@ class TestMD5 < Test::Unit::TestCase
     assert_equal "450c1ae043459546517b3dd2f98250f0", MD5.hexdigest(:foo)
     assert_equal "f06967526af9d7a512594b0a81b31ede", MD5.hexdigest(:bar)
 
-    assert_not_equal MD5.hexdigest("foo"), MD5.hexdigest(:foo)
+    refute_equal MD5.hexdigest("foo"), MD5.hexdigest(:foo)
   end
 
   def test_hexdigest_integer
     assert_equal "7605ec17fd7fd213fdcd23cac302cbb4", MD5.hexdigest(1)
     assert_equal "097c311a46d330e4e119ba2b1dc0f9a5", MD5.hexdigest(2)
 
-    assert_not_equal MD5.hexdigest("1"), MD5.hexdigest(1)
+    refute_equal MD5.hexdigest("1"), MD5.hexdigest(1)
   end
 
   def test_hexdigest_boolean
     assert_equal "a690a0615820e2e5c53901d8b8958509", MD5.hexdigest(true)
     assert_equal "fca6a9b459e702fa93513c6a8b8c5dfe", MD5.hexdigest(false)
 
-    assert_not_equal MD5.hexdigest("true"), MD5.hexdigest(true)
-    assert_not_equal MD5.hexdigest("false"), MD5.hexdigest(false)
+    refute_equal MD5.hexdigest("true"), MD5.hexdigest(true)
+    refute_equal MD5.hexdigest("false"), MD5.hexdigest(false)
   end
 
   def test_hexdigest_nil
     assert_equal "35589a1cc0b3ca90fc52d0e711c0c434", MD5.hexdigest(nil)
 
-    assert_not_equal MD5.hexdigest("nil"), MD5.hexdigest(nil)
+    refute_equal MD5.hexdigest("nil"), MD5.hexdigest(nil)
   end
 
   def test_hexdigest_array
@@ -49,7 +49,7 @@ class TestMD5 < Test::Unit::TestCase
     assert_equal "868ee214faf277829a85667cf332749f", MD5.hexdigest({:a => 1})
     assert_equal "fa9df957c2b26de6fcca9d062ea8701e", MD5.hexdigest({:b => 2})
 
-    assert_not_equal MD5.hexdigest([:b, 2]), MD5.hexdigest({:b => 2})
+    refute_equal MD5.hexdigest([:b, 2]), MD5.hexdigest({:b => 2})
 
     assert_equal MD5.hexdigest({:b => 2, :a => 1}), MD5.hexdigest({:a => 1, :b => 2})
     assert_equal MD5.hexdigest({:c => 3, :b => 2, :a => 1}), MD5.hexdigest({:a => 1, :b => 2, :c => 3})

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestPedantic < Test::Unit::TestCase
+class TestPedantic < Minitest::Test
   filename = File.expand_path("../../lib/linguist/languages.yml", __FILE__)
   LANGUAGES = YAML.load(File.read(filename))
   GRAMMARS = YAML.load(File.read(File.expand_path("../../grammars.yml", __FILE__)))

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestRepository < Test::Unit::TestCase
+class TestRepository < Minitest::Test
   def rugged_repository
     @rugged ||= Rugged::Repository.new(File.expand_path("../../.git", __FILE__))
   end

--- a/test/test_samples.rb
+++ b/test/test_samples.rb
@@ -1,7 +1,7 @@
 require_relative "./helper"
 require "tempfile"
 
-class TestSamples < Test::Unit::TestCase
+class TestSamples < Minitest::Test
   include Linguist
 
   def test_up_to_date

--- a/test/test_shebang.rb
+++ b/test/test_shebang.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestShebang < Test::Unit::TestCase
+class TestShebang < Minitest::Test
   include Linguist
 
   def assert_interpreter(interpreter, body)

--- a/test/test_tokenizer.rb
+++ b/test/test_tokenizer.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestTokenizer < Test::Unit::TestCase
+class TestTokenizer < Minitest::Test
   include Linguist
 
   def samples_path


### PR DESCRIPTION
This gives us a consistent test framework across all Ruby versions which should help avoid errors that are only found when CI runs the tests on different Rubies. (And this fixes an immediate bug where there's no  `skip` method in the version of test-unit we're currently using only on Ruby 2.2.)

/cc @arfon @bkeepers 