### PR TITLE
Add designated color of eC language for display in language bar.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3414,6 +3414,7 @@ desktop:
 
 eC:
   type: programming
+  color: "#4A4773"
   search_term: ec
   extensions:
   - .ec


### PR DESCRIPTION
I'm hoping this very trivial change will give eC it's designated color in the language bar of the repository page.
Many thanks!