### PR TITLE
Exclude gettext catalogues from statistics

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1047,7 +1047,7 @@ Gentoo Eclass:
   ace_mode: sh
 
 Gettext Catalog:
-  type: programming
+  type: prose
   search_term: pot
   searchable: false
   aliases:


### PR DESCRIPTION
Gettext catalogues are used for translations and are thus essentially prose, but were classified as "programming" in 507d191d7d.

In large projects like e.g. wesnoth/wesnoth, gettext can dominate the language statistics with about 95% although the actual code is C++.