### PR TITLE
Fix the type classification of some languages.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -718,7 +718,7 @@ DTrace:
   ace_mode: c_cpp
 
 Darcs Patch:
-  type: programming
+  type: data
   search_term: dpatch
   aliases:
   - dpatch
@@ -736,13 +736,14 @@ Dart:
   ace_mode: dart
 
 Diff:
-  type: programming
+  type: data
   color: "#88dddd"
   extensions:
   - .diff
   - .patch
   aliases:
   - udiff
+  tm_scope: source.diff
   ace_mode: diff
 
 Dockerfile:
@@ -1156,7 +1157,7 @@ Graphviz (DOT):
   ace_mode: text
 
 Groff:
-  type: programming
+  type: markup
   extensions:
   - .man
   - '.1'


### PR DESCRIPTION
As discussed in https://github.com/github/linguist/commit/507d191d7d2b8d3ae65d2e135d715e627db1537f

Darcs Patch: `programming` → `data`
Diff: `programming` → `data`
Groff: `programming` → `markup`

Gettext Catalog has already been changed to `prose`.