### PR TITLE
Use correct VCL syntax highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -630,3 +630,6 @@
 [submodule "vendor/grammars/Lean.tmbundle"]
 	path = vendor/grammars/Lean.tmbundle
 	url = https://github.com/leanprover/Lean.tmbundle
+[submodule "vendor/grammars/sublime-varnish"]
+	path = vendor/grammars/sublime-varnish
+	url = https://github.com/brandonwamboldt/sublime-varnish

--- a/grammars.yml
+++ b/grammars.yml
@@ -490,6 +490,8 @@ vendor/grammars/sublime-text-ox/:
 - source.ox
 vendor/grammars/sublime-text-pig-latin/:
 - source.pig_latin
+vendor/grammars/sublime-varnish:
+- source.varnish.vcl
 vendor/grammars/sublime_cobol:
 - source.acucobol
 - source.cobol

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3102,11 +3102,11 @@ UnrealScript:
 
 VCL:
   type: programming
-  ace_mode: perl
   color: "#0298c3"
   extensions:
   - .vcl
-  tm_scope: source.perl
+  tm_scope: source.varnish.vcl
+  ace_mode: text
 
 VHDL:
   type: programming


### PR DESCRIPTION
GitHub current uses Perl as it was "close enough" but I think we should use proper syntax highlighting :)

I've added my own repo which is a Sublime Text plugin for Syntax highlighting (MIT licensed). My Nginx one is currently used so I assume the VCL one should work the same.