### PR TITLE
Use #000080 for Lua color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1730,7 +1730,7 @@ LoomScript:
 Lua:
   type: programming
   ace_mode: lua
-  color: "#fa1fa1"
+  color: "#000080"
   extensions:
   - .lua
   - .fcgi


### PR DESCRIPTION
This is the color of the official Lua logo, as seen at http://www.lua.org/images/