### PR TITLE
Grammar for Inno Setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -594,3 +594,6 @@
 [submodule "vendor/grammars/ec.tmbundle"]
 	path = vendor/grammars/ec.tmbundle
 	url = https://github.com/ecere/ec.tmbundle
+[submodule "vendor/grammars/InnoSetup"]
+	path = vendor/grammars/InnoSetup
+	url = https://github.com/idleberg/InnoSetup-Sublime-Text

--- a/grammars.yml
+++ b/grammars.yml
@@ -51,6 +51,8 @@ vendor/grammars/Handlebars:
 - text.html.handlebars
 vendor/grammars/IDL-Syntax:
 - source.webidl
+vendor/grammars/InnoSetup/:
+- source.inno
 vendor/grammars/Isabelle.tmbundle:
 - source.isabelle.root
 - source.isabelle.theory

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1346,7 +1346,7 @@ Inform 7:
 Inno Setup:
   extensions:
   - .iss
-  tm_scope: none
+  tm_scope: source.inno
   ace_mode: text
 
 Io:

--- a/samples/Inno Setup/expat.iss
+++ b/samples/Inno Setup/expat.iss
@@ -1,0 +1,69 @@
+; Basic setup script for the Inno Setup installer builder.  For more
+; information on the free installer builder, see www.jrsoftware.org.
+;
+; This script was contributed by Tim Peters.
+; It was designed for Inno Setup 2.0.19 but works with later versions as well.
+
+[Setup]
+AppName=Expat
+AppId=expat
+AppVersion=2.1.0
+AppVerName=Expat 2.1.0
+AppCopyright=Copyright 1998-2012 Thai Open Source Software Center, Clark Cooper, and the Expat maintainers
+AppPublisher=The Expat Developers
+AppPublisherURL=http://www.libexpat.org/
+AppSupportURL=http://www.libexpat.org/
+AppUpdatesURL=http://www.libexpat.org/
+UninstallDisplayName=Expat XML Parser 2.1.0
+VersionInfoVersion=2.1.0
+
+DefaultDirName={pf}\Expat 2.1.0
+UninstallFilesDir={app}\Uninstall
+
+Compression=lzma
+SolidCompression=yes
+SourceDir=..
+OutputDir=win32
+DisableStartupPrompt=yes
+AllowNoIcons=yes
+DisableProgramGroupPage=yes
+DisableReadyPage=yes
+
+[Files]
+Flags: ignoreversion; Source: win32\bin\Release\xmlwf.exe;  DestDir: "{app}\Bin"
+Flags: ignoreversion; Source: win32\MANIFEST.txt;           DestDir: "{app}"
+Flags: ignoreversion; Source: Changes;                      DestDir: "{app}"; DestName: Changes.txt
+Flags: ignoreversion; Source: COPYING;                      DestDir: "{app}"; DestName: COPYING.txt
+Flags: ignoreversion; Source: README;                       DestDir: "{app}"; DestName: README.txt
+Flags: ignoreversion; Source: doc\*.html;                   DestDir: "{app}\Doc"
+Flags: ignoreversion; Source: doc\*.css;                    DestDir: "{app}\Doc"
+Flags: ignoreversion; Source: doc\*.png;                    DestDir: "{app}\Doc"
+Flags: ignoreversion; Source: win32\bin\Release\*.dll;      DestDir: "{app}\Bin"
+Flags: ignoreversion; Source: win32\bin\Release\*.lib;      DestDir: "{app}\Bin"
+Flags: ignoreversion; Source: expat.dsw;                    DestDir: "{app}\Source"
+Flags: ignoreversion; Source: win32\README.txt;             DestDir: "{app}\Source"
+Flags: ignoreversion; Source: bcb5\*.bp*;                   DestDir: "{app}\Source\bcb5"
+Flags: ignoreversion; Source: bcb5\*.mak;                   DestDir: "{app}\Source\bcb5"
+Flags: ignoreversion; Source: bcb5\*.def;                   DestDir: "{app}\Source\bcb5"
+Flags: ignoreversion; Source: bcb5\*.txt;                   DestDir: "{app}\Source\bcb5"
+Flags: ignoreversion; Source: bcb5\*.bat;                   DestDir: "{app}\Source\bcb5"
+Flags: ignoreversion; Source: lib\*.c;                      DestDir: "{app}\Source\lib"
+Flags: ignoreversion; Source: lib\*.h;                      DestDir: "{app}\Source\lib"
+Flags: ignoreversion; Source: lib\*.def;                    DestDir: "{app}\Source\lib"
+Flags: ignoreversion; Source: lib\*.dsp;                    DestDir: "{app}\Source\lib"
+Flags: ignoreversion; Source: examples\*.c;                 DestDir: "{app}\Source\examples"
+Flags: ignoreversion; Source: examples\*.dsp;               DestDir: "{app}\Source\examples"
+Flags: ignoreversion; Source: tests\*.c;                    DestDir: "{app}\Source\tests"
+Flags: ignoreversion; Source: tests\*.cpp;                  DestDir: "{app}\Source\tests"
+Flags: ignoreversion; Source: tests\*.h;                    DestDir: "{app}\Source\tests"
+Flags: ignoreversion; Source: tests\README.txt;             DestDir: "{app}\Source\tests"
+Flags: ignoreversion; Source: tests\benchmark\*.c;          DestDir: "{app}\Source\tests\benchmark"
+Flags: ignoreversion; Source: tests\benchmark\*.ds*;        DestDir: "{app}\Source\tests\benchmark"
+Flags: ignoreversion; Source: tests\benchmark\README.txt;   DestDir: "{app}\Source\tests\benchmark"
+Flags: ignoreversion; Source: xmlwf\*.c*;                   DestDir: "{app}\Source\xmlwf"
+Flags: ignoreversion; Source: xmlwf\*.h;                    DestDir: "{app}\Source\xmlwf"
+Flags: ignoreversion; Source: xmlwf\*.dsp;                  DestDir: "{app}\Source\xmlwf"
+
+[Messages]
+WelcomeLabel1=Welcome to the Expat XML Parser Setup Wizard
+WelcomeLabel2=This will install [name/ver] on your computer.%n%nExpat is an XML parser with a C-language API, and is primarily made available to allow developers to build applications which use XML using a portable API and fast implementation.%n%nIt is strongly recommended that you close all other applications you have running before continuing. This will help prevent any conflicts during the installation process.


### PR DESCRIPTION
This pull request adds a grammar for Inno Setup. I also added a sample file.
I found two grammars for Inno Setup:
- [idleberg/InnoSetup-Sublime-Text](https://github.com/idleberg/InnoSetup-Sublime-Text): [example in Lightshow](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fidleberg%2FInnoSetup-Sublime-Text%2Fmaster%2FInnoSetup.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoapp-packages%2Fexpat%2F21e128c023ff2c55e05f230e5758e6a01e362c2f%2Fwin32%2Fexpat.iss&code=) (the one added in this PR)
- [shadyproject/sublime-inno-setup](https://github.com/shadyproject/sublime-inno-setup): [example in Lightshow](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fshadyproject%2Fsublime-inno-setup%2Fmaster%2FIss.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoapp-packages%2Fexpat%2F21e128c023ff2c55e05f230e5758e6a01e362c2f%2Fwin32%2Fexpat.iss&code=)

I chose the first one because the second one doesn't seem to recognize quoted strings. Also, it seems more active lately. However, the first one recognizes URLs as comments.