### PR TITLE
Grammar for OpenSCAD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -630,3 +630,6 @@
 [submodule "vendor/grammars/Lean.tmbundle"]
 	path = vendor/grammars/Lean.tmbundle
 	url = https://github.com/leanprover/Lean.tmbundle
+[submodule "vendor/grammars/openscad.tmbundle"]
+	path = vendor/grammars/openscad.tmbundle
+	url = https://github.com/tbuser/openscad.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -383,6 +383,8 @@ vendor/grammars/ooc.tmbundle:
 - source.ooc
 vendor/grammars/opa.tmbundle:
 - source.opa
+vendor/grammars/openscad.tmbundle/:
+- source.scad
 vendor/grammars/oz-tmbundle/Syntaxes/Oz.tmLanguage:
 - source.oz
 vendor/grammars/pascal.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2117,7 +2117,7 @@ OpenSCAD:
   type: programming
   extensions:
   - .scad
-  tm_scope: none
+  tm_scope: source.scad
   ace_mode: scad
 
 Org:


### PR DESCRIPTION
This pull requests adds [tbuser/openscad.tmbundle](https://github.com/tbuser/openscad.tmbundle) as a grammar for OpenSCAD.
[Here is an example of the highlighting in Lightshow.](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftbuser%2Fopenscad.tmbundle%2Fmaster%2FSyntaxes%2FOpenSCAD.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgithub%2Flinguist%2Fmaster%2Fsamples%2FOpenSCAD%2Fnot_simple.scad&code=)