### PR TITLE
add .boot to clojure extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -514,6 +514,7 @@ Clojure:
   ace_mode: clojure
   color: "#db5855"
   extensions:
+  - .boot
   - .clj
   - .cl2
   - .cljc
@@ -522,7 +523,6 @@ Clojure:
   - .cljscm
   - .cljx
   - .hic
-  - .boot
   filenames:
   - riemann.config
 

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -514,8 +514,8 @@ Clojure:
   ace_mode: clojure
   color: "#db5855"
   extensions:
-  - .boot
   - .clj
+  - .boot
   - .cl2
   - .cljc
   - .cljs

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -522,6 +522,7 @@ Clojure:
   - .cljscm
   - .cljx
   - .hic
+  - .boot
   filenames:
   - riemann.config
 

--- a/samples/Clojure/build.boot
+++ b/samples/Clojure/build.boot
@@ -1,0 +1,15 @@
+;; from: https://github.com/boot-clj/boot#configure-task-options
+
+(set-env!
+  :source-paths #{"src"}
+  :dependencies '[[me.raynes/conch "0.8.0"]])
+
+(task-options!
+  pom {:project 'my-project
+       :version "0.1.0"}
+  jar {:manifest {"Foo" "bar"}})
+
+(deftask build
+  "Build my project."
+  []
+  (comp (pom) (jar) (install)))


### PR DESCRIPTION
[Boot](http://boot-clj.com/) is a build tool for clojure.  The `.boot` files are just clojure files though.  Would be nice to have those highlighted accordingly on github.