### PR TITLE
Made assembly color more noticeable

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -198,7 +198,7 @@ AspectJ:
 
 Assembly:
   type: programming
-  color: "#a67219"
+  color: "#6E4C13"
   search_term: nasm
   aliases:
   - nasm


### PR DESCRIPTION
It's bothered me for a while; the Java and Assembly color look almost exactly alike. [Here's](https://imgur.com/XayyV0L) a picture for a comparison.

Anyway, this pull request changes the Assembly color from #a67219 to [#6E4C13](http://www.colorpicker.com/6e4c13), which makes it look darker and more distinctive compared to Java.