### PR TITLE
Update Elm support by adding its own syntax highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -526,3 +526,6 @@
 [submodule "vendor/grammars/Scalate.tmbundle"]
 	path = vendor/grammars/Scalate.tmbundle
 	url = https://github.com/scalate/Scalate.tmbundle
+[submodule "vendor/grammars/Elm.tmLanguage"]
+	path = vendor/grammars/Elm.tmLanguage
+	url = https://github.com/deadfoxygrandpa/Elm.tmLanguage

--- a/grammars.yml
+++ b/grammars.yml
@@ -31,6 +31,8 @@ vendor/grammars/ColdFusion:
 - text.html.cfm
 vendor/grammars/Docker.tmbundle:
 - source.dockerfile
+vendor/grammars/Elm.tmLanguage:
+- source.elm
 vendor/grammars/Handlebars:
 - text.html.handlebars
 vendor/grammars/IDL-Syntax:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -789,7 +789,7 @@ Elm:
   type: programming
   extensions:
   - .elm
-  tm_scope: source.haskell
+  tm_scope: source.elm
   ace_mode: elm
 
 Emacs Lisp:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -787,6 +787,7 @@ Elixir:
 
 Elm:
   type: programming
+  color: "#60B5CC"
   extensions:
   - .elm
   tm_scope: source.elm


### PR DESCRIPTION
Until now, Elm's been using Haskell syntax highlighting. The language has grown farther apart from Haskell in the past months and could really use its own highlighting at this point.