### PR TITLE
Add grammar for CartoCSS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -531,3 +531,6 @@
 [submodule "vendor/grammars/sass-textmate-bundle"]
 	path = vendor/grammars/sass-textmate-bundle
 	url = https://github.com/nathos/sass-textmate-bundle
+[submodule "vendor/grammars/carto-atom"]
+	path = vendor/grammars/carto-atom
+	url = https://github.com/yohanboniface/carto-atom

--- a/grammars.yml
+++ b/grammars.yml
@@ -136,6 +136,8 @@ vendor/grammars/c.tmbundle:
 - source.c.platform
 vendor/grammars/capnproto.tmbundle:
 - source.capnp
+vendor/grammars/carto-atom:
+- source.css.mss
 vendor/grammars/ceylon-sublimetext:
 - module.ceylon
 - source.ceylon

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -450,12 +450,13 @@ Cap'n Proto:
   ace_mode: text
 
 CartoCSS:
+  type: programming
   aliases:
   - Carto
   extensions:
   - .mss
   ace_mode: text
-  tm_scope: none
+  tm_scope: source.css.mss
 
 Ceylon:
   type: programming

--- a/script/convert-grammars
+++ b/script/convert-grammars
@@ -148,10 +148,12 @@ def load_grammar(path)
   case File.extname(path.downcase)
   when '.plist', '.tmlanguage'
     Plist::parse_xml(path)
-  when '.cson', '.json'
+  when '.cson'
     cson = `"#{CSONC}" "#{path}"`
     raise "Failed to convert CSON grammar '#{path}': #{$?.to_s}" unless $?.success?
     JSON.parse(cson)
+  when '.json'
+    JSON.parse(File.read(path))
   else
     raise "Invalid document type #{path}"
   end

--- a/script/convert-grammars
+++ b/script/convert-grammars
@@ -44,7 +44,7 @@ class DirectoryPackage
         path.split('/')[-2] == 'Syntaxes'
       when '.tmlanguage'
         true
-      when '.cson'
+      when '.cson', '.json'
         path.split('/')[-2] == 'grammars'
       else
         false
@@ -148,7 +148,7 @@ def load_grammar(path)
   case File.extname(path.downcase)
   when '.plist', '.tmlanguage'
     Plist::parse_xml(path)
-  when '.cson'
+  when '.cson', '.json'
     cson = `"#{CSONC}" "#{path}"`
     raise "Failed to convert CSON grammar '#{path}': #{$?.to_s}" unless $?.success?
     JSON.parse(cson)


### PR DESCRIPTION
This pull request has to wait, until yohanboniface/carto-atom#1 is resolved. But I'm optimistic, that the owner will choose a suitable license. He [has noted in the package.json](https://github.com/yohanboniface/carto-atom/blob/master/package.json#L5) that he intended to release it under WTFPL.

In order to get this work, I had to change the `download-grammars`-script to accept files that end with `.json` instead of `.cson`.