### PR TITLE
Use PHP language detection on .inc files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2171,6 +2171,7 @@ PHP:
   - .aw
   - .ctp
   - .fcgi
+  - .inc
   - .php3
   - .php4
   - .php5


### PR DESCRIPTION
It's pretty common for PHP projects to have `.inc` files which are PHP, so we should apply heuristic detection against .inc files for PHP detection.

Fixes https://github.com/github/linguist/issues/1799