### PR TITLE
Fix Emacs modeline in DTrace sample.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -711,6 +711,8 @@ DM:
 
 DTrace:
   type: programming
+  aliases:
+  - dtrace-script
   extensions:
   - .d
   interpreters:

--- a/samples/DTrace/javascript-trace.d
+++ b/samples/DTrace/javascript-trace.d
@@ -1,4 +1,4 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* -*- Mode: dtrace-script; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *


### PR DESCRIPTION
One of the DTrace sample files specifies the Emacs C++ mode.  The original author probably had a good reason for doing this, but for now I think it's better to modify the sample.  I believe this will fix the build failure in #2233

Apparently, the DTrace mode for Emacs is called dtrace-script:
https://github.com/dotemacs/dtrace-script-mode

For this reason, I added `dtrace-script` as a Linguist alias for `DTrace`.  I'm not at all sure if this is how the Emacs ↦ Linguist language mapping should be done.