### PR TITLE
Finding by alias too.

### DIFF
--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -49,7 +49,7 @@ module Linguist
       return @language if defined?(@language)
 
       @language = if lang = git_attributes['linguist-language']
-        Language.find_by_name(lang)
+        Language.find_by_alias(lang)
       else
         super
       end


### PR DESCRIPTION
Linguist overrides using the language aliases should work too. Previously they didn't as we did `find_by_name` instead of `find_by_alias` 

See [here](https://github.com/MarioZ/MadMilkman.Ini/commit/042dcdb8fd365ef91ac05dc18df8a48cb5013b90) for an example of this issue

/ cc @MarioZ 