### PR TITLE
.jbuilder as a Ruby extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2666,6 +2666,7 @@ Ruby:
   - .gemspec
   - .god
   - .irbrc
+  - .jbuilder
   - .mspec
   - .pluginspec
   - .podspec

--- a/samples/Ruby/index.json.jbuilder
+++ b/samples/Ruby/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@courts) do |court|
+  json.extract! court, :id, :name_r, :region, :region_r, :email, :website
+  json.url court_url(court, format: :json)
+end


### PR DESCRIPTION
This pull request adds `.jbuilder` as Ruby extension as discussed in #2194.