### PR TITLE
Disambiguate MPEG transport streams from TypeScript files

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -209,6 +209,8 @@ module Linguist
     disambiguate "TypeScript", "XML" do |data|
       if data.include?("<TS ")
         Language["XML"]
+      elsif /\AG/.match(data)
+	    # MPEG transport stream (.ts) starts with 'G'
       else
         Language["TypeScript"]
       end


### PR DESCRIPTION
Determine when a file is an MPEG transport stream

Example of misclassified repo: https://github.com/neil-morrison44/VidiiUStreamer