### PR TITLE
Detect all markup languages when computing language statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ cat .gitattributes
 *.rb linguist-language=Java
 ```
 
-Checking code you didn't write, such as JavaScript libraries, into your git repo is a common practice, but this often inflates your project's language stats and may even cause your project to be labeled as another language. By default, Linguist treats all of the paths defined in [lib/linguist/vendor.yml](https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml) as vendored and therefore doesn't include them in the language statistics for a repository.
+Checking code you didn't write, such as JavaScript libraries, into your git repo is a common practice, but this often inflates your project's language stats and may even cause your project to be labeled as another language. By default, Linguist treats all of the paths defined in [lib/linguist/vendor.yml](https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml) as vendored and therefore doesn't include them in the language statistics for a repository. Vendored files are also hidden by default in diffs on github.com.
 
 Use the `linguist-vendored` attribute to vendor or un-vendor paths.
 
@@ -43,7 +43,7 @@ special-vendored-path/* linguist-vendored
 jquery.js linguist-vendored=false
 ```
 
-Similar to vendored files, Linguist excludes documentation files from your project's language stats. [lib/linguist/documentation.yml](lib/linguist/documentation.yml) lists common documentation paths and excludes them from the language statistics for your repository.
+Similar to vendored files, Linguist excludes documentation files from your project's language stats. (Unlike vendored files, documentation files are displayed in diffs on github.com.) [lib/linguist/documentation.yml](lib/linguist/documentation.yml) lists common documentation paths and excludes them from the language statistics for your repository.
 
 Use the `linguist-documentation` attribute to mark or unmark paths as documentation.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Linguist supports a number of different custom overrides strategies for language
 
 ### Using gitattributes
 
-Add a `.gitattributes` file to your project and use standard git-style path matchers for the files you want to override to set `linguist-language` and `linguist-vendored`.
+Add a `.gitattributes` file to your project and use standard git-style path matchers for the files you want to override to set `linguist-documentation`, `linguist-language`, and `linguist-vendored`.
 
 ```
 $ cat .gitattributes
@@ -41,6 +41,16 @@ Use the `linguist-vendored` attribute to vendor or un-vendor paths.
 $ cat .gitattributes
 special-vendored-path/* linguist-vendored
 jquery.js linguist-vendored=false
+```
+
+Similar to vendored files, Linguist excludes documentation files from your project's language stats. [lib/linguist/documentation.yml](lib/linguist/documentation.yml) lists common documentation paths and excludes them from the language statistics for your repository.
+
+Use the `linguist-documentation` attribute to mark or unmark paths as documentation.
+
+```
+$ cat .gitattributes
+project-docs/* linguist-documentation
+docs/formatter.rb linguist-documentation=false
 ```
 
 ### Using Emacs and Vim modelines

--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -236,6 +236,21 @@ module Linguist
       name =~ VendoredRegexp ? true : false
     end
 
+    documentation_paths = YAML.load_file(File.expand_path("../documentation.yml", __FILE__))
+    DocumentationRegexp = Regexp.new(documentation_paths.join('|'))
+
+    # Public: Is the blob in a documentation directory?
+    #
+    # Documentation files are ignored by language statistics.
+    #
+    # See "documentation.yml" for a list of documentation conventions that match
+    # this pattern.
+    #
+    # Return true or false
+    def documentation?
+      name =~ DocumentationRegexp ? true : false
+    end
+
     # Public: Get each line of data
     #
     # Requires Blob#data

--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -332,5 +332,15 @@ module Linguist
     def tm_scope
       language && language.tm_scope
     end
+
+    DETECTABLE_TYPES = [:programming, :markup].freeze
+
+    # Internal: Should this blob be included in repository language statistics?
+    def include_in_language_stats?
+      !vendored? &&
+      !documentation? &&
+      !generated? &&
+      language && DETECTABLE_TYPES.include?(language.type)
+    end
   end
 end

--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -14,5 +14,6 @@
 
 - (^|/)CONTRIBUTING(\.|$)
 - (^|/)COPYING(\.|$)
+- (^|/)INSTALL(\.|$)
 - (^|/)LICEN[CS]E(\.|$)
 - (^|/)README(\.|$)

--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -1,0 +1,18 @@
+# Documentation files and directories are excluded from language
+# statistics.
+#
+# Lines in this file are Regexps that are matched against the file
+# pathname.
+#
+# Please add additional test coverage to
+# `test/test_blob.rb#test_documentation` if you make any changes.
+
+## Documentation Conventions ##
+
+- ^docs?/
+- ^Documentation/
+
+- (^|/)CONTRIBUTING(\.|$)
+- (^|/)COPYING(\.|$)
+- (^|/)LICEN[CS]E(\.|$)
+- (^|/)README(\.|$)

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -32,13 +32,6 @@ module Linguist
     # Valid Languages types
     TYPES = [:data, :markup, :programming, :prose]
 
-    # Names of non-programming languages that we will still detect
-    #
-    # Returns an array
-    def self.detectable_markup
-      ["CSS", "Less", "Sass", "SCSS", "Stylus", "TeX"]
-    end
-
     # Detect languages by a specific type
     #
     # type - A symbol that exists within TYPES

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2684,6 +2684,13 @@ STON:
   tm_scope: source.smalltalk
   ace_mode: text
 
+SVG:
+  type: data
+  extensions:
+  - .svg
+  tm_scope: source.xml
+  ace_mode: xml
+
 Sage:
   type: programming
   group: Python
@@ -3199,7 +3206,6 @@ XML:
   - .srdf
   - .stTheme
   - .sublime-snippet
-  - .svg
   - .targets
   - .tmCommand
   - .tmLanguage

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -439,6 +439,7 @@ COBOL:
 
 CSS:
   type: markup
+  tm_scope: source.css
   ace_mode: css
   color: "#563d7c"
   extensions:
@@ -2688,7 +2689,7 @@ SVG:
   type: data
   extensions:
   - .svg
-  tm_scope: source.xml
+  tm_scope: text.xml
   ace_mode: xml
 
 Sage:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -438,6 +438,7 @@ COBOL:
   ace_mode: cobol
 
 CSS:
+  type: markup
   ace_mode: css
   color: "#563d7c"
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1174,6 +1174,7 @@ HTML:
   type: markup
   tm_scope: text.html.basic
   ace_mode: html
+  color: "#e44b23"
   aliases:
   - xhtml
   extensions:

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -4,7 +4,7 @@ require 'rugged'
 
 module Linguist
   class LazyBlob
-    GIT_ATTR = ['linguist-language', 'linguist-vendored']
+    GIT_ATTR = ['linguist-documentation', 'linguist-language', 'linguist-vendored']
     GIT_ATTR_OPTS = { :priority => [:index], :skip_system => true }
     GIT_ATTR_FLAGS = Rugged::Repository::Attributes.parse_opts(GIT_ATTR_OPTS)
 
@@ -34,6 +34,14 @@ module Linguist
         return boolean_attribute(attr)
       else
         return super
+      end
+    end
+
+    def documentation?
+      if attr = git_attributes['linguist-documentation']
+        boolean_attribute(attr)
+      else
+        super
       end
     end
 

--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -8,6 +8,8 @@ module Linguist
   # Its primary purpose is for gathering language statistics across
   # the entire project.
   class Repository
+    DETECTABLE_TYPES = [:programming, :markup].freeze
+
     attr_reader :repository
 
     # Public: Create a new Repository based on the stats of
@@ -159,8 +161,7 @@ module Linguist
           # Skip vendored or generated blobs
           next if blob.vendored? || blob.generated? || blob.language.nil?
 
-          # Only include programming languages and acceptable markup languages
-          if blob.language.type == :programming || Language.detectable_markup.include?(blob.language.name)
+          if DETECTABLE_TYPES.include?(blob.language.type)
             file_map[new] = [blob.language.group.name, blob.size]
           end
         end

--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -159,7 +159,7 @@ module Linguist
           blob = Linguist::LazyBlob.new(repository, delta.new_file[:oid], new, mode.to_s(8))
 
           # Skip vendored or generated blobs
-          next if blob.vendored? || blob.generated? || blob.language.nil?
+          next if blob.vendored? || blob.documentation? || blob.generated? || blob.language.nil?
 
           if DETECTABLE_TYPES.include?(blob.language.type)
             file_map[new] = [blob.language.group.name, blob.size]

--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -8,8 +8,6 @@ module Linguist
   # Its primary purpose is for gathering language statistics across
   # the entire project.
   class Repository
-    DETECTABLE_TYPES = [:programming, :markup].freeze
-
     attr_reader :repository
 
     # Public: Create a new Repository based on the stats of
@@ -158,12 +156,8 @@ module Linguist
 
           blob = Linguist::LazyBlob.new(repository, delta.new_file[:oid], new, mode.to_s(8))
 
-          # Skip vendored or generated blobs
-          next if blob.vendored? || blob.documentation? || blob.generated? || blob.language.nil?
-
-          if DETECTABLE_TYPES.include?(blob.language.type)
-            file_map[new] = [blob.language.group.name, blob.size]
-          end
+          next unless blob.include_in_language_stats?
+          file_map[new] = [blob.language.group.name, blob.size]
         end
       end
 

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -517,4 +517,29 @@ class TestBlob < Minitest::Test
     refute blob.new(" ").empty?
     refute blob.new("nope").empty?
   end
+
+  def test_include_in_language_stats
+    vendored = sample_blob("bower_components/custom/custom.js")
+    assert_predicate vendored, :vendored?
+    refute_predicate vendored, :include_in_language_stats?
+
+    documentation = fixture_blob("README")
+    assert_predicate documentation, :documentation?
+    refute_predicate documentation, :include_in_language_stats?
+
+    generated = sample_blob("CSS/bootstrap.min.css")
+    assert_predicate generated, :generated?
+    refute_predicate generated, :include_in_language_stats?
+
+    data = sample_blob("Ant Build System/filenames/ant.xml")
+    assert_equal :data, data.language.type
+    refute_predicate data, :include_in_language_stats?
+
+    prose = sample_blob("Markdown/tender.md")
+    assert_equal :prose, prose.language.type
+    refute_predicate prose, :include_in_language_stats?
+
+    included = sample_blob("HTML/pages.html")
+    assert_predicate included, :include_in_language_stats?
+  end
 end

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -470,6 +470,11 @@ class TestBlob < Minitest::Test
     assert_predicate fixture_blob("COPYING.txt"), :documentation?
     assert_predicate fixture_blob("foo/COPYING"), :documentation?
 
+    assert_predicate fixture_blob("INSTALL"), :documentation?
+    assert_predicate fixture_blob("INSTALL.md"), :documentation?
+    assert_predicate fixture_blob("INSTALL.txt"), :documentation?
+    assert_predicate fixture_blob("foo/INSTALL"), :documentation?
+
     refute_predicate fixture_blob("foo.md"), :documentation?
   end
 

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -441,6 +441,38 @@ class TestBlob < Minitest::Test
     assert sample_blob("subproject/activator.bat").vendored?
   end
 
+  def test_documentation
+    assert_predicate fixture_blob("doc/foo.md"), :documentation?
+    assert_predicate fixture_blob("docs/foo.md"), :documentation?
+    refute_predicate fixture_blob("project/doc/foo.md"), :documentation?
+    refute_predicate fixture_blob("project/docs/foo.md"), :documentation?
+
+    assert_predicate fixture_blob("Documentation/foo.md"), :documentation?
+    refute_predicate fixture_blob("project/Documentation/foo.md"), :documentation?
+
+    assert_predicate fixture_blob("README"), :documentation?
+    assert_predicate fixture_blob("README.md"), :documentation?
+    assert_predicate fixture_blob("README.txt"), :documentation?
+    assert_predicate fixture_blob("foo/README"), :documentation?
+
+    assert_predicate fixture_blob("CONTRIBUTING"), :documentation?
+    assert_predicate fixture_blob("CONTRIBUTING.md"), :documentation?
+    assert_predicate fixture_blob("CONTRIBUTING.txt"), :documentation?
+    assert_predicate fixture_blob("foo/CONTRIBUTING"), :documentation?
+
+    assert_predicate fixture_blob("LICENSE"), :documentation?
+    assert_predicate fixture_blob("LICENCE.md"), :documentation?
+    assert_predicate fixture_blob("LICENSE.txt"), :documentation?
+    assert_predicate fixture_blob("foo/LICENSE"), :documentation?
+
+    assert_predicate fixture_blob("COPYING"), :documentation?
+    assert_predicate fixture_blob("COPYING.md"), :documentation?
+    assert_predicate fixture_blob("COPYING.txt"), :documentation?
+    assert_predicate fixture_blob("foo/COPYING"), :documentation?
+
+    refute_predicate fixture_blob("foo.md"), :documentation?
+  end
+
   def test_language
     Samples.each do |sample|
       blob = sample_blob(sample[:path])

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -442,10 +442,10 @@ class TestBlob < Minitest::Test
   end
 
   def test_documentation
-    assert_predicate fixture_blob("doc/foo.md"), :documentation?
-    assert_predicate fixture_blob("docs/foo.md"), :documentation?
-    refute_predicate fixture_blob("project/doc/foo.md"), :documentation?
-    refute_predicate fixture_blob("project/docs/foo.md"), :documentation?
+    assert_predicate fixture_blob("doc/foo.html"), :documentation?
+    assert_predicate fixture_blob("docs/foo.html"), :documentation?
+    refute_predicate fixture_blob("project/doc/foo.html"), :documentation?
+    refute_predicate fixture_blob("project/docs/foo.html"), :documentation?
 
     assert_predicate fixture_blob("Documentation/foo.md"), :documentation?
     refute_predicate fixture_blob("project/Documentation/foo.md"), :documentation?

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -99,4 +99,16 @@ class TestRepository < Minitest::Test
     # overridden .gitattributes
     assert !override_unvendored.vendored?
   end
+
+  def test_linguist_override_documentation?
+    attr_commit = "d4c8fb8a28e91f97a7e53428a365c0abbac36d3d"
+    repo = linguist_repo(attr_commit).read_index
+
+    readme = Linguist::LazyBlob.new(rugged_repository, attr_commit, "README.md")
+    arduino = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/Arduino/hello.ino")
+
+    # overridden by .gitattributes
+    refute_predicate readme, :documentation?
+    assert_predicate arduino, :documentation?
+  end
 end


### PR DESCRIPTION
Originally, only `programming` languages were included in repository language statistics. In 33ebee0f6a1e097550df0c7a69c5ffe57223f558 we started detecting a few selected `markup` languages as well. We didn't include all `markup` languages because at the time formats like Markdown and AsciiDoc were labeled as `markup` languages, and we thought that including those prose (i.e., non-code) languages in repository statistics on github.com was misleading for repositories that are largely about code but also contain a lot of documentation (e.g., https://github.com/rails/rails).

This hand-picked set of whitelisted `markup` languages can cause strange categorization for some repositories. For example, it includes CSS (and some variants) but not HTML. This results in repositories that contain the source code for a static website being classified as either a JavaScript (`programming`) or CSS (`markup`) repository, with no mention of HTML anywhere.

Fast-forward to today, and prose languages are no longer `markup` languages; they're now `prose` languages. So now we can include all `markup` languages in repository language statistics without worrying about undesirable effects for documentation-heavy repositories.

/cc @tnm @gjtorikian @bkeepers @arfon 