### PR TITLE
Add cpplint.py to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -24,6 +24,9 @@
 - (^|/)config.guess$
 - (^|/)config.sub$
 
+# Linters
+- cpplint.py
+
 # Node dependencies
 - node_modules/
 


### PR DESCRIPTION
`cpplint.py` is Google's Python script used for linting C++ files.
I have a small C++ project with `cpplint.py` included mistakenly making
Python the main language of my project.