### PR TITLE
Add .xml.dist as a XML file extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3154,6 +3154,7 @@ XML:
   - .xlf
   - .xliff
   - .xmi
+  - .xml.dist
   - .xsd
   - .xul
   - .zcml
@@ -3164,9 +3165,7 @@ XML:
   - Web.Debug.config
   - Web.Release.config
   - Web.config
-  - build.xml.dist
   - packages.config
-  - phpunit.xml.dist
 
 XProc:
   type: programming

--- a/samples/XML/phpunit.xml.dist
+++ b/samples/XML/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite>
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
This PR adds `.xml.dist` as a XML file extension.
Many example of these files can be seen in: https://github.com/search?o=asc&q=extension%3Adist+xml+version&ref=searchresults&s=indexed&type=Code&utf8=%E2%9C%93