### PR TITLE
GLSL should not be in the C group.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -994,7 +994,6 @@ GDScript:
   ace_mode: text
 
 GLSL:
-  group: C
   type: programming
   extensions:
   - .glsl


### PR DESCRIPTION
I believe it was a mistake to put GLSL in the C group.

E.g. this repository is reported as 100% C in the language bar:
https://github.com/larsbrinkhoff/glsl-sphere-tracing