### PR TITLE
Allow British-English spelled LICENCE-files

### DIFF
--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -60,10 +60,10 @@ class TestGrammars < Minitest::Test
   def test_submodules_have_licenses
     categories = submodule_paths.group_by do |submodule|
       files = Dir[File.join(ROOT, submodule, "*")]
-      license = files.find { |path| File.basename(path) =~ /\blicense\b/i } || files.find { |path| File.basename(path) =~ /\bcopying\b/i }
+      license = files.find { |path| File.basename(path) =~ /\blicen[cs]e\b/i } || files.find { |path| File.basename(path) =~ /\bcopying\b/i }
       if license.nil?
         if readme = files.find { |path| File.basename(path) =~ /\Areadme\b/i }
-          license = readme if File.read(readme) =~ /\blicense\b/i
+          license = readme if File.read(readme) =~ /\blicen[cs]e\b/i
         end
       end
       if license.nil?


### PR DESCRIPTION
The license-file in yohanboniface/carto-atom is called LICENCE (British-English spelling) and thus not covered by the current RegEx in [test_grammars.rb](https://github.com/github/linguist/blob/8430f694e549c6bb0ad61bbd444759aa17664997/test/test_grammars.rb).

This pull request changes this RegEx to also accept files called `LICENCE`.