### PR TITLE
Add missing ^ in regexp for Frege heuristic

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -175,7 +175,7 @@ module Linguist
     disambiguate "Frege", "Forth", "Text" do |data|
       if /^(: |also |new-device|previous )/.match(data)
         Language["Forth"]
-      elsif /\s*(import|module|package|data|type) /.match(data)
+      elsif /^\s*(import|module|package|data|type) /.match(data)
         Language["Frege"]
       else
         Language["Text"]

--- a/samples/Text/messages.fr
+++ b/samples/Text/messages.fr
@@ -1,1 +1,2 @@
 the green potato=la pomme de terre verte
+le nouveau type de musique=the new type of music


### PR DESCRIPTION
Forgot to match keywords only at the beginning of a line.  This caused some false positives.