### PR TITLE
Ignore symbolic links

### DIFF
--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -150,9 +150,9 @@ module Linguist
         next if delta.binary
 
         if [:added, :modified].include? delta.status
-          # Skip submodules
+          # Skip submodules and symlinks
           mode = delta.new_file[:mode]
-          next if (mode & 040000) != 0
+          next if (mode & 0040000) != 0 || (mode & 0120000) != 0
 
           blob = Linguist::LazyBlob.new(repository, delta.new_file[:oid], new, mode.to_s(8))
 

--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -152,7 +152,8 @@ module Linguist
         if [:added, :modified].include? delta.status
           # Skip submodules and symlinks
           mode = delta.new_file[:mode]
-          next if (mode & 0040000) != 0 || (mode & 0120000) != 0
+          mode_format = (mode & 0170000)
+          next if mode_format == 0120000 || mode_format == 040000 || mode_format == 0160000
 
           blob = Linguist::LazyBlob.new(repository, delta.new_file[:oid], new, mode.to_s(8))
 

--- a/test/fixtures/SVG/alg_schema.link.svg
+++ b/test/fixtures/SVG/alg_schema.link.svg
@@ -1,0 +1,1 @@
+alg_schema.svg

--- a/test/fixtures/SVG/alg_schema.svg
+++ b/test/fixtures/SVG/alg_schema.svg
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="744.09448819"
+   height="1052.3622047"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="alg_schema.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.834386"
+     inkscape:cx="409.42881"
+     inkscape:cy="681.83774"
+     inkscape:document-units="px"
+     inkscape:current-layer="g3759"
+     showgrid="false"
+     inkscape:window-width="1280"
+     inkscape:window-height="993"
+     inkscape:window-x="1280"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3914" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g3759"
+       transform="translate(-3.3909149,-21.218048)">
+      <rect
+         ry="11.855058"
+         rx="14.468504"
+         y="138.58023"
+         x="108.08632"
+         height="66.263969"
+         width="247.48737"
+         id="rect2985"
+         style="fill:#1f3d55;fill-opacity:1;fill-rule:evenodd;stroke:#3f5d75;stroke-width:5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <text
+         sodipodi:linespacing="125%"
+         id="text3755"
+         y="163.58023"
+         x="238.39091"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:24px;text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1"
+           y="163.58023"
+           x="238.39091"
+           id="tspan3757"
+           sodipodi:role="line">Sequence KEY</tspan><tspan
+           style="font-size:24px;text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1"
+           y="193.58023"
+           x="238.39091"
+           sodipodi:role="line"
+           id="tspan4055">256 bits</tspan></text>
+    </g>
+    <g
+       id="g3870"
+       transform="translate(-0.73178617,29.27145)">
+      <g
+         id="g3759-5"
+         transform="translate(-0.40143056,286.32219)">
+        <rect
+           style="fill:#1f3d55;fill-opacity:1;fill-rule:evenodd;stroke:#3f5d75;stroke-width:5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           id="rect2985-5"
+           width="247.48737"
+           height="74.751289"
+           x="108.08632"
+           y="130.09291"
+           rx="14.468504"
+           ry="13.373494" />
+        <flowRoot
+           transform="translate(2.4712344,-292.01415)"
+           style="font-size:24px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
+           id="flowRoot3797"
+           xml:space="preserve"><flowRegion
+             id="flowRegion3799"><rect
+               style="font-size:24px;text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1"
+               y="428.79074"
+               x="125"
+               height="58.346195"
+               width="86.479271"
+               id="rect3801" /></flowRegion><flowPara
+             id="flowPara3805">Salt</flowPara><flowPara
+             id="flowPara3841">96 bits</flowPara></flowRoot>        <flowRoot
+           transform="translate(115.26831,-291.40674)"
+           style="font-size:24px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
+           id="flowRoot3797-6"
+           xml:space="preserve"><flowRegion
+             id="flowRegion3799-5"><rect
+               style="font-size:24px;text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1"
+               y="428.79074"
+               x="125"
+               height="60.933453"
+               width="104.07261"
+               id="rect3801-6" /></flowRegion><flowPara
+             id="flowPara3805-9">Counter</flowPara><flowPara
+             id="flowPara3809-3">32 bits</flowPara></flowRoot>        <path
+           inkscape:connector-curvature="0"
+           id="path3845"
+           d="m 229.11476,138.88943 0,57.95451"
+           style="fill:none;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.6979728,0,0,0.6979728,71.363842,197.71804)"
+       id="g3759-7">
+      <rect
+         ry="13.373494"
+         rx="14.297379"
+         y="130.09291"
+         x="108.08632"
+         height="74.751289"
+         width="244.56023"
+         id="rect2985-4"
+         style="fill:#1f3d55;fill-opacity:1;fill-rule:evenodd;stroke:#3f5d75;stroke-width:7.16360283;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <text
+         sodipodi:linespacing="125%"
+         id="text3755-5"
+         y="178.58023"
+         x="141.31805"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#beff83;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:32px;fill:#beff83;fill-opacity:1"
+           y="178.58023"
+           x="141.31805"
+           id="tspan3757-2"
+           sodipodi:role="line">AES Cipher</tspan></text>
+    </g>
+    <path
+       style="fill:#6ea1cc;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 225,437.36218 0,-50 -15,5 25,-35 25,35 -15,-5 0,50 z"
+       id="path3912"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:#6ea1cc;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 340,302.36218 50,0 -5,-15 35,25 -35,25 5,-15 -50,0 z"
+       id="path3912-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="fill:#6ea1cc;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 245,192.36218 0,50 15,-5 -25,35 -25,-35 15,5 0,-50 z"
+       id="path3912-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <g
+       transform="matrix(0.6979728,0,0,0.6979728,361.36384,197.71804)"
+       id="g3759-7-7">
+      <rect
+         ry="13.373494"
+         rx="17.857012"
+         y="130.09291"
+         x="108.08632"
+         height="74.751289"
+         width="305.44867"
+         id="rect2985-4-4"
+         style="fill:#1f3d55;fill-opacity:1;fill-rule:evenodd;stroke:#3f5d75;stroke-width:7.16360283;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <text
+         sodipodi:linespacing="125%"
+         id="text3755-5-4"
+         y="159.80484"
+         x="255.9357"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#beff83;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
+         xml:space="preserve"><tspan
+           style="font-size:25.78897095px;text-align:center;text-anchor:middle;fill:#beff83;fill-opacity:1"
+           y="159.80484"
+           x="255.9357"
+           sodipodi:role="line"
+           id="tspan3979">Secure random data</tspan><tspan
+           style="font-size:25.78897095px;text-align:center;text-anchor:middle;fill:#beff83;fill-opacity:1"
+           y="192.04105"
+           x="255.9357"
+           sodipodi:role="line"
+           id="tspan3983">128 bits</tspan></text>
+    </g>
+    <path
+       style="fill:#6ea1cc;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.45614035"
+       d="m 550,352.36218 0,50 15,-5 -25,35 -25,-35 15,5 0,-50 z"
+       id="path3912-5-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
+       x="540"
+       y="382.36218"
+       id="text4003"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         x="540"
+         y="382.36218"
+         id="tspan4007"
+         style="font-size:16px;text-align:center;text-anchor:middle">Division by alphabet length</tspan><tspan
+         sodipodi:role="line"
+         x="540"
+         y="402.36218"
+         style="font-size:16px;text-align:center;text-anchor:middle"
+         id="tspan4053">repeated passcode-length times.</tspan></text>
+    <g
+       transform="matrix(0.6979728,0,0,0.6979728,344.55869,369.3865)"
+       id="g3759-7-7-7">
+      <g
+         id="g4045"
+         transform="translate(-1.21417,-6.070852)">
+        <rect
+           style="fill:#1f3d55;fill-opacity:1;fill-rule:evenodd;stroke:#3f5d75;stroke-width:7.16360283;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+           id="rect2985-4-4-8"
+           width="305.44867"
+           height="74.751289"
+           x="131.15555"
+           y="130.09291"
+           rx="17.857012"
+           ry="13.373494" />
+        <text
+           xml:space="preserve"
+           style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#beff83;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;-inkscape-font-specification:Bitstream Vera Sans"
+           x="283.77673"
+           y="158.71724"
+           id="text3755-5-4-6"
+           sodipodi:linespacing="125%"><tspan
+             id="tspan3983-8"
+             sodipodi:role="line"
+             x="283.77673"
+             y="158.71724"
+             style="font-size:25.78897095px;text-align:center;text-anchor:middle;fill:#beff83;fill-opacity:1">Passcode</tspan><tspan
+             id="tspan4043"
+             sodipodi:role="line"
+             x="283.77673"
+             y="190.95346"
+             style="font-size:25.78897095px;text-align:center;text-anchor:middle;fill:#beff83;fill-opacity:1">2-16 characters</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
I am opening this pull request to get some help on it.
I am trying to implement the change suggested in #1685 to ignore symbolic links.

@bkeepers suggested to change [these lines in `repository.rb`](https://github.com/github/linguist/blob/master/lib/linguist/repository.rb#L153-L155). Is that going to affect the search results as well? (as @quasado wanted)

I made the changes which should ignore symlinks based on the mode attribute. I tested on the two files that I added in `test/fixtures/SVG/`. It doesn't work, the mode doesn't seem to change for a symbolic link at all... :/