### PR TITLE
Add instrumentation to detection and classification

### DIFF
--- a/lib/linguist.rb
+++ b/lib/linguist.rb
@@ -6,3 +6,15 @@ require 'linguist/repository'
 require 'linguist/samples'
 require 'linguist/shebang'
 require 'linguist/version'
+
+class << Linguist
+  attr_accessor :instrumenter
+
+  def instrument(*args, &bk)
+    if instrumenter
+      instrumenter.instrument(*args, &bk)
+    else
+      yield
+    end
+  end
+end

--- a/lib/linguist/classifier.rb
+++ b/lib/linguist/classifier.rb
@@ -16,9 +16,11 @@ module Linguist
     #
     # Returns an Array of Language objects, most probable first.
     def self.call(blob, possible_languages)
-      language_names = possible_languages.map(&:name)
-      classify(Samples.cache, blob.data, language_names).map do |name, _|
-        Language[name] # Return the actual Language objects
+      Linguist.instrument("linguist.bayesian_classification") do
+        language_names = possible_languages.map(&:name)
+        classify(Samples.cache, blob.data, language_names).map do |name, _|
+          Language[name] # Return the actual Language objects
+        end
       end
     end
 

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -105,19 +105,21 @@ module Linguist
       # Bail early if the blob is binary or empty.
       return nil if blob.likely_binary? || blob.binary? || blob.empty?
 
-      # Call each strategy until one candidate is returned.
-      STRATEGIES.reduce([]) do |languages, strategy|
-        candidates = strategy.call(blob, languages)
-        if candidates.size == 1
-          return candidates.first
-        elsif candidates.size > 1
-          # More than one candidate was found, pass them to the next strategy.
-          candidates
-        else
-          # No candiates were found, pass on languages from the previous strategy.
-          languages
-        end
-      end.first
+      Linguist.instrument("linguist.detection") do
+        # Call each strategy until one candidate is returned.
+        STRATEGIES.reduce([]) do |languages, strategy|
+          candidates = strategy.call(blob, languages)
+          if candidates.size == 1
+            return candidates.first
+          elsif candidates.size > 1
+            # More than one candidate was found, pass them to the next strategy.
+            candidates
+          else
+            # No candiates were found, pass on languages from the previous strategy.
+            languages
+          end
+        end.first
+      end
     end
 
     # Public: Get all Languages


### PR DESCRIPTION
This pull request adds instrumentation to Linguist's language detection and bayesian classification.

The idea is that applications pulling in Linguist can set `Linguist.instrumenter` to `ActiveSupport::Notifications` (or whatever instrumentation service they're using) to receive instrumentation details whenever Linguist performs a detection or classification.

cc @bkeepers @vmg 