### PR TITLE
Added XC syntax

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -642,3 +642,6 @@
 [submodule "vendor/grammars/sublime-varnish"]
 	path = vendor/grammars/sublime-varnish
 	url = https://github.com/brandonwamboldt/sublime-varnish
+[submodule "vendor/grammars/xc.tmbundle"]
+	path = vendor/grammars/xc.tmbundle
+	url = https://github.com/graymalkin/xc.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -531,8 +531,6 @@ vendor/grammars/verilog.tmbundle:
 vendor/grammars/x86-assembly-textmate-bundle:
 - source.asm.x86
 vendor/grammars/xc.tmbundle/:
-- source.c
-- source.c.platform
 - source.xc
 vendor/grammars/xml.tmbundle:
 - text.xml

--- a/grammars.yml
+++ b/grammars.yml
@@ -530,6 +530,10 @@ vendor/grammars/verilog.tmbundle:
 - source.verilog
 vendor/grammars/x86-assembly-textmate-bundle:
 - source.asm.x86
+vendor/grammars/xc.tmbundle/:
+- source.c
+- source.c.platform
+- source.xc
 vendor/grammars/xml.tmbundle:
 - text.xml
 - text.xml.xsl

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3237,7 +3237,7 @@ XC:
   color: "#99DA07"
   extensions:
   - .xc
-  tm_scope: source.c
+  tm_scope: source.xc
   ace_mode: c_cpp
 
 XML:


### PR DESCRIPTION
XC has various keywords which aren't part of C++, so while the C++ syntax highlighting mostly works, there's a lot of cases where it doesn't.

I've forked the C/C++ textmate definition and have it working for XC's extra keywords.

See [here](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgraymalkin%2Fxc.tmbundle%2Fmaster%2FSyntaxes%2FXC.plist&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fxcore%2Fsc_avb%2Fblob%2Fmaster%2Fmodule_avb%2Fsrc%2Favb.xc) for a preview.

