### PR TITLE
Grammar for Mediawiki

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -597,3 +597,6 @@
 [submodule "vendor/grammars/InnoSetup"]
 	path = vendor/grammars/InnoSetup
 	url = https://github.com/idleberg/InnoSetup-Sublime-Text
+[submodule "vendor/grammars/mediawiki.tmbundle"]
+	path = vendor/grammars/mediawiki.tmbundle
+	url = https://github.com/textmate/mediawiki.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -338,6 +338,8 @@ vendor/grammars/matlab.tmbundle:
 - source.octave
 vendor/grammars/maven.tmbundle:
 - text.xml.pom
+vendor/grammars/mediawiki.tmbundle/:
+- text.html.mediawiki
 vendor/grammars/mercury-tmlanguage:
 - source.mercury
 vendor/grammars/monkey.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1807,7 +1807,7 @@ MediaWiki:
   wrap: true
   extensions:
   - .mediawiki
-  tm_scope: none
+  tm_scope: text.html.mediawiki
   ace_mode: text
 
 Mercury:


### PR DESCRIPTION
Grammar from this [TextMate bundle](https://github.com/textmate/mediawiki.tmbundle): [example in Lightshow](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftextmate%2Fmediawiki.tmbundle%2Fmaster%2FSyntaxes%2FMediawiki.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgithub%2Flinguist%2Fmaster%2Fsamples%2FMediaWiki%2Fmediawiki.mediawiki&code=)

[There is an alternative](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftosher%2FMediawiker%2Fmaster%2FMediawiki.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgithub%2Flinguist%2Fmaster%2Fsamples%2FMediaWiki%2Fmediawiki.mediawiki&code=) but it's basically a port of the first one to Sublime Text. I though I would need help to choose but then I saw the two are identical :/