### PR TITLE
Opt in to container-based Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ before_install:
   - git fetch origin v2.0.0:v2.0.0
   - git fetch origin test/attributes:test/attributes
   - git fetch origin test/master:test/master
-  - sudo apt-get install libicu-dev -y
+  - script/vendor-deb libicu48 libicu-dev
+  - bundle config build.charlock_holmes --with-icu-include=$(pwd)/vendor/debs/include --with-icu-lib=$(pwd)/vendor/debs/lib
   - git submodule init
   - git submodule sync --quiet
   - script/fast-submodule-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ notifications:
   disabled: true
 git:
   submodules: false
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,5 @@
 sudo: false
-before_install:
-  - git fetch origin master:master
-  - git fetch origin v2.0.0:v2.0.0
-  - git fetch origin test/attributes:test/attributes
-  - git fetch origin test/master:test/master
-  - script/vendor-deb libicu48 libicu-dev
-  - bundle config build.charlock_holmes --with-icu-include=$(pwd)/vendor/debs/include --with-icu-lib=$(pwd)/vendor/debs/lib
-  - git submodule init
-  - git submodule sync --quiet
-  - script/fast-submodule-update
+before_install: script/travis/before_install
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 before_install:
   - git fetch origin master:master
   - git fetch origin v2.0.0:v2.0.0

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -2,10 +2,8 @@
 
 set -ex
 
-git fetch origin master:master
-git fetch origin v2.0.0:v2.0.0
-git fetch origin test/attributes:test/attributes
-git fetch origin test/master:test/master
+# Fetch all commits/refs needed to run our tests.
+git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
 
 script/vendor-deb libicu48 libicu-dev
 if ruby -e 'exit RUBY_VERSION >= "2.0" && RUBY_VERSION < "2.1"'; then

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -ex
+
+git fetch origin master:master
+git fetch origin v2.0.0:v2.0.0
+git fetch origin test/attributes:test/attributes
+git fetch origin test/master:test/master
+
+script/vendor-deb libicu48 libicu-dev
+bundle config build.charlock_holmes --with-icu-include=$(pwd)/vendor/debs/include --with-icu-lib=$(pwd)/vendor/debs/lib
+
+git submodule init
+git submodule sync --quiet
+script/fast-submodule-update

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -8,7 +8,14 @@ git fetch origin test/attributes:test/attributes
 git fetch origin test/master:test/master
 
 script/vendor-deb libicu48 libicu-dev
-bundle config build.charlock_holmes --with-icu-include=$(pwd)/vendor/debs/include --with-icu-lib=$(pwd)/vendor/debs/lib
+if ruby -e 'exit RUBY_VERSION >= "2.0" && RUBY_VERSION < "2.1"'; then
+  # Workaround for https://bugs.ruby-lang.org/issues/8074. We can't use this
+  # solution on all versions of Ruby due to
+  # https://github.com/bundler/bundler/pull/3338.
+  bundle config build.charlock_holmes --with-icu-include=$(pwd)/vendor/debs/include --with-icu-lib=$(pwd)/vendor/debs/lib
+else
+  bundle config build.charlock_holmes --with-icu-dir=$(pwd)/vendor/debs
+fi
 
 git submodule init
 git submodule sync --quiet

--- a/script/vendor-deb
+++ b/script/vendor-deb
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$0")/.."
+
+mkdir -p vendor/apt vendor/debs
+
+(cd vendor/apt && apt-get --assume-yes download "$@")
+
+for deb in vendor/apt/*.deb; do
+  ar p $deb data.tar.gz | tar -vzxC vendor/debs --strip-components=2
+done


### PR DESCRIPTION
This speeds up our builds by providing lower latency, better caching, and more resources on the build machine. See http://docs.travis-ci.com/user/workers/container-based-infrastructure/.

The only major change here is that we can't install `libicu-dev` globally on the test machine. Instead we extract it to `vendor/debs` and point `charlock_holmes` at it.

Note that the build sometimes fails because apparently the `ace_modes.json` file sometimes can't be downloaded. This would normally cause us to skip the test that relies on that file, but `#skip` doesn't exist in the version of `test-unit` being used on Ruby 2.2. #1930 will fix the `#skip` problem. I doubt that the intermittent failure to download `ace_modes.json` is unique to container-based builds, though I suppose it's possible.

/cc @arfon @bkeepers 