### PR TITLE
QML as a programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2487,7 +2487,7 @@ Python traceback:
   ace_mode: text
 
 QML:
-  type: markup
+  type: programming
   color: "#44a51c"
   extensions:
   - .qml


### PR DESCRIPTION
This pull request sets QML as a programming language as discussed in #1152.