### PR TITLE
added Rusthon to languages list for syntax highlighting in md.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2386,6 +2386,11 @@ Python traceback:
   tm_scope: text.python.traceback
   ace_mode: text
 
+Rusthon:
+  type: programming
+  ace_mode: python
+  color: "#3581ba"
+
 QML:
   type: markup
   color: "#44a51c"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2376,6 +2376,8 @@ Python:
   - python
   - python2
   - python3
+  aliases:
+  - rusthon
 
 Python traceback:
   type: data
@@ -2385,11 +2387,6 @@ Python traceback:
   - .pytb
   tm_scope: text.python.traceback
   ace_mode: text
-
-Rusthon:
-  type: programming
-  ace_mode: python
-  color: "#3581ba"
 
 QML:
   type: markup


### PR DESCRIPTION
fixes syntax highlighting for rusthon code in markdown on github.
```python
a = [1,2,3]
```
should have same syntax colors as above.
```rusthon
a = [1,2,3]
```


rusthon project page:
https://github.com/rusthon/Rusthon