### PR TITLE
Add  "use 5.xxx" to Perl Heuristic

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -92,7 +92,7 @@ module Linguist
     disambiguate "Perl", "Perl6", "Prolog" do |data|
       if data.include?("use v6")
         Language["Perl6"]
-      elsif data.include?("use strict")
+      elsif data.match(/use strict|use\s+v?5\./)
         Language["Perl"]
       elsif data.include?(":-")
         Language["Prolog"]

--- a/samples/Perl/use5.pl
+++ b/samples/Perl/use5.pl
@@ -1,0 +1,3 @@
+use Mojolicious::Lite;
+use 5.20.0;
+use experimental 'signatures';

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -48,7 +48,7 @@ class TestHeuristcs < Minitest::Test
   def test_pl_prolog_perl_by_heuristics
     assert_heuristics({
       "Prolog" => "Prolog/turing.pl",
-      "Perl" => "Perl/perl-test.t",
+      "Perl" => ["Perl/perl-test.t", "Perl/use5.pl"]
     })
   end
 


### PR DESCRIPTION
This updates the Perl heuristic to detect "use 5.xxx" as plain ol' Perl.

Fixes: https://github.com/github/linguist/issues/2074

/cc @kentfredric