### PR TITLE
Grammar for HTTP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -532,3 +532,6 @@
 [submodule "vendor/grammars/sublime-bsv"]
 	path = vendor/grammars/sublime-bsv
 	url = https://github.com/thotypous/sublime-bsv
+[submodule "vendor/grammars/Sublime-HTTP"]
+	path = vendor/grammars/Sublime-HTTP
+	url = https://github.com/httpspec/sublime-highlighting

--- a/grammars.yml
+++ b/grammars.yml
@@ -66,6 +66,8 @@ vendor/grammars/Stata.tmbundle:
 - source.stata
 vendor/grammars/Sublime-Coq:
 - source.coq
+vendor/grammars/Sublime-HTTP:
+- source.httpspec
 vendor/grammars/Sublime-Inform:
 - source.Inform7
 vendor/grammars/Sublime-Lasso:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1211,7 +1211,7 @@ HTTP:
   type: data
   extensions:
   - .http
-  tm_scope: none
+  tm_scope: source.httpspec
   ace_mode: text
 
 Hack:


### PR DESCRIPTION
This pull request adds [a grammar](https://github.com/httpspec/sublime-highlighting) for HTTP as discussed in #1862.