### PR TITLE
Add a heuristic to disambiguate between NL and NewLisp

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -270,5 +270,13 @@ module Linguist
       end
     end
 
+    disambiguate "NL", "NewLisp" do |data|
+      if /^g3 /.match(data)
+        Language["NL"]
+      else
+        Language["NewLisp"]
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The proposed PR adds a simple heuristic to disambiguate between NL and NewLisp files which both can have extension `.nl` (#2113).