### PR TITLE
Add a color code for J language to languages.yml.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1379,6 +1379,7 @@ Isabelle:
 
 J:
   type: programming
+  color: "#2d8abd"
   extensions:
   - .ijs
   tm_scope: source.j


### PR DESCRIPTION
This color is the arithmetic average of the colors of the [J wiki icon](http://www.jsoftware.com/jwiki/moin_static194/common/jwlogo.png).  And yes, I used J to compute the average. :recycle: 