### PR TITLE
Fix categorization for Racket shell scripts.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2596,6 +2596,8 @@ Racket:
   - .rktd
   - .rktl
   - .scrbl
+  interpreters:
+  - racket
   tm_scope: source.racket
   ace_mode: lisp
 
@@ -2850,7 +2852,6 @@ Scheme:
   - .ss
   interpreters:
   - guile
-  - racket
   - bigloo
   - chicken
   ace_mode: scheme


### PR DESCRIPTION
The current implementation categorizes shell scripts written in Racket
as Scheme, which is incorrect.

For example:

```racket
#!/usr/bin/env racket

#lang racket

"Hello World!"
```

This should be categorized as Racket, not Scheme. [This file][1]
demonstrates the problem in an existing repository.

[1]: https://github.com/drautb/sketchbook/blob/master/racket/sublime-project-generator/generate-sublime-project.rkt