### PR TITLE
Improve repository language statistics

### DIFF
--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -10,7 +10,8 @@
 ## Documentation Conventions ##
 
 - ^docs?/
-- ^Documentation/
+- ^[Dd]ocumentation/
+- ^man/
 
 - (^|/)CONTRIBUTING(\.|$)
 - (^|/)COPYING(\.|$)

--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -10,7 +10,7 @@
 ## Documentation directories ##
 
 - ^docs?/
-- ^[Dd]ocumentation/
+- (^|/)[Dd]ocumentation/
 - (^|/)javadoc/
 - ^man/
 

--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -7,11 +7,14 @@
 # Please add additional test coverage to
 # `test/test_blob.rb#test_documentation` if you make any changes.
 
-## Documentation Conventions ##
+## Documentation directories ##
 
 - ^docs?/
 - ^[Dd]ocumentation/
+- (^|/)javadoc/
 - ^man/
+
+## Documentation files ##
 
 - (^|/)CONTRIBUTING(\.|$)
 - (^|/)COPYING(\.|$)

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3165,7 +3165,7 @@ XC:
   ace_mode: c_cpp
 
 XML:
-  type: markup
+  type: data
   ace_mode: xml
   aliases:
   - rss

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -251,3 +251,6 @@
 # ProGuard
 - proguard.pro
 - proguard-rules.pro
+
+# Android Google APIs
+- (^|/)\.google_apis/

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -452,6 +452,9 @@ class TestBlob < Minitest::Test
     refute_predicate fixture_blob("project/Documentation/foo.md"), :documentation?
     refute_predicate fixture_blob("project/documentation/foo.md"), :documentation?
 
+    assert_predicate fixture_blob("javadoc/foo.html"), :documentation?
+    assert_predicate fixture_blob("project/javadoc/foo.html"), :documentation?
+
     assert_predicate fixture_blob("man/foo.html"), :documentation?
     refute_predicate fixture_blob("project/man/foo.html"), :documentation?
 

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -449,8 +449,8 @@ class TestBlob < Minitest::Test
 
     assert_predicate fixture_blob("Documentation/foo.md"), :documentation?
     assert_predicate fixture_blob("documentation/foo.md"), :documentation?
-    refute_predicate fixture_blob("project/Documentation/foo.md"), :documentation?
-    refute_predicate fixture_blob("project/documentation/foo.md"), :documentation?
+    assert_predicate fixture_blob("project/Documentation/foo.md"), :documentation?
+    assert_predicate fixture_blob("project/documentation/foo.md"), :documentation?
 
     assert_predicate fixture_blob("javadoc/foo.html"), :documentation?
     assert_predicate fixture_blob("project/javadoc/foo.html"), :documentation?

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -448,7 +448,12 @@ class TestBlob < Minitest::Test
     refute_predicate fixture_blob("project/docs/foo.html"), :documentation?
 
     assert_predicate fixture_blob("Documentation/foo.md"), :documentation?
+    assert_predicate fixture_blob("documentation/foo.md"), :documentation?
     refute_predicate fixture_blob("project/Documentation/foo.md"), :documentation?
+    refute_predicate fixture_blob("project/documentation/foo.md"), :documentation?
+
+    assert_predicate fixture_blob("man/foo.html"), :documentation?
+    refute_predicate fixture_blob("project/man/foo.html"), :documentation?
 
     assert_predicate fixture_blob("README"), :documentation?
     assert_predicate fixture_blob("README.md"), :documentation?

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -439,6 +439,9 @@ class TestBlob < Minitest::Test
     assert sample_blob("activator.bat").vendored?
     assert sample_blob("subproject/activator").vendored?
     assert sample_blob("subproject/activator.bat").vendored?
+
+    assert_predicate fixture_blob(".google_apis/bar.jar"), :vendored?
+    assert_predicate fixture_blob("foo/.google_apis/bar.jar"), :vendored?
   end
 
   def test_documentation


### PR DESCRIPTION
This PR fixes a number of bugs that have been pointed out since #2097 landed.

* Reclassifies XML as `data`, since in most cases it is merely a serialization format for a tool (e.g., a project file for an IDE), not something essential to the repository that contains it.
* Adds a few more documentation and vendor patterns based on some repositories that are getting misclassified as HTML.

I'm still looking for more misclassified repos and will update this PR with more fixes.

Fixes #2124 #2134 #2138 

/cc @github/linguist 