### PR TITLE
Handling misconecption of Ocaml and Standard ML in issue #2208

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -71,6 +71,20 @@ module Linguist
         Language["BitBake"]
       end
     end
+    
+    # disambiguity support for OCaml and Standard ML 
+    # -> is very common in Ocaml
+    # => is very common in StandardMl 
+    # using some other reserved words which are used in each language respectively
+    disambiguate "OCaml,Standard ML" do |data|
+    OcamlRegex = /->|assert|class|external|functor|match|mutable|struct|try|inherit|module|virtual/
+    StandardMLRegex = /=>|abstype|datatype|handle|infixr|nonfix|withtype|local|andalso|orelese/
+    if OcamlRegex.match(data)
+      Language["OCaml"]
+      elsif (StandardMLRegex.match(data))
+        Language["Standard ML"]
+      end
+    end
 
     disambiguate "C#", "Smalltalk" do |data|
       if /![\w\s]+methodsFor: /.match(data)


### PR DESCRIPTION
I added code in heuristics.rb of lib folder.
There are few unique keywords which are present uniquely in both the languages.
Ocaml :-     /->|assert|class|external|functor|match|mutable|struct|try|inherit|module|virtual/
Standard ML :-    /=>|abstype|datatype|handle|infixr|nonfix|withtype|local|andalso|orelese/
I created the regular expression and matched it with the data and if keywords are present then return the language which it matched. 