### PR TITLE
Bump escape-utils to 1.1.0

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.executables << 'linguist'
 
   s.add_dependency 'charlock_holmes', '~> 0.7.3'
-  s.add_dependency 'escape_utils',    '~> 1.0.1'
+  s.add_dependency 'escape_utils',    '~> 1.1.0'
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '~> 0.23.0b1'
 


### PR DESCRIPTION
EscapeUtils recently bumped to version 1.1.0 after merging https://github.com/brianmario/escape_utils/pull/59. I'd like to pull this version into a few other projects and the the `~> 1.0.1` is preventing Bundler from being able to find a compatible version. This bump *shouldn't* have any side effects on Linguist, as the only two uses I can find are https://github.com/github/linguist/blob/a0d5a8338bacaa925c9e0215b4f8b2bbcd1115d1/lib/linguist/blob_helper.rb#L102 and https://github.com/github/linguist/blob/a0d5a8338bacaa925c9e0215b4f8b2bbcd1115d1/lib/linguist/language.rb#L459, both of which use `escape_url`, which should not have changed.

P.S. That new verison of EscapeUtils adds support for a new method `escape_uri_component` that does URL escaping but with space encoded as `%20` instead of `+` (the way `escape_url` does). So, https://github.com/github/linguist/blob/a0d5a8338bacaa925c9e0215b4f8b2bbcd1115d1/lib/linguist/language.rb#L459 could be updated to not require the gsub.

/cc @brianmario 