### PR TITLE
Add colour for XMOS XC in linguist

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3234,6 +3234,7 @@ WebIDL:
 
 XC:
   type: programming
+  color: "#99DA07"
   extensions:
   - .xc
   tm_scope: source.c


### PR DESCRIPTION
Adds a colour matching the XMOS colour scheme for .xc files.