### PR TITLE
Detection by extension made case-insensitive

### DIFF
--- a/lib/linguist/file_blob.rb
+++ b/lib/linguist/file_blob.rb
@@ -67,7 +67,7 @@ module Linguist
     #
     # Returns an Array
     def extensions
-      basename, *segments = File.basename(name).split(".")
+      basename, *segments = File.basename(name).downcase.split(".")
 
       segments.map.with_index do |segment, index|
         "." + segments[index..-1].join(".")

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -80,7 +80,7 @@ module Linguist
           raise ArgumentError, "Extension is missing a '.': #{extension.inspect}"
         end
 
-        @extension_index[extension] << language
+        @extension_index[extension.downcase] << language
       end
 
       language.interpreters.each do |interpreter|
@@ -198,7 +198,7 @@ module Linguist
     # Returns all matching Languages or [] if none were found.
     def self.find_by_extension(extname)
       extname = ".#{extname}" unless extname.start_with?(".")
-      @extension_index[extname]
+      @extension_index[extname.downcase]
     end
 
     # DEPRECATED
@@ -535,8 +535,8 @@ module Linguist
 
     if extnames = extensions[name]
       extnames.each do |extname|
-        if !options['extensions'].index { |x| x.end_with? extname }
-          warn "#{name} has a sample with extension (#{extname}) that isn't explicitly defined in languages.yml" unless extname == '.script!'
+        if !options['extensions'].index { |x| x.downcase.end_with? extname.downcase }
+          warn "#{name} has a sample with extension (#{extname.downcase}) that isn't explicitly defined in languages.yml" unless extname == '.script!'
           options['extensions'] << extname
         end
       end

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -204,7 +204,6 @@ Assembly:
   - nasm
   extensions:
   - .asm
-  - .ASM
   - .a51
   tm_scope: source.asm.x86
   ace_mode: assembly_x86
@@ -349,8 +348,6 @@ C:
   color: "#555"
   extensions:
   - .c
-  - .C
-  - .H
   - .cats
   - .h
   - .idc
@@ -429,8 +426,6 @@ COBOL:
   type: programming
   extensions:
   - .cob
-  - .COB
-  - .CPY
   - .cbl
   - .ccp
   - .cobol
@@ -867,14 +862,6 @@ FORTRAN:
   color: "#4d41b1"
   extensions:
   - .f90
-  - .F
-  - .F03
-  - .F08
-  - .F77
-  - .F90
-  - .F95
-  - .FOR
-  - .FPP
   - .f
   - .f03
   - .f08
@@ -918,9 +905,7 @@ Forth:
   color: "#341708"
   extensions:
   - .fth
-  - .4TH
   - .4th
-  - .F
   - .f
   - .for
   - .forth
@@ -969,7 +954,6 @@ GAS:
   group: Assembly
   extensions:
   - .s
-  - .S
   tm_scope: source.asm.x86
   ace_mode: assembly_x86
 
@@ -1127,7 +1111,6 @@ Graphviz (DOT):
   tm_scope: source.dot
   extensions:
   - .dot
-  - .DOT
   - .gv
   ace_mode: text
 
@@ -2210,7 +2193,6 @@ Perl:
   color: "#0298c3"
   extensions:
   - .pl
-  - .PL
   - .cgi
   - .fcgi
   - .perl
@@ -2442,8 +2424,6 @@ R:
   - splus
   extensions:
   - .r
-  - .R
-  - .Rd
   - .rd
   - .rsx
   filenames:
@@ -2496,7 +2476,6 @@ RMarkdown:
   ace_mode: markdown
   extensions:
   - .rmd
-  - .Rmd
   tm_scope: none
 
 Racket:
@@ -3201,11 +3180,11 @@ XML:
   - .svg
   - .targets
   - .tmCommand
+  - .tml
   - .tmLanguage
   - .tmPreferences
   - .tmSnippet
   - .tmTheme
-  - .tml
   - .ts
   - .ui
   - .urdf

--- a/samples/Eiffel/application.e
+++ b/samples/Eiffel/application.e
@@ -1,0 +1,44 @@
+note
+	description : "nino application root class"
+	date        : "$Date$"
+	revision    : "$Revision$"
+
+class
+	APPLICATION
+
+inherit
+	ARGUMENTS
+
+	HTTP_SERVER_SHARED_CONFIGURATION
+
+create
+	make
+
+feature {NONE} -- Initialization
+
+	make
+			-- Run application.
+		local
+			l_server : HTTP_SERVER
+			l_cfg: HTTP_SERVER_CONFIGURATION
+			l_http_handler : HTTP_HANDLER
+		do
+			create l_cfg.make
+			l_cfg.http_server_port := 9_000
+			l_cfg.document_root := default_document_root
+			set_server_configuration (l_cfg)
+			debug ("nino")
+				l_cfg.set_is_verbose (True)
+			end
+
+			create l_server.make (l_cfg)
+			create {APPLICATION_CONNECTION_HANDLER} l_http_handler.make (l_server)
+			l_server.setup (l_http_handler)
+		end
+
+feature -- Access
+
+	default_document_root: STRING = "webroot"
+
+end
+

--- a/samples/Eiffel/book_collection.e
+++ b/samples/Eiffel/book_collection.e
@@ -1,0 +1,82 @@
+class
+	BOOK_COLLECTION
+
+create
+	make
+
+feature {NONE} -- Initialization
+
+	make (a_name: STRING_32)
+			-- Create a book collection with `a_name' as `name'.
+		do
+			set_name (a_name)
+			create book_index.make (10)
+		ensure
+			name_set: name = a_name
+		end
+
+feature -- Access
+
+	name: STRING_32
+			-- Name.
+
+	books: LIST [BOOK]
+			-- collection of book.
+		do
+			create {LINKED_LIST [BOOK]} Result.make
+			across
+				book_index as it
+			loop
+				Result.append (it.item)
+			end
+		end
+
+	books_by_author (a_author: STRING_32): LIST [BOOK]
+			-- Books wrote by `a_author' in this collection.
+		do
+			if attached book_index [a_author] as l_result then
+				Result := l_result
+			else
+				create {LINKED_LIST [BOOK]} Result.make
+			end
+		end
+
+feature -- Change
+
+	set_name (a_name: STRING_32)
+			-- Set `name' with `a_name'.
+		do
+			name := a_name
+		ensure
+			name_set: name = a_name
+		end
+
+	add_book (a_book: BOOK)
+			-- Extend collection with `a_book'.
+		local
+			l: detachable LIST [BOOK]
+		do
+			l := book_index.at (a_book.author.name)
+			if l = Void then
+				create {LINKED_LIST [BOOK]} l.make
+				book_index.put (l, a_book.author.name)
+			end
+			l.force (a_book)
+		end
+
+	add_books (book_list: like books)
+			-- Append collection with `book_list'.
+		do
+			across
+				book_list as it
+			loop
+				add_book (it.item)
+			end
+		end
+
+feature {NONE} -- Implementation
+
+	book_index: HASH_TABLE [LIST [BOOK], STRING_32]
+			-- Association of author name and its books.
+
+end -- class BOOK_COLLECTION

--- a/samples/Eiffel/git_checkout_command.e
+++ b/samples/Eiffel/git_checkout_command.e
@@ -1,0 +1,41 @@
+note
+	description: "Git checkout command."
+	author: "Olivier Ligot"
+
+class
+	GIT_CHECKOUT_COMMAND
+
+inherit
+	GIT_COMMAND
+
+create
+	make,
+	make_master
+
+feature {NONE} -- Initialization
+
+	make (a_branch: STRING)
+			-- Checkout the branch `a_branch'.
+		do
+			initialize
+			arguments.force_last (a_branch)
+			branch := a_branch
+		ensure
+			branch_set: branch = a_branch
+		end
+
+	make_master
+			-- Checkout the master branch.
+		do
+			make ("master")
+		end
+
+feature -- Access
+
+	branch: STRING
+			-- Branch to checkout
+
+	name: STRING = "checkout"
+			-- Git subcommand name
+
+end

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -12,7 +12,7 @@ class TestPedantic < Minitest::Test
   def test_extensions_are_sorted
     LANGUAGES.each do |name, language|
       extensions = language['extensions']
-      assert_sorted extensions[1..-1] if extensions && extensions.size > 1
+      assert_sorted extensions[1..-1].map(&:downcase) if extensions && extensions.size > 1
     end
   end
 

--- a/test/test_samples.rb
+++ b/test/test_samples.rb
@@ -43,7 +43,7 @@ class TestSamples < Minitest::Test
       if extnames = Samples.cache['extnames'][name]
         extnames.each do |extname|
           next if extname == '.script!'
-          assert options['extensions'].index { |x| x.end_with? extname }, "#{name} has a sample with extension (#{extname}) that isn't explicitly defined in languages.yml"
+          assert options['extensions'].index { |x| x.downcase.end_with? extname.downcase }, "#{name} has a sample with extension (#{extname.downcase}) that isn't explicitly defined in languages.yml"
         end
       end
 
@@ -67,7 +67,7 @@ class TestSamples < Minitest::Test
         if language_matches.length > 1
           language_matches.each do |match|
             samples = "samples/#{match.name}/*#{extension}"
-            assert Dir.glob(samples).any?, "Missing samples in #{samples.inspect}. See https://github.com/github/linguist/blob/master/CONTRIBUTING.md"
+            assert Dir.glob(samples, File::FNM_CASEFOLD).any?, "Missing samples in #{samples.inspect}. See https://github.com/github/linguist/blob/master/CONTRIBUTING.md"
           end
         end
       end


### PR DESCRIPTION
This is the implementation of an idea @larsbrinkhoff suggested in #2072.
With this pull request the search by file extensions is case-insensitive.
I wanted to see if it creates any issue with the detection.

It actually solves a few incorrect detections and I think it globally makes sense:
For instance, all `.e` files in the [Rosetta project](https://github.com/acmeism/RosettaCodeData) are detected as Eiffel but most of them are actually E code.
With this pull request the detection results get [a lot better](https://gist.github.com/pchaigno/7159e16ac9801507d60f).
In general, it looks like lower-case and upper-case extensions are regularly mixed. See #2072, #308, #268 or #1035 for examples.