### PR TITLE
Add Bluespec SystemVerilog grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -529,3 +529,6 @@
 [submodule "vendor/grammars/Elm.tmLanguage"]
 	path = vendor/grammars/Elm.tmLanguage
 	url = https://github.com/deadfoxygrandpa/Elm.tmLanguage
+[submodule "vendor/grammars/sublime-bsv"]
+	path = vendor/grammars/sublime-bsv
+	url = https://github.com/thotypous/sublime-bsv

--- a/grammars.yml
+++ b/grammars.yml
@@ -394,6 +394,8 @@ vendor/grammars/sublime-befunge:
 - source.befunge
 vendor/grammars/sublime-better-typescript:
 - source.ts
+vendor/grammars/sublime-bsv:
+- source.bsv
 vendor/grammars/sublime-cirru:
 - source.cirru
 vendor/grammars/sublime-glsl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -314,7 +314,7 @@ Bluespec:
   type: programming
   extensions:
   - .bsv
-  tm_scope: source.verilog
+  tm_scope: source.bsv
   ace_mode: verilog
 
 Boo:


### PR DESCRIPTION
The grammar is not perfect, but produces almost the same syntax highlighting as the official vim highlighter provided by the vendor, and is far better than using a Verilog highlighter (as it is currently done).

I have tested the grammar on [Lightshow](https://lightshow.githubapp.com) and it worked correctly with the [samples](https://github.com/github/linguist/tree/master/samples/Bluespec) already present in the repository. I hope I did not forget anything - please tell me if anything is missing from this pull request.
