### PR TITLE
apt-get update before downloading deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 before_install: script/travis/before_install
 rvm:
   - 1.9.3

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -5,6 +5,8 @@ set -ex
 # Fetch all commits/refs needed to run our tests.
 git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
 
+sudo apt-get update
+
 script/vendor-deb libicu48 libicu-dev
 if ruby -e 'exit RUBY_VERSION >= "2.0" && RUBY_VERSION < "2.1"'; then
   # Workaround for https://bugs.ruby-lang.org/issues/8074. We can't use this


### PR DESCRIPTION
Apparently [it is advised to run `sudo apt-get update`](http://docs.travis-ci.com/user/common-build-problems/#Linux%3A-apt-fails-to-install-package-with-404-error) before using any `apt` commands on travis.

This adds it to our `before_install` script, which also requires that we remove the `sudo: false` flag. We'll see how that impacts the duration of the builds.

/cc @arfon @aroben 