### PR TITLE
Fix issue with github/linguist#1932

### DIFF
--- a/script/download-grammars
+++ b/script/download-grammars
@@ -150,7 +150,7 @@ end
 
 def install_grammar(tmp_dir, source, all_scopes)
   is_url = source.start_with?("http:", "https:")
-  is_single_file = source.end_with?('.tmLanguage', '.plist')
+  is_single_file = source.downcase.end_with?('.tmlanguage', '.plist') && !File.directory?(source)
 
   p = if !is_url
         if is_single_file


### PR DESCRIPTION
#1932 introduced an error that prevented [download-grammars](https://github.com/github/linguist/blob/master/script/download-grammars) from working. The script issued an error message saying that `vendor/grammars/Elm.tmLanguage` is not a file (what is true because it is a directory).

The reason for this is:
Submodules must not end with neither `.tmlanguage` nor `.plist`. Otherwise the `download-grammars`-script will interpret the submodule as a `SingleFile` instead of a `DirectoryPackage`, which will lead to an error message.

The relevant line in `download-grammars` is https://github.com/github/linguist/blob/f2ab426d38dc391a6b0612cecf29cb67efa931b4/script/download-grammars#L153