### PR TITLE
Add Neovim config file names to VimL language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3203,12 +3203,15 @@ VimL:
   search_term: vim
   aliases:
   - vim
+  - nvim
   extensions:
   - .vim
   filenames:
+  - .nvimrc
   - .vimrc
   - _vimrc
   - gvimrc
+  - nvimrc
   - vimrc
   ace_mode: text
 

--- a/samples/VimL/filenames/.nvimrc
+++ b/samples/VimL/filenames/.nvimrc
@@ -1,0 +1,10 @@
+set nocompatible
+set ignorecase
+set smartcase
+set showmatch
+set showcmd
+
+syntax on
+
+set hlsearch " Highlight searches
+set incsearch " Do incremental searching


### PR DESCRIPTION
[Neovim](http://neovim.org/) uses configuration files named `.nvimrc` rather than `.vimrc`

See this PR for details neovim/neovim#330