### PR TITLE
very trivial -- Add color for language eC in lib/linguist/languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1465,6 +1465,7 @@ YAML:
 eC:
   type: programming
   search_term: ec
+  color: "#434967"
   primary_extension: .ec
   extensions:
   - .eh


### PR DESCRIPTION
I'm hoping this very trivial change will give eC it's designated color in the language bar of the repository page.
Many thanks!