### PR TITLE
Heuristics for .cs files: C# and Smalltalk

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -72,7 +72,7 @@ module Linguist
     disambiguate "C#", "Smalltalk" do |data|
       if /![\w\s]+methodsFor: /.match(data)
         Language["Smalltalk"]
-      elsif /^\s*namespace\s*[\w\.]+\s*{/.match(data) || /^\s*using\s*[\w\.]+\s*;/.match(data)
+      elsif /^\s*namespace\s*[\w\.]+\s*{/.match(data) || /^\s*\/\//.match(data)
         Language["C#"]
       end
     end

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -69,6 +69,14 @@ module Linguist
       end
     end
 
+    disambiguate "C#", "Smalltalk" do |data|
+      if /![\w\s]+methodsFor: /.match(data)
+        Language["Smalltalk"]
+      elsif /^\s*namespace\s*[\w\.]+\s*{/.match(data) || /^\s*using\s*[\w\.]+\s*;/.match(data)
+        Language["C#"]
+      end
+    end
+
     disambiguate "Objective-C", "C++", "C" do |data|
       if (/^[ \t]*@(interface|class|protocol|property|end|synchronised|selector|implementation)\b/.match(data))
         Language["Objective-C"]

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -133,6 +133,13 @@ class TestHeuristcs < Minitest::Test
     })
   end
 
+  def test_cs_by_heuristics
+    assert_heuristics({
+      "C#" => all_fixtures("C#", "*.cs"),
+      "Smalltalk" => all_fixtures("Smalltalk", "*.cs")
+    })
+  end
+
   def assert_heuristics(hash)
     candidates = hash.keys.map { |l| Language[l] }
 


### PR DESCRIPTION
This pull request adds heuristic rules to distinguish C# and Smalltalk on the `.cs` extension.
It solves the issues reported in #1907.

Here are the results of the detection when running Linguist on a few repositories (the 7 last are from #1907):

      | Actual language | C# | Smalltalk
------|-----------------------|-------------|--------
[1,000 first results from C# search](https://github.com/search?o=desc&q=extension%3Acs+public&ref=searchresults&s=&type=Code&utf8=%E2%9C%93) | C# | 100% | 0.00%
[theseion/pharogenesis](https://github.com/theseion/pharogenesis) | Smalltalk | **7.26%** | 92.74%
[nant/nant](https://github.com/nant/nant) | C# | 100.00 | 0.00%
[LouisTakePILLz/ExtensionLib](https://github.com/LouisTakePILLz/ExtensionLib) | C# | 100.00 | 0.00%
[Robmaister/SharpFont](https://github.com/Robmaister/SharpFont) | C# | 100.00 | 0.00%
[ShareX/ShareX](https://github.com/ShareX/ShareX) | C# | 100.00 | 0.00%
[sillsdev/phonology-assistant](https://github.com/sillsdev/phonology-assistant) | C# | 100.00 | 0.00%
[JoshKeegan/PiSearch](https://github.com/JoshKeegan/PiSearch) | C# | 100.00 | 0.00%
[JoshKeegan/hpop](https://github.com/JoshKeegan/hpop) | C# | 100.00 | 0.00%

The only miss-detection is for [theseion/pharogenesis](https://github.com/theseion/pharogenesis) which is a really big collection of Smalltalk files (~43,800 of them). The results from Linguist don't change before and after this pull request (7.23% C# before). I looked at the content of a few of the miss-detected files and they were all really small files (no more than 10 lines).