### PR TITLE
Exclude `examples` folder

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -210,6 +210,9 @@
 # Samples folders
 - ^[Ss]amples/
 
+# Examples folders
+- ^[Ee]xamples/
+
 # LICENSE, README, git config files
 - ^COPYING$
 - LICENSE$


### PR DESCRIPTION
I would say its even more common than the Samples folder (see Reveal.js, Three.js, Express, Meteor, Backbone...)

I was forced to use a `.gitattributes` to exclude the "examples" folder from the language stats, as my whole project was marked as HTML instead of Javascript.