### PR TITLE
Standardized color hexcode length to 6

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -356,7 +356,7 @@ Bro:
 
 C:
   type: programming
-  color: "#555"
+  color: "#555555"
   extensions:
   - .c
   - .cats


### PR DESCRIPTION
C was the only language to have a hex code length of 3. 
#555555 == #555 == rgb(85, 85, 85)