### PR TITLE
Allow hyphens in Emacs mode

### DIFF
--- a/lib/linguist/strategy/modeline.rb
+++ b/lib/linguist/strategy/modeline.rb
@@ -1,7 +1,7 @@
 module Linguist
   module Strategy
     class Modeline
-      EmacsModeline = /-\*-\s*mode:\s*(\w+);?\s*-\*-/i
+      EmacsModeline = /-\*-\s*mode:\s*([\w-]+);?\s*-\*-/i
       VimModeline = /\/\*\s*vim:\s*set\s*(?:ft|filetype)=(\w+):\s*\*\//i
 
       # Public: Detects language based on Vim and Emacs modelines

--- a/test/fixtures/Data/Modelines/emacs-lisp
+++ b/test/fixtures/Data/Modelines/emacs-lisp
@@ -1,0 +1,1 @@
+;; -*- mode: emacs-lisp; -*-

--- a/test/test_modelines.rb
+++ b/test/test_modelines.rb
@@ -13,6 +13,7 @@ class TestModelines < Minitest::Test
     assert_modeline Language["Prolog"], fixture_blob("Data/Modelines/not_perl.pl")
     assert_modeline Language["Smalltalk"], fixture_blob("Data/Modelines/example_smalltalk.md")
     assert_modeline Language["PHP"], fixture_blob("Data/Modelines/iamphp.inc")
+    assert_modeline Language["Emacs Lisp"], fixture_blob("Data/Modelines/emacs-lisp")
   end
 
   def test_modeline_languages
@@ -21,5 +22,6 @@ class TestModelines < Minitest::Test
     assert_equal Language["Prolog"], fixture_blob("Data/Modelines/not_perl.pl").language
     assert_equal Language["Smalltalk"], fixture_blob("Data/Modelines/example_smalltalk.md").language
     assert_equal Language["PHP"], fixture_blob("Data/Modelines/iamphp.inc").language
+    assert_equal Language["Emacs Lisp"], fixture_blob("Data/Modelines/emacs-lisp").language
   end
 end


### PR DESCRIPTION
Hi there!

I was wondering why [my Spacemacs config](https://github.com/hollingberry/dotfiles/blob/master/emacs/.spacemacs) didn't have syntax highlighting... I think I found the problem.

I modifed the EmacsModeline regexp to allow hyphens in the mode name. This means (I hope) that files with

    ;; -*- mode: emacs-lisp -*-

at the top are now correctly recognized as written in Emacs Lisp.

This doesn't solve the problem of more complex modelines like

    ;; -*- mode: emacs-lisp; coding: utf-8 -*-

because the regexp expects the `-*-` terminator after the first semicolon. If you'd like, I can make the regexp support this sort of thing as well.