### PR TITLE
Shebang first

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -96,8 +96,8 @@ module Linguist
 
     STRATEGIES = [
       Linguist::Strategy::Modeline,
-      Linguist::Strategy::Filename,
       Linguist::Shebang,
+      Linguist::Strategy::Filename,
       Linguist::Heuristics,
       Linguist::Classifier
     ]

--- a/test/fixtures/Shell/crossbuild_liblua5.1
+++ b/test/fixtures/Shell/crossbuild_liblua5.1
@@ -1,0 +1,57 @@
+#! /bin/sh
+#
+# Builds and installs liblua5.1 for the cross toolchain.
+# Executed by build-uqm-dependencies.chroot
+
+# Include our common functions
+. /usr/lib/crossbuild/crossbuild.subr
+
+# envvar LIBLUA51_URL
+#
+# Specifies the URL of the liblua5.1 source tarball you want to use.
+export LIBLUA51_URL="http://www.lua.org/ftp/lua-5.1.5.tar.gz"
+
+# envvar INSTALL_TOP
+#
+# This determines where lua's makefiles install everything (we don't want to use
+# /usr/local!).
+export INSTALL_TOP="/usr/${HOST_TRIPLET}"
+
+# envvar TO_BIN
+#
+# Names of the binary files to install (that's right, lua's makefiles don't
+# determine this automatically, and since we end up with files named according
+# to Windows conventions the install chokes without these)
+export TO_BIN="lua.exe luac.exe"
+
+# envvar TO_LIB
+#
+# Names of the libraries to install, see TO_BIN
+export TO_LIB="liblua.a lua51.dll"
+
+
+# liblua5.1 uses custom makefiles and does not natively support cross-building.
+# However, with our cross toolchain in its PATH it successfully builds the mingw
+# target.
+export PATH=/usr/${HOST_TRIPLET}/bin:${PATH}
+
+echo "*************************************************************************"
+echo "--- BEGIN: crossbuild_liblua5.1 ---"
+
+get_tarball "liblua5.1" "${LIBLUA51_URL}" gz
+
+cd ${SRC_ROOT_DIR}/liblua5.1/*
+
+if [ -f Makefile ]; then
+  make clean
+  make --environment-overrides mingw install
+
+
+else
+  echo "crossbuild_liblua5.1 failed: Could not find Makefile"
+  echo "(is the liblua5.1 source tarball sane?)"
+  exit 1
+fi
+
+echo "--- END: crossbuild_liblua5.1 ---"
+echo "*************************************************************************"

--- a/test/fixtures/Shell/graylog2-server.init.d
+++ b/test/fixtures/Shell/graylog2-server.init.d
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:        graylog2-server
+# Required-Start:  $network
+# Required-Stop:   $network
+# Default-Start:   2 3 4 5
+# Default-Stop:    1
+# Short-Description: Start Graylog2 server
+### END INIT INFO
+
+# Written by Lital Natan <litaln@gmail.com>
+
+PREFIX=/usr
+SHAREDIR=$PREFIX/share/graylog2-server
+SERVER_JAR=$SHAREDIR/graylog2-server.jar
+SYSLOG4J_JAR=$SHAREDIR/syslog4j-0.9.46-bin.jar
+SVCNAME="graylog2-server"
+
+CONFIG="/etc/graylog2.conf"
+LOGFILE="/var/log/graylog2.log"
+PIDFILE="/var/run/graylog2.pid"
+
+start() {
+    if [ ! -e $CONFIG ]; then
+        echo "Config file $CONFIG does not exist"
+        return 1
+    fi
+
+    echo "Starting ${SVCNAME}"
+        nohup `which java` -cp $SERVER_JAR:$SYSLOG4J_JAR org.graylog2.Main \
+      -p ${PIDFILE} -f ${CONFIG} > $LOGFILE 2>&1 &
+
+    # Sleep before testing the service
+    sleep 2
+
+    graylog2_test || return 1
+}
+
+stop() {
+    pid=`< $PIDFILE`
+    kill $pid
+    rm -f ${PIDFILE} # just in case
+}
+
+graylog2_test() {
+    # Graylog2 only deletes its PID file if it hits a config error
+    if [ ! -e ${PIDFILE} ]; then
+        echo "Configuration error, check ${CONFIG}"
+        return 1
+    fi
+
+    local pid=`cat ${PIDFILE}`
+
+    # Graylog2 isn't running, so that means there was a problem
+    if [ ! -e /proc/$pid ]; then
+        echo "Something went wrong, check ${LOGFILE}"
+        rm -f ${PIDFILE}
+        return 1
+    else
+        return 0
+    fi
+}
+
+
+status() {
+    graylog2_test > /dev/null 2>&1
+    if [ "$?" == "0" ]; then
+       echo "Graylog2 server is up"
+       return 0
+    else
+       echo "Graylog2 server is down"
+       return 1
+    fi
+}
+
+
+restart() {
+    stop
+    start
+}
+
+case "$1" in
+    start)
+  start
+  ;;
+    stop)
+  stop
+  ;;
+    status)
+        status
+        ;;
+    restart)
+  restart
+  ;;
+    *)
+  echo "Usage $0 {start|stop|restart|status}"
+  RETVAL=1
+esac


### PR DESCRIPTION
This PR moves the `Shebang` strategy above `Filename`:

```ruby
STRATEGIES = [
  Linguist::Strategy::Modeline,
  Linguist::Shebang,
  Linguist::Strategy::Filename,
  Linguist::Heuristics,
  Linguist::Classifier
]
```

IMO `Modeline` should still be before `Shebang` as it's an explicit statement of content by the user. This PR fixes https://github.com/github/linguist/issues/2081 and https://github.com/github/linguist/issues/1991

@pchaigno said in https://github.com/github/linguist/issues/1991:

> It would require a bit of work since currently the first strategy is also generating the list of candidates but it could surely help solve this type of issue.

I don't believe this is an issue as neither the `Modeline` or `Shebang` strategies rely upon 'incoming' languages like the [`Heuristics` does](https://github.com/github/linguist/blob/f5bc9735afee25446f537f6c4f895b80438c53cc/lib/linguist/heuristics.rb#L16). As the `Filename` strategy still precedes the `Heuristics` we should be OK.

/ cc @pchaigno @bkeepers 