### PR TITLE
Give Diff a color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -738,6 +738,7 @@ Dart:
 
 Diff:
   type: programming
+  color: "#88dddd"
   extensions:
   - .diff
   - .patch


### PR DESCRIPTION
Diff (Or Patch) is something that is [used quite a lot on GitHub](https://github.com/search?utf8=%E2%9C%93&q=extension%3Adiff+NOT+nothack&type=Code&ref=searchresults) for various things, and it is usually paired with Shell. A lot of repositories, such as the @OvercastNetwork's [SportBukkit](https://github.com/OvercastNetwork/SportBukkit), only use these two things, one of which isn't represented in the language summary. If I somehow magically did this right, it should show the magnificent language in [all it's glory](http://jadonfowler.xyz/diff). 

I'd love to see this great and useful language be put next to Shell. Repositories that only use Shell should only have Shell, and repositories that use Diff & Shell should have both.