### PR TITLE
'Text' shouldn't qualify as a valid modeline language.

### DIFF
--- a/lib/linguist/strategy/modeline.rb
+++ b/lib/linguist/strategy/modeline.rb
@@ -1,7 +1,7 @@
 module Linguist
   module Strategy
     class Modeline
-      EmacsModeline = /-\*-\s*(?:mode:)?\s*(\w+);?\s*-\*-/
+      EmacsModeline = /-\*-\s*mode:\s*(\w+);?\s*-\*-/
       VimModeline = /\/\*\s*vim:\s*set\s*(?:ft|filetype)=(\w+):\s*\*\//
 
       # Public: Detects language based on Vim and Emacs modelines

--- a/test/fixtures/Data/Modelines/example_smalltalk.md
+++ b/test/fixtures/Data/Modelines/example_smalltalk.md
@@ -1,1 +1,1 @@
-; -*-Smalltalk-*-
+; -*-mode:Smalltalk-*-


### PR DESCRIPTION
A number of `.f` files previously correctly identified as Forth, are now identified as Text. This is because they contain the Emacs modeline `-*- text -*-`.

Perhaps it would be appropriate to exclude text from the modeline strategy?

http://github.com/search?q=extension%3Af+dup+swap+text&type=Code