### PR TITLE
Add JSONiq & XQuery scope from Atom package

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1412,7 +1412,7 @@ JSONiq:
   ace_mode: jsoniq
   extensions:
   - .jq
-  tm_scope: source.xquery
+  tm_scope: source.jq
 
 Jade:
   group: HTML
@@ -3184,6 +3184,7 @@ XQuery:
   - .xql
   - .xqm
   - .xqy
+  tm_scope: source.jq
   ace_mode: xquery
 
 XS:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1412,7 +1412,7 @@ JSONiq:
   ace_mode: jsoniq
   extensions:
   - .jq
-  tm_scope: source.jq
+  tm_scope: source.xquery
 
 Jade:
   group: HTML
@@ -3184,7 +3184,7 @@ XQuery:
   - .xql
   - .xqm
   - .xqy
-  tm_scope: source.jq
+  tm_scope: source.xquery
   ace_mode: xquery
 
 XS:


### PR DESCRIPTION
I have built a XQuery and JSONiq Atom package: https://atom.io/packages/language-jsoniq
I would like the Javascript lexer to be used for XQuery and JSONiq syntax highlighting in github.

However, the highlighting is done programmatically, not by using a grammar file. Would that be a problem?
Please let me know what I can do to contribute better XQuery and JSONiq syntax highlighting to github.