### PR TITLE
Assign handlebars a color for the language bar.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1258,6 +1258,7 @@ Haml:
 
 Handlebars:
   type: markup
+  color: "#fe5629"
   aliases:
   - hbs
   - htmlbars
@@ -2202,7 +2203,7 @@ PHP:
   aliases:
   - inc
 
-#Oracle 
+#Oracle
 PLSQL:
   type: programming
   ace_mode: sql
@@ -2214,7 +2215,7 @@ PLSQL:
   - .plb
   - .sql
 
-#Postgres 
+#Postgres
 PLpgSQL:
   type: programming
   ace_mode: pgsql

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1258,7 +1258,7 @@ Haml:
 
 Handlebars:
   type: markup
-  color: "#fe5629"
+  color: "#01a9d6"
   aliases:
   - hbs
   - htmlbars


### PR DESCRIPTION
I noticed that [Handlebars](http://handlebarsjs.com/) didn't have a color for the language bar.

I used the orange from the [Handlebars T-Shirt](http://devswag.com/collections/handlebars/products/handlebars-t-shirt-1) on DevSwag.

Thanks!

Also I hope it was ok, I found some trailing white space and removed it :grin: 