### PR TITLE
New grammar for Racket

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -112,9 +112,6 @@
 [submodule "vendor/grammars/nesC.tmbundle"]
 	path = vendor/grammars/nesC.tmbundle
 	url = https://github.com/cdwilson/nesC.tmbundle
-[submodule "vendor/grammars/racket-tmbundle"]
-	path = vendor/grammars/racket-tmbundle
-	url = https://github.com/christophevg/racket-tmbundle
 [submodule "vendor/grammars/haxe-sublime-bundle"]
 	path = vendor/grammars/haxe-sublime-bundle
 	url = https://github.com/clemos/haxe-sublime-bundle

--- a/.gitmodules
+++ b/.gitmodules
@@ -543,3 +543,6 @@
 [submodule "vendor/grammars/language-hy"]
 	path = vendor/grammars/language-hy
 	url = https://github.com/rwtolbert/language-hy
+[submodule "vendor/grammars/Racket"]
+	path = vendor/grammars/Racket
+	url = https://github.com/soegaard/racket-highlight-for-github

--- a/grammars.yml
+++ b/grammars.yml
@@ -56,6 +56,8 @@ vendor/grammars/PHP-Twig.tmbundle:
 - text.html.twig
 vendor/grammars/RDoc.tmbundle:
 - text.rdoc
+vendor/grammars/Racket:
+- source.racket
 vendor/grammars/SCSS.tmbundle:
 - source.scss
 vendor/grammars/Scalate.tmbundle:

--- a/grammars.yml
+++ b/grammars.yml
@@ -362,8 +362,6 @@ vendor/grammars/python-django.tmbundle:
 vendor/grammars/r.tmbundle:
 - source.r
 - text.tex.latex.rd
-vendor/grammars/racket-tmbundle:
-- source.racket
 vendor/grammars/restructuredtext.tmbundle:
 - text.restructuredtext
 vendor/grammars/ruby-haml.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2475,7 +2475,7 @@ Racket:
   - .rktd
   - .rktl
   - .scrbl
-  tm_scope: none
+  tm_scope: source.racket
   ace_mode: lisp
 
 Ragel in Ruby Host:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2475,7 +2475,7 @@ Racket:
   - .rktd
   - .rktl
   - .scrbl
-  tm_scope: source.racket
+  tm_scope: none
   ace_mode: lisp
 
 Ragel in Ruby Host:


### PR DESCRIPTION
This pull request adds the new grammar for Racket proposed by @soegaard in #1946.
It should fix the issues #1822 and #1887 for Racket.

Example on Lightshow: [before](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=source.racket&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fsoegaard%2Fracket-highlight-for-github%2Fmaster%2Fracket.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdscorbett%2Fpygments%2F78f24f4def553698979b785739461fc7602f777b%2Ftests%2Fexamplefiles%2Fexample.rkt&code=) and [after](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fsoegaard%2Fracket-highlight-for-github%2Fmaster%2Fracket.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdscorbett%2Fpygments%2F78f24f4def553698979b785739461fc7602f777b%2Ftests%2Fexamplefiles%2Fexample.rkt&code=).