### PR TITLE
Use all extension segments

### DIFF
--- a/lib/linguist/file_blob.rb
+++ b/lib/linguist/file_blob.rb
@@ -76,9 +76,13 @@ module Linguist
     def extensions
       basename, *segments = name.split(".")
 
-      segments.map.with_index do |segment, index|
-        "." + segments[index..-1].join(".")
+      segments.map! { |segment| "." + segment }
+
+      combined = segments.map.with_index do |segment, index|
+        segments[index..-1].join
       end
+
+      (combined + segments).uniq
     end
   end
 end

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -173,12 +173,11 @@ module Linguist
     def self.find_by_filename(filename)
       basename = File.basename(filename)
 
-      # find the first extension with language definitions
-      extname = FileBlob.new(filename).extensions.detect do |e|
-        !@extension_index[e].empty?
+      exts = FileBlob.new(filename).extensions.map do |e|
+        @extension_index[e]
       end
 
-      (@filename_index[basename] + @extension_index[extname]).compact.uniq
+      (@filename_index[basename] + exts).flatten.compact.uniq
     end
 
     # Public: Look up Languages by file extension.

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -492,7 +492,7 @@ class TestBlob < Minitest::Test
 
         blob = fixture_blob(filepath)
         if language == 'Data'
-          assert blob.language.nil?, "A language was found for #{filepath}"
+          assert blob.language.nil?, "#{filepath} was detected as #{blob.language}"
         else
           assert blob.language, "No language for #{filepath}"
           assert_equal language, blob.language.name, blob.name

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -4,6 +4,6 @@ class TestFileBlob < Minitest::Test
   def test_extensions
     assert_equal [".gitignore"], Linguist::FileBlob.new(".gitignore").extensions
     assert_equal [".xml"],  Linguist::FileBlob.new("build.xml").extensions
-    assert_equal [".html.erb", ".erb"],  Linguist::FileBlob.new("dotted.dir/index.html.erb").extensions
+    assert_equal [".html.erb", ".erb", ".html"],  Linguist::FileBlob.new("dotted.dir/index.html.erb").extensions
   end
 end

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -221,6 +221,7 @@ class TestLanguage < Minitest::Test
     assert_equal [Language['Clojure']], Language.find_by_filename('riemann.config')
     assert_equal [Language['HTML+Django']], Language.find_by_filename('index.jinja')
     assert_equal [Language['Chapel']], Language.find_by_filename('examples/hello.chpl')
+    assert_includes Language.find_by_filename("index.html.fr"), Language["HTML"]
   end
 
   def test_find_by_interpreter


### PR DESCRIPTION
A filename like `index.html.fr` would previously return `.html.fr` and
`.fr` as possible extensions. This makes it so it will also return
`.html`.

The tests are currently failing because now `bootstrap.css.map` is being detected as CSS when it should be nothing. I think this change has the potential to cause a lot of issues like that, so before this can merge we may want to investigate filtering out any results that don’t cross some confidence threshold in the classifier.

/cc @arfon