### PR TITLE
change submodule url for proper AS3 syntax highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -249,7 +249,7 @@
 	url = https://github.com/shellderp/sublime-robot-plugin
 [submodule "vendor/grammars/actionscript3-tmbundle"]
 	path = vendor/grammars/actionscript3-tmbundle
-	url = https://github.com/simongregory/actionscript3-tmbundle
+	url = https://github.com/honzabrecka/actionscript3-tmbundle
 [submodule "vendor/grammars/Sublime-QML"]
 	path = vendor/grammars/Sublime-QML
 	url = https://github.com/skozlovf/Sublime-QML


### PR DESCRIPTION
Current grammar doesn't work well with. It properly color neither code written in Flash Professional nor well identified code snippets in README (discussed in #2067). It works only if the complete class is defined, which can be useful for text editor, but not for GitHub's purposes. I think that it should work as expected, otherwise it's useless feature.