### PR TITLE
languages.yml: don't assume .conf is Apache

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -148,7 +148,6 @@ ApacheConf:
   - apache
   extensions:
   - .apacheconf
-  - .conf
   tm_scope: source.apache-config
   ace_mode: apache_conf
 


### PR DESCRIPTION
The assumption that `.conf` files are Apache is causing many projects to be detected incorrectly as being primarily "ApacheConf".

The `.conf` extension is widely used by software; Apache accounts for only a very tiny proportion of its overall use. The addition of `.conf` for ApacheConf has resulted in projects which contain none (or almost no) Apache config being marked as primarily containing it.

The problem was introduced by 18a3ef9e5e80889d3daf88dab9338a65c97a7310