### PR TITLE
Add .ruby to the list of ruby file extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2713,6 +2713,7 @@ Ruby:
   - .rbw
   - .rbx
   - .ru
+  - .ruby
   - .thor
   - .watchr
   interpreters:


### PR DESCRIPTION
Can be found in Rails partial, eg `.html.ruby`