### PR TITLE
Adding tm_scope for REBOL language and removing REBOL from LICENSE_WHITE...

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2628,6 +2628,7 @@ Rebol:
   - .r3
   - .rebol
   ace_mode: text
+  tm_scope: source.rebol
 
 Red:
   type: programming

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -13,7 +13,6 @@ class TestGrammars < Minitest::Test
     # These grammars have no license but have been grandfathered in. New grammars
     # must have a license that allows redistribution.
     "vendor/grammars/Sublime-Lasso",
-    "vendor/grammars/Sublime-REBOL",
     "vendor/grammars/x86-assembly-textmate-bundle"
   ].freeze
 


### PR DESCRIPTION
...LIST as now is license available in the Sublime-REBOL project.