### PR TITLE
Add .odd to XML extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3326,6 +3326,7 @@ XML:
   - .mxml
   - .nproj
   - .nuspec
+  - .odd
   - .osm
   - .plist
   - .pluginspec

--- a/tei-odd-sample.odd
+++ b/tei-odd-sample.odd
@@ -1,0 +1,1304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="tei-pm.nvdl"
+  type="application/xml"
+  schematypens="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xml:lang="en">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>TEI Simple</title>
+            </titleStmt>
+            <publicationStmt>
+                <publisher>TEI Consortium</publisher>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/3.0/"> Distributed under a
+                  Creative Commons Attribution-ShareAlike 3.0 Unported License </licence>
+                    <licence target="http://www.opensource.org/licenses/BSD-2-Clause">
+                        <p>Copyright 2014 TEI Consortium.</p>
+                        <p>All rights reserved.</p>
+                        <p>Redistribution and use in source and binary forms, with or without
+                     modification, are permitted provided that the following conditions are met:</p>
+                        <list>
+                            <item>Redistributions of source code must retain the above copyright notice,
+                        this list of conditions and the following disclaimer.</item>
+                            <item>Redistributions in binary form must reproduce the above copyright notice,
+                        this list of conditions and the following disclaimer in the documentation
+                        and/or other materials provided with the distribution.</item>
+                        </list>
+                        <p>This software is provided by the copyright holders and contributors "as is" and
+                     any express or implied warranties, including, but not limited to, the implied
+                     warranties of merchantability and fitness for a particular purpose are
+                     disclaimed. In no event shall the copyright holder or contributors be liable
+                     for any direct, indirect, incidental, special, exemplary, or consequential
+                     damages (including, but not limited to, procurement of substitute goods or
+                     services; loss of use, data, or profits; or business interruption) however
+                     caused and on any theory of liability, whether in contract, strict liability,
+                     or tort (including negligence or otherwise) arising in any way out of the use
+                     of this software, even if advised of the possibility of such damage.</p>
+                    </licence>
+                    <p>TEI material can be licensed differently depending on the use you intend to make
+                  of it. Hence it is made available under both the CC+BY and BSD-2 licences. The
+                  CC+BY licence is generally appropriate for usages which treat TEI content as data
+                  or documentation. The BSD-2 licence is generally appropriate for usage of TEI
+                  content in a software environment. For further information or clarification,
+                  please contact the <ref target="mailto:info@tei-c.org">TEI Consortium</ref>. </p>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>created ab initio during a meeting in Oxford</p>
+            </sourceDesc>
+        </fileDesc>
+    </teiHeader>
+    <text>
+        <front>
+            <titlePage>
+                <docTitle>
+                    <titlePart type="main">TEI Simple</titlePart>
+                </docTitle>
+                <docAuthor>Sebastian Rahtz</docAuthor>
+                <docAuthor>Brian Pytlik Zillig</docAuthor>
+                <docAuthor>Martin Mueller</docAuthor>
+                <docDate>Version 0.1: 30th November 2014</docDate>
+            </titlePage>
+        </front>
+        <body>
+            <div>
+                <head>Summary</head>
+                <p>The <hi>TEI Simple</hi> project aims to define a <hi rend="italic">highly-constrained</hi> and <hi rend="italic">prescriptive</hi> subset of the Text Encoding Initiative (TEI) Guidelines
+          suited to the representation of early modern and modern books, a formally-defined set of
+          processing rules which permit modern web applications to easily present and analyze the
+          encoded texts, mapping to other ontologies, and processes to describe the encoding status
+          and richness of a TEI digital text. This document describes
+	the constrained subset</p>
+            </div>
+            <div>
+                <head>
+                    <anchor xml:id="SECTION_1002"/>Background</head>
+                <p>The Text Encoding Initiative (TEI) has developed over 20 years into a key technology in
+          text-centric humanities disciplines, with an extremely wide range of applications, from
+          diplomatic editions to dictionaries, from prosopography to speech transcription and
+          linguistic analysis. It has been able to achieve its range of use by adopting a <hi rend="italic">descriptive</hi> rather than <hi rend="italic">prescriptive </hi> approach
+          , by recommending <hi rend="italic">customization</hi> to suit particular projects, and by
+          eschewing any attempt to dictate how the digital texts should be rendered or exchanged.
+          However, this flexibility has come at the cost of relatively limited success in
+          interoperability. In our view there is a distinct set of uses (primarily in the area of
+          digitized ‘European’-style books) that would benefit from a <hi rend="italic">prescriptive</hi> recipe for digital text; this will sit alongside other
+          domain-specific, constrained TEI customizations, such as the very successful <hi rend="italic">Epidoc</hi> in the epigraphic community. TEI-Simple may become a prototype
+          for a new family of constrained customizations. For instance, a TEI Simple MS for
+          manuscript based work could be built on top of the ENRICH project, drawing on many of the
+          lessons and some of the code for TEI Simple. </p>
+                <p>The TEI has long maintained an introductory subset (TEI Lite), and a constrained
+          customization for use in outsourcing production to commercial vendors (TEI Tite), but both
+          of these permit enormous variation, and have nothing to say about processing. The present
+          project can be viewed in some ways as a revision of TEI Lite, re-examining the basis of
+          the choices therein, focusing it for a more specific area, and adding a "cradle to grave"
+          processing model that associates the TEI Simple schema with explicit and standardized
+          options for displaying and querying texts. This means being able to specify what a
+          programmer should do with particular TEI elements when they are encountered, allowing
+          programmers to build stylesheets that work for everybody and to query a corpus of
+          documents reliably.</p>
+                <p>This project, TEI Simple, focuses on interoperability, machine generation, and
+          low-cost integration. The TEI architecture facilitates customizations of many kinds; TEI
+          Simple aims to produce a complete 'out of the box' customization which meets the needs of
+          the many users for whom the task of creating a customization is daunting or seems
+          irrelevant. TEI Simple in no way intends to constrain the expressive liberty of encoders
+          who do not think that it is either possible or desirable to follow this path. It does,
+          however, promise to make life easier for those who think there is some virtue in
+          travelling that path as far as it will take you, which for quite a few projects will be
+          far enough. Some users will never feel the need to move beyond it, others will outgrow it,
+          and when they do they will have learned enough to do so.</p>
+                <p>A major driver for this project is the texts created by phase 1 of the EEBO-TCP project,
+          which were placed in the public domain on 1 January 2015. Another 45,000 texts will
+          join over the following five years, creating by 2020 an archive of 70,000 consistently
+          encoded books published in England from 1475 to 1700, including works of literature,
+          philosophy, politics, religion, geography, science and all other areas of human endeavor.
+          When we compare the query potential of the EEBO TCP texts in their current and quite
+          simple encoding with flat file versions of those text, it is clear that the difference in
+          query potential is very high, especially if you add to that coarse encoding simple forms
+          of linguistic annotation or named entity tagging that can be added in a largely
+          algorithmic fashion. During 2012 and 2013 extensive work has been undertaken at
+          Northwestern, Michigan and Oxford to enrich these texts and bring them into line with the
+          current TEI Guidelines (where necessary working with the TEI to modify the Guidelines).
+          TEI Simple uses this corpus as a point of departure and will provide its users with a
+          friendlier environment for manipulating EEBO texts in various projects. But TEI Simple
+          should not be understood as an EEBO specific project. We believe that, given the
+          extraordinary degree of internal diversity in the EEBO source files, a project that starts
+          from them can, with appropriate modifications, accommodate a wide range of printed texts
+          differing in language, genre, or time and place of origin. </p>
+            </div>
+            <div>
+                <head>The TEI Simple schema</head>
+                <schemaSpec ident="teisimple" start="TEI teiCorpus">
+                    <specGrpRef target="#base"/>
+                    <specGrpRef target="#header"/>
+                    <specGrpRef target="#transcr"/>
+                    <specGrpRef target="#attclasses"/>
+                    <specGrpRef target="#modelclasses"/>
+                    <specGrpRef target="#simpleelements"/>
+                    <specGrpRef target="#simpleelementspm"/>
+                    <specGrpRef target="#simplechanges"/>
+                    <specGrpRef target="#rendition"/>
+                </schemaSpec>
+                <include xmlns="http://www.w3.org/2001/XInclude" href="elementsummary.xml"/>
+                <div>
+                    <head>The TEI infrastructure</head>
+                    <specGrp xml:id="base">
+                        <moduleRef key="tei"/>
+                    </specGrp>
+                </div>
+                <div>
+                    <head>The header</head>
+                    <p>The default set of elements for the header are loaded using the
+                     <term>header</term> module. In addition, elements from other modules are
+                  loaded, if they are tagged in the classification as being needed for the header
+                  only.</p>
+                    <specGrp xml:id="header">
+                        <moduleRef key="header"/>
+                        <elementRef key="att"/>
+                        <elementRef key="biblStruct"/>
+                        <elementRef key="biblScope"/>
+                        <elementRef key="charDecl"/>
+                        <elementRef key="charProp"/>
+                        <elementRef key="editor"/>
+                        <elementRef key="email"/>
+                        <elementRef key="gi"/>
+                        <elementRef key="glyph"/>
+                        <elementRef key="glyphName"/>
+                        <elementRef key="imprint"/>
+                        <elementRef key="localName"/>
+                        <elementRef key="listPerson"/>
+                        <elementRef key="monogr"/>
+                        <elementRef key="msDesc"/>
+                        <elementRef key="msIdentifier"/>
+                        <elementRef key="physDesc"/>
+                        <elementRef key="relatedItem"/>
+                        <elementRef key="repository"/>
+                        <elementRef key="resp"/>
+                        <elementRef key="respStmt"/>
+                        <elementRef key="teiHeader"/>
+                        <elementRef key="term"/>
+                        <elementRef key="textDesc"/>
+                        <elementRef key="typeDesc"/>
+                        <elementRef key="value"/>
+                        <p>Elements which are only intended to be used in the header are banned from the
+                        <gi>text</gi>, using a Schematron rule.</p>
+                        <elementSpec ident="text" mode="change">
+                            <include xmlns="http://www.w3.org/2001/XInclude" href="headeronly.xml"/>
+                        </elementSpec>
+                    </specGrp>
+                </div>
+                <div>
+                    <head>Transcription</head>
+                    <p>In order to support the <gi>sourcedoc</gi> and <gi>facsimile</gi> elements, the
+                  basic transcriptional elements are loaded, and two attribute classes.</p>
+                    <specGrp xml:id="transcr">
+                        <elementRef key="damage"/>
+                        <elementRef key="damageSpan"/>
+                        <elementRef key="facsimile"/>
+                        <elementRef key="line"/>
+                        <elementRef key="listTranspose"/>
+                        <elementRef key="metamark"/>
+                        <elementRef key="mod"/>
+                        <elementRef key="redo"/>
+                        <elementRef key="restore"/>
+                        <elementRef key="retrace"/>
+                        <elementRef key="sourceDoc"/>
+                        <elementRef key="surface"/>
+                        <elementRef key="surfaceGrp"/>
+                        <elementRef key="surplus"/>
+                        <elementRef key="transpose"/>
+                        <elementRef key="undo"/>
+                        <elementRef key="zone"/>
+                        <classRef key="att.coordinated"/>
+                        <classRef key="att.global.change"/>
+                    </specGrp>
+                </div>
+                <div>
+                    <head>Attribute classes</head>
+                    <specGrp xml:id="attclasses">
+                        <p>The <term>tei</term> module brings with it a default set of attribute classes.
+                     We need some more specialist ones from other modules, and to delete some
+                     default ones which we don't plan to use.</p>
+                        <classRef key="att.global.analytic"/>
+                        <classRef key="att.global.facs"/>
+                        <classRef key="att.milestoneUnit"/>
+                        <classRef key="att.global.linking"/>
+                        <classSpec type="atts" ident="att.datcat" mode="delete"/>
+                        <classSpec type="atts" ident="att.declarable" mode="delete"/>
+                        <classSpec type="atts" ident="att.divLike" mode="delete"/>
+                        <p>Some uncommon attributes are removed from global linking.</p>
+                        <classSpec type="atts" ident="att.global.linking" mode="change">
+                            <attList>
+                                <attDef ident="synch" mode="delete"/>
+                                <attDef ident="copyOf" mode="delete"/>
+                                <attDef ident="exclude" mode="delete"/>
+                                <attDef ident="select" mode="delete"/>
+                            </attList>
+                        </classSpec>
+                        <p>URLs have a constraint that a local pointer must have a corresponding ID.</p>
+                        <classSpec type="atts" ident="att.pointing" mode="change">
+                            <attList>
+                                <attDef ident="target" mode="change">
+                                    <constraintSpec ident="validtarget" scheme="isoschematron">
+                                        <constraint>
+                                            <rule xmlns="http://purl.oclc.org/dsdl/schematron" context="tei:*[@target]">
+                                                <let name="results" value="for $t in        tokenize(normalize-space(@target),'\s+') return starts-with($t,'#') and not(id(substring($t,2)))"/>
+                                                <report test="some $x in $results  satisfies $x"> Error: Every
+                                       local pointer in "<value-of select="@target"/>" must point to
+                                       an ID in this document (<value-of select="$results"/>)</report>
+                                            </rule>
+                                        </constraint>
+                                    </constraintSpec>
+                                </attDef>
+                            </attList>
+                        </classSpec>
+                        <p>Constrained value lists are added to attribute classes where possible.</p>
+                        <classSpec type="atts" mode="change" ident="att.placement">
+                            <attList>
+                                <attDef ident="place" mode="change">
+                                    <valList type="closed" mode="replace">
+                                        <valItem ident="above">
+                      <?exactMatch supralinear?>
+                                            <desc>above the line</desc>
+                                        </valItem>
+                                        <valItem ident="below">
+                                            <desc>below the line</desc>
+                                        </valItem>
+                                        <valItem ident="top">
+                      <?exactMatch pageTop?>
+                                            <desc>at the top of the page</desc>
+                                        </valItem>
+                                        <valItem ident="top-right">
+                                            <desc>at the top right of the page</desc>
+                                        </valItem>
+                                        <valItem ident="top-left">
+                                            <desc>at the top left of the page</desc>
+                                        </valItem>
+                                        <valItem ident="top-center">
+                                            <desc>at the top center of the page</desc>
+                                        </valItem>
+                                        <valItem ident="bottom-right">
+                      <?exactMatch bot-right?>
+                                            <desc>at the bottom right of the page</desc>
+                                        </valItem>
+                                        <valItem ident="bottom-left">
+                      <?exactMatch bot-left?>
+                                            <desc>at the bottom left of the page</desc>
+                                        </valItem>
+                                        <valItem ident="bottom-center">
+                      <?exactMatch bot-center?>
+                                            <desc>at the bottom center of the page</desc>
+                                        </valItem>
+                                        <valItem ident="bottom">
+                      <?exactMatch foot?>
+                                            <desc>at the foot of the page</desc>
+                                        </valItem>
+                                        <valItem ident="tablebottom">
+                                            <desc>underneath a table</desc>
+                      <?exactMatch tablefoot?>
+                                        </valItem>
+                                        <valItem ident="margin">
+                      <?exactMatch margin-outer?>
+                      <?exactMatch marg1?>
+                      <?exactMatch marg2?>
+                      <?exactMatch marg4?>
+                                            <desc>in the outer margin</desc>
+                                        </valItem>
+                                        <valItem ident="margin-left">
+                      <?exactMatch left?>
+                                            <desc>in the left margin</desc>
+                                        </valItem>
+                                        <valItem ident="margin-right">
+                      <?exactMatch right?>
+                                            <desc>in the right margin</desc>
+                                        </valItem>
+                                        <valItem ident="opposite">
+                                            <desc>on the opposite, i.e. facing, page.</desc>
+                                        </valItem>
+                                        <valItem ident="overleaf">
+                                            <desc>on the other side of the leaf.</desc>
+                                        </valItem>
+                                        <valItem ident="end">
+                                            <desc>at the end of the volume.</desc>
+                                        </valItem>
+                                        <valItem ident="divend">
+                                            <desc>at the end the current division.</desc>
+                                        </valItem>
+                                        <valItem ident="parend">
+                                            <desc>at the end the current paragraph.</desc>
+                                        </valItem>
+                                        <valItem ident="inline">
+                      <?exactMatch in?>
+                                            <desc>within the body of the text.</desc>
+                                        </valItem>
+                                        <valItem ident="inspace">
+                                            <desc>in a predefined space, for example left by an earlier
+                                    scribe.</desc>
+                                        </valItem>
+                                        <valItem ident="display">
+                                            <desc>formatted like a quotation</desc>
+                                        </valItem>
+                                    </valList>
+                                </attDef>
+                            </attList>
+                        </classSpec>
+                        <classSpec type="atts" ident="att.dimensions" mode="change">
+                            <attList>
+                                <attDef ident="unit" mode="change">
+                                    <valList mode="add" type="closed">
+                                        <valItem ident="chars">
+                                            <desc>characters</desc>
+                      <?exactMatch char?>
+                      <?exactMatch characters?>
+                                        </valItem>
+                                        <valItem ident="lines">
+                                            <desc>lines</desc>
+                      <?exactMatch line?>
+                                        </valItem>
+                                        <valItem ident="pages">
+                                            <desc>pages</desc>
+                      <?exactMatch page?>
+                                        </valItem>
+                                        <valItem ident="words">
+                                            <desc>words</desc>
+                      <?exactMatch word?>
+                                        </valItem>
+                                        <valItem ident="cm">
+                                            <desc>centimetres</desc>
+                                        </valItem>
+                                        <valItem ident="mm">
+                                            <desc>millimetre</desc>
+                                        </valItem>
+                                        <valItem ident="in">
+                                            <desc>inches</desc>
+                                        </valItem>
+                                    </valList>
+                                </attDef>
+                            </attList>
+                        </classSpec>
+                        <classSpec type="atts" ident="att.global" mode="change">
+                            <constraintSpec ident="renditionpointer" scheme="isoschematron">
+                                <constraint>
+                                    <rule xmlns="http://purl.oclc.org/dsdl/schematron" context="tei:*[@rendition]">
+                                        <let name="results" value="for $val in tokenize(normalize-space(@rendition),'\s+') return        starts-with($val,'simple:')        or        (starts-with($val,'#')        and        //tei:rendition[@xml:id=substring($val,2)])"/>
+                                        <assert test="every $x in $results satisfies $x"> Error: Each of
+                                       the rendition values in "<value-of select="@rendition"/>"
+                                       must point to a local ID or to a token in the Simple scheme
+                                          (<value-of select="$results"/>)</assert>
+                                    </rule>
+                                </constraint>
+                            </constraintSpec>
+                            <constraintSpec ident="corresppointer" scheme="isoschematron">
+                                <constraint>
+                                    <rule xmlns="http://purl.oclc.org/dsdl/schematron" context="tei:*[@corresp]">
+                                        <let name="results" value="for $t in        tokenize(normalize-space(@corresp),'\s+') return starts-with($t,'#') and not(id(substring($t,2)))"/>
+                                        <report test="some $x in $results  satisfies $x"> Error: Every
+                                       local pointer in "<value-of select="@corresp"/>" must point to
+                                       an ID in this document (<value-of select="$results"/>)</report>
+                                    </rule>
+                                </constraint>
+                            </constraintSpec>
+                            <attList>
+                                <attDef ident="rend" mode="delete"/>
+                                <attDef ident="style" mode="delete"/>
+                                <attDef ident="rendition" mode="change">
+                                    <valList mode="add" type="semi">
+                                        <valItem ident="simple:allcaps">
+                      <?exactMatch upper-roman?>
+                      <?exactMatch uc?>
+                                            <desc>all capitals</desc>
+                                        </valItem>
+                                        <valItem ident="simple:blackletter">
+                      <?exactMatch blackLetter?>
+                      <?exactMatch blackletterType?>
+                      <?exactMatch FrakturType?>
+                      <?exactMatch gothic?>
+                                            <desc>black letter or gothic typeface</desc>
+                                        </valItem>
+                                        <valItem ident="simple:bold">
+                      <?exactMatch b?>
+                      <?exactMatch bo?>
+                      <?exactMatch bol?>
+                      <?exactMatch strong?>
+                                            <desc>bold typeface</desc>
+                                        </valItem>
+                                        <valItem ident="simple:bottombraced">
+                                            <desc>marked with a brace under the bottom of the text</desc>
+                                        </valItem>
+                                        <valItem ident="simple:boxed">
+                      <?exactMatch border?>
+                                            <desc>border around the text</desc>
+                                        </valItem>
+                                        <valItem ident="simple:centre">
+                      <?exactMatch center?>
+                                            <desc>centred</desc>
+                                        </valItem>
+                                        <valItem ident="simple:cursive">
+                                            <desc>cursive typeface</desc>
+                                        </valItem>
+                                        <valItem ident="simple:display">
+                                            <desc>block display</desc>
+                                        </valItem>
+                                        <valItem ident="simple:doublestrikethrough">
+                                            <desc>strikethrough with double line</desc>
+                                        </valItem>
+                                        <valItem ident="simple:doubleunderline">
+                                            <desc>underlined with double line</desc>
+                                        </valItem>
+                                        <valItem ident="simple:dropcap">
+                      <?exactMatch decorInit?>
+                                            <desc>initial letter larger or decorated</desc>
+                                        </valItem>
+                                        <valItem ident="simple:float">
+                                            <desc>floated out of main flow</desc>
+                                        </valItem>
+                                        <valItem ident="simple:hyphen">
+                                            <desc>with a hyphen here (eg in line break)</desc>
+                                        </valItem>
+                                        <valItem ident="simple:inline">
+                                            <desc>inline rendering</desc>
+                                        </valItem>
+                                        <valItem ident="simple:italic">
+                      <?exactMatch italics?>
+                      <?exactMatch ITALIC?>
+                      <?exactMatch i?>
+                      <?exactMatch it?>
+                      <?exactMatch ital?>
+                                            <desc>italic typeface</desc>
+                                        </valItem>
+                                        <valItem ident="simple:larger">
+                      <?exactMatch large?>
+                                            <desc>larger type</desc>
+                                        </valItem>
+                                        <valItem ident="simple:left">
+                      <?exactMatch left?>
+                                            <desc>aligned to the left or left-justified</desc>
+                                        </valItem>
+                                        <valItem ident="simple:leftbraced">
+                      <?exactMatch braced?>
+                                            <desc>marked with a brace on the left side of the text</desc>
+                                        </valItem>
+                                        <valItem ident="simple:letterspace">
+                      <?exactMatch spaceletter?>
+                                            <desc>letter-spaced</desc>
+                                        </valItem>
+                                        <valItem ident="simple:normalstyle">
+                                            <desc>upright shape and default weight of typeface</desc>
+                                        </valItem>
+                                        <valItem ident="simple:normalweight">
+                      <?exactMatch roman?>
+                                            <desc>normal typeface weight</desc>
+                                        </valItem>
+                                        <valItem ident="simple:right">
+                      <?exactMatch right-aligned?>
+                                            <desc>aligned to the right or right-justified</desc>
+                                        </valItem>
+                                        <valItem ident="simple:rightbraced">
+                                            <desc>marked with a brace to the right of the text</desc>
+                                        </valItem>
+                                        <valItem ident="simple:rotateleft">
+                      <?exactMatch rotateCounterclockwise?>
+                                            <desc>rotated to the left</desc>
+                                        </valItem>
+                                        <valItem ident="simple:rotateright">
+                      <?exactMatch rotateClockwise?>
+                                            <desc>rotated to the right</desc>
+                                        </valItem>
+                                        <valItem ident="simple:smallcaps">
+                      <?exactMatch sc?>
+                      <?exactMatch smallCap?>
+                                            <desc>small caps</desc>
+                                        </valItem>
+                                        <valItem ident="simple:smaller">
+                      <?exactMatch small?>
+                                            <desc>smaller type</desc>
+                                        </valItem>
+                                        <valItem ident="simple:strikethrough">
+                                            <desc>strike through</desc>
+                                        </valItem>
+                                        <valItem ident="simple:subscript">
+                      <?exactMatch sub?>
+                                            <desc>subscript</desc>
+                                        </valItem>
+                                        <valItem ident="simple:superscript">
+                      <?exactMatch sup?>
+                      <?exactMatch super?>
+                                            <desc>superscript</desc>
+                                        </valItem>
+                                        <valItem ident="simple:topbraced">
+                                            <desc>marked with a brace above the text</desc>
+                                        </valItem>
+                                        <valItem ident="simple:typewriter">
+                                            <desc>fixed-width typeface, like typewriter</desc>
+                                        </valItem>
+                                        <valItem ident="simple:underline">
+                      <?exactMatch u?>
+                                            <desc>underlined with single line</desc>
+                                        </valItem>
+                                        <valItem ident="simple:wavyunderline">
+                                            <desc>underlined with wavy line</desc>
+                                        </valItem>
+                                    </valList>
+                                </attDef>
+                            </attList>
+                        </classSpec>
+                    </specGrp>
+                </div>
+                <div>
+                    <head>Model classes</head>
+                    <specGrp xml:id="modelclasses">
+                        <p>A set of unused model classes are removed.</p>
+                        <classSpec type="model" ident="model.entryPart" mode="delete"/>
+                        <classSpec type="model" ident="model.placeNamePart" mode="delete"/>
+                        <classSpec type="model" ident="model.placeStateLike" mode="delete"/>
+                        <classSpec type="model" ident="model.egLike" mode="delete"/>
+                        <classSpec type="model" ident="model.offsetLike" mode="delete"/>
+                        <classSpec type="model" ident="model.pPart.msdesc" mode="delete"/>
+                        <classSpec type="model" ident="model.oddDecl" mode="delete"/>
+                        <classSpec type="model" ident="model.specDescLike" mode="delete"/>
+                        <classSpec type="model" ident="model.entryPart" mode="delete"/>
+                        <classSpec type="model" ident="model.placeNamePart" mode="delete"/>
+                        <classSpec type="model" ident="model.placeStateLike" mode="delete"/>
+                        <classSpec type="model" ident="model.certLike" mode="delete"/>
+                        <classSpec type="model" ident="model.glossLike" mode="delete"/>
+                    </specGrp>
+                </div>
+                <div>
+                    <head>Elements</head>
+                    <p>The main part of Simple is the set of selected elements.</p>
+                    <include xmlns="http://www.w3.org/2001/XInclude" href="simpleelements.xml"/>
+                    <specGrp xmlns:XSL="http://www.w3.org/1999/XSL/Transform" xml:id="simpleelementspm">
+                        <elementSpec mode="change" ident="ab">
+                            <model behaviour="paragraph(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="abbr">
+                            <model predicate="parent::choice and count(parent::*/*) gt 1" behaviour="omit()"/>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="actor">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="add">
+                            <model behaviour="inline(.)">
+                                <rendition>color: green; text-decoration: underline;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="address">
+                            <model behaviour="block(.)">
+                                <rendition>margin-top: 2em; margin-left: 2em; margin-right: 2em; margin-bottom:
+            2em;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="addrLine">
+                            <model behaviour="block(.)">
+                                <rendition>white-space: nowrap;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="addSpan">
+                            <model behaviour="anchor(@xml:id)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="am">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="anchor">
+                            <model behaviour="anchor(@xml:id)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="argument">
+                            <model behaviour="block(.)">
+                                <rendition>margin-bottom: 0.5em;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="author">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()"/>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="back">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="bibl">
+                            <constraintSpec mode="add" ident="noEmptyBibl" scheme="isoschematron">
+                                <constraint>
+                                    <assert xmlns="http://purl.oclc.org/dsdl/schematron" test="child::* or child::text()[normalize-space(.)]" role="ERROR">
+                Element "<name/>" may not be empty.
+            </assert>
+                                </constraint>
+                            </constraintSpec>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="body">
+                            <modelSequence>
+                                <model behaviour="index(.,'toc')"/>
+                                <model behaviour="block(.)"/>
+                            </modelSequence>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="byline">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="c">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="castGroup">
+                            <model predicate="child::*" behaviour="list(castItem|castGroup)">
+                                <desc>Insert list. </desc>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="castItem">
+                            <model behaviour="listItem(.)">
+                                <desc>Insert item, rendered as described in parent list rendition. </desc>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="castList">
+                            <model predicate="child::*" behaviour="list(castItem)" useSourceRendition="true">
+                                <rendition>list-style: ordered;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="cb">
+                            <model behaviour="break('column',@n)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="cell">
+                            <model behaviour="cell(.)">
+                                <desc>Insert table cell. </desc>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="choice">
+                            <constraintSpec ident="choiceSize" scheme="isoschematron" mode="add">
+                                <constraint>
+                                    <assert xmlns="http://purl.oclc.org/dsdl/schematron" test="count(*) &gt; 1" role="ERROR">
+                    Element "<name/>" must have at least two child
+		    elements.</assert>
+                                </constraint>
+                            </constraintSpec>
+                            <constraintSpec ident="choiceContent" scheme="isoschematron" mode="add">
+                                <constraint>
+                                    <assert xmlns="http://purl.oclc.org/dsdl/schematron" test="(tei:corr or tei:sic or tei:expan or     tei:abbr or tei:reg or tei:orig) and ((tei:corr and tei:sic) or (tei:expan     and tei:abbr) or (tei:reg and tei:orig))" role="ERROR">
+                    Element "<name/>" must have corresponding corr/sic, expand/abbr, reg/orig </assert>
+                                </constraint>
+                            </constraintSpec>
+                            <model predicate="sic and corr" behaviour="alternate(corr[1],sic[1])"/>
+                            <model predicate="abbr and expan" behaviour="alternate(expan[1],abbr[1])"/>
+                            <model predicate="orig and reg" behaviour="alternate(reg[1],orig[1])"/>
+                            <model output="plain" predicate="sic and corr" behaviour="inline(corr[1])"/>
+                            <model output="plain" predicate="abbr and expan" behaviour="inline(expan[1])"/>
+                            <model output="plain" predicate="orig and reg" behaviour="inline(reg[1])"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="cit">
+                            <model predicate="child::quote and child::bibl" behaviour="cit(.)">
+                                <desc>Insert cit. </desc>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="closer">
+                            <model behaviour="block(.)">
+                                <rendition>margin-top: 1em; margin-left: 1em; margin-left: 1em;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="corr">
+                            <model predicate="parent::choice and count(parent::*/*) gt 1" behaviour="omit()">
+                                <desc>Omit, if handled in parent choice. </desc>
+                            </model>
+                            <model behaviour="inline(.)">
+                                <rendition scope="before">content: '[';</rendition>
+                                <rendition scope="after">content: ']';</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="date">
+                            <model output="print" predicate="text()" behaviour="inline(.)"/>
+                            <model output="print" predicate="@when and not(text())" behaviour="inline(@when)"/>
+                            <model predicate="@when" output="web" behaviour="alternate(.,@when)"/>
+                            <model predicate="text()" behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="dateline">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="del">
+                            <model behaviour="inline(.)">
+                                <rendition>   text-decoration: line-through;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="desc">
+                            <model behaviour="omit()"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="div">
+                            <model predicate="@type='title_page'" behaviour="block(.)">
+                                <rendition>border: 1px solid black; padding: 5px;</rendition>
+                            </model>
+                            <model behaviour="section(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="docAuthor">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()">
+                                <desc>Omit if located in teiHeader. </desc>
+                            </model>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="docDate">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()">
+                                <desc>Omit if located in teiHeader. </desc>
+                            </model>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="docEdition">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()">
+                                <desc>Omit if located in teiHeader. </desc>
+                            </model>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="docImprint">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()">
+                                <desc>Omit if located in teiHeader. </desc>
+                            </model>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="docTitle">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()">
+                                <desc>Omit if located in teiHeader. </desc>
+                            </model>
+                            <model behaviour="block(.)">
+                                <rendition>font-size: large;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="epigraph">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="ex">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="expan">
+                            <model predicate="parent::choice and count(parent::*/*) gt 1" behaviour="omit()"/>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="figDesc">
+                            <model behaviour="inline(.)">
+                                <rendition scope="before">content: '[..';</rendition>
+                                <rendition scope="after">content: '..]';</rendition>
+                                <rendition>color: grey;font-style:italic;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="figure">
+                            <model predicate="head or @rendition='simple:display'" behaviour="block(.)"/>
+                            <model behaviour="inline(.)">
+                                <rendition>
+display: block;
+border-top: solid 1pt blue;
+border-bottom: solid 1pt blue;
+		</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="floatingText">
+                            <model behaviour="block(.)">
+                                <rendition>
+	  margin: 6pt;
+	  border: solid black 1pt;
+	</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="foreign">
+                            <model behaviour="inline(.)">
+                                <rendition>font-style:italic;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="formula">
+                            <model predicate="@rendition='simple:display'" behaviour="block(.)"/>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="front">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="fw">
+                            <model predicate="ancestor::p or ancestor::ab" behaviour="inline(.)"/>
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="g">
+                            <model predicate="not(text())" behaviour="glyph(@ref)"/>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="gap">
+                            <model predicate="desc" behaviour="inline(desc)">
+                                <rendition>color: grey;</rendition>
+                            </model>
+                            <model predicate="@extent" behaviour="inline(@extent)">
+                                <rendition scope="before">content: '[..';</rendition>
+                                <rendition scope="after">content: '..]';</rendition>
+                                <rendition>color: grey;</rendition>
+                            </model>
+                            <model behaviour="inline()">
+                                <rendition scope="before">content: '[...]';</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="graphic">
+                            <model behaviour="graphic(@url,@width,@height,@scale)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="group">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="handShift">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="head">
+                            <model predicate="parent::figure" behaviour="block(.)">
+                                <rendition>font-style: italic;</rendition>
+                            </model>
+                            <model predicate="parent::table" behaviour="block(.)">
+                                <rendition>font-style: italic;</rendition>
+                            </model>
+                            <model predicate="parent::lg" behaviour="block(.)">
+                                <rendition>font-style: italic;</rendition>
+                            </model>
+                            <model predicate="parent::list" behaviour="block(.)">
+                                <rendition>font-weight: bold;</rendition>
+                            </model>
+                            <model predicate="parent::div" behaviour="heading(.,@type,div)"/>
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="hi">
+                            <model predicate="@rendition" behaviour="inline(.)" useSourceRendition="true">
+                                <rendition>font-style: italic;</rendition>
+                            </model>
+                            <model predicate="not(@rendition)" behaviour="inline(.)">
+                                <rendition>font-style: italic;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="imprimatur">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="item">
+                            <model predicate="parent::list[@rendition]" behaviour="listItem(.)"/>
+                            <model predicate="not(parent::list[@rendition])" behaviour="listItem(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="l">
+                            <model behaviour="block(.)" useSourceRendition="true">
+                                <rendition> margin-left: 1em; </rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="label">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="lb">
+                            <model predicate="ancestor::sp" behaviour="break('line',@n)"/>
+                            <model behaviour="omit()"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="lg">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="list">
+                            <model predicate="@rendition" behaviour="list(item)" useSourceRendition="true"/>
+                            <model predicate="not(@rendition)" behaviour="list(item)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="listBibl">
+                            <model behaviour="list(bibl)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="measure">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="milestone">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="name">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="note">
+                            <model predicate="@place" behaviour="note(.,@place)"/>
+                            <model predicate="parent::div and not(@place)" behaviour="block(.)">
+                                <rendition>margin-left: 10px;margin-right: 10px; font-size:smaller;</rendition>
+                            </model>
+                            <model predicate="not(@place)" behaviour="inline(.)">
+                                <rendition scope="before">content:" [";</rendition>
+                                <rendition scope="after">content:"] ";</rendition>
+                                <rendition>font-size:small;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="num">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="opener">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="orig">
+                            <model predicate="parent::choice and count(parent::*/*) gt 1" behaviour="omit()">
+                                <desc>Omit, if handled in parent choice. </desc>
+                            </model>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="p">
+                            <model behaviour="paragraph(.)" useSourceRendition="true">
+                                <rendition>text-align: justify;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="pb">
+                            <constraintSpec ident="pbposition" scheme="isoschematron">
+                                <constraint>
+                                    <report xmlns="http://purl.oclc.org/dsdl/schematron" test="parent::*/text() and not           (preceding-sibling::text() and           following-sibling::text())">please make sure pb elements are not at the start or end of mixed content </report>
+                                </constraint>
+                            </constraintSpec>
+                            <model behaviour="break('page',@n)">
+                                <rendition>
+	  display: block;
+	  color: grey;
+	  float: right;
+	</rendition>
+                                <rendition scope="before">content: '[Page ';</rendition>
+                                <rendition scope="after">content: ']';</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="pc">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="postscript">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="publisher">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()">
+                                <desc>Omit if located in teiHeader. </desc>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="pubPlace">
+                            <model predicate="ancestor::teiHeader" behaviour="omit()">
+                                <desc>Omit if located in teiHeader. </desc>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="q">
+                            <model predicate="l" behaviour="block(.)" useSourceRendition="true">
+                                <rendition>margin-left: 10px; margin-right: 10px;
+		</rendition>
+                            </model>
+                            <model predicate="ancestor::p or ancestor::cell" behaviour="inline(.)" useSourceRendition="true">
+                                <rendition scope="before">content: '‘';</rendition>
+                                <rendition scope="after">content: '’';</rendition>
+                            </model>
+                            <model behaviour="block(.)" useSourceRendition="true">
+                                <rendition>margin-left: 10px; margin-right: 10px;
+		</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="quote">
+                            <model predicate="ancestor::p" behaviour="inline(.)" useSourceRendition="true">
+                                <desc>If it is inside a paragraph then it is inline, otherwise it is block level</desc>
+                                <rendition scope="before">content: '‘';</rendition>
+                                <rendition scope="after">content: '’';</rendition>
+                            </model>
+                            <model behaviour="block(.)" useSourceRendition="true">
+                                <desc>If it is inside a paragraph then it is inline, otherwise it is block level</desc>
+                                <rendition>margin-left: 10px; margin-right: 10px;
+		</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="ref">
+                            <model behaviour="inline(.)" predicate="not(@target)"/>
+                            <model predicate="not(text())" behaviour="link(@target,@target)"/>
+                            <model behaviour="link(.,@target)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="reg">
+                            <model predicate="not(parent::choice)" behaviour="inline(.)"/>
+                            <model predicate="parent::choice and count(parent::*/*) gt 1" behaviour="omit()">
+                                <desc>Omit, if handled in parent choice.</desc>
+                            </model>
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="rhyme">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="role">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="roleDesc">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="row">
+                            <model predicate="@role='label'" behaviour="row(.)">
+                                <rendition>font-weight: bold;</rendition>
+                            </model>
+                            <model behaviour="row(.)">
+                                <desc>Insert table row. </desc>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="rs">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="s">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="salute">
+                            <model predicate="parent::closer" behaviour="inline(.)"/>
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="seg">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec ident="sic" mode="change">
+                            <model predicate="parent::choice and count(parent::*/*) gt 1" behaviour="omit()"/>
+                            <model behaviour="inline(.)">
+                                <rendition scope="before">content: '{';</rendition>
+                                <rendition scope="after">content: '}';</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="signed">
+                            <model behaviour="block(.)" predicate="parent::closer">
+                                <rendition>
+		  text-align: right;
+		</rendition>
+                            </model>
+                            <model behaviour="inline(.)">
+                                <rendition>
+		 font-style: italic;
+		</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="sp">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="space">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="speaker">
+                            <model behaviour="block(.)">
+                                <rendition> font-style:italic; </rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="spGrp">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="stage">
+                            <model behaviour="block(.)">
+                                <rendition>font-style: italic;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="subst">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="supplied">
+                            <model predicate="parent::choice" behaviour="omit()"/>
+                            <model predicate="@reason='damage'" behaviour="inline(.)">
+                                <rendition scope="before">content:"&lt;";</rendition>
+                                <rendition scope="after">content:"&gt;";</rendition>
+                            </model>
+                            <model predicate="@reason='illegible' or not(@reason)" behaviour="inline(.)">
+                                <rendition scope="before">content:"[";</rendition>
+                                <rendition scope="after">content:"]";</rendition>
+                            </model>
+                            <model predicate="@reason='omitted'" behaviour="inline(.)">
+                                <rendition scope="before">content:"(";</rendition>
+                                <rendition scope="after">content:")";</rendition>
+                            </model>
+                            <model behaviour="inline(.)">
+                                <rendition scope="before">content:"{";</rendition>
+                                <rendition scope="after">content:"}";</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="table">
+                            <model behaviour="table(.)">
+                                <rendition>
+		  font-size: smaller;
+		  background-color: #F0F0F0;
+		</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="fileDesc">
+                            <model behaviour="title(titleStmt)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="profileDesc">
+                            <model behaviour="omit()"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="revisionDesc">
+                            <model behaviour="omit()"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="encodingDesc">
+                            <model behaviour="omit()"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="teiHeader">
+                            <model behaviour="metadata(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="TEI">
+                            <model behaviour="document(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="text">
+                            <model behaviour="body(.)">
+                                <rendition>
+            max-width: 80%;
+            margin: auto;
+            font-family: Verdana, Tahoma, Geneva, Arial, Helvetica, sans-serif;
+         </rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="time">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="title">
+                            <modelSequence predicate="parent::titleStmt/parent::fileDesc">
+                                <model predicate="preceding-sibling::title" behaviour="text(' — ')"/>
+                                <model behaviour="text(.)">
+                                    <rendition>color: red; font-size: 2em;</rendition>
+                                </model>
+                            </modelSequence>
+                            <model predicate="not(@level) and parent::bibl" behaviour="inline(.)"/>
+                            <modelSequence predicate="@level='m' or not(@level)">
+                                <model behaviour="inline(.)">
+                                    <rendition>font-style: italic;</rendition>
+                                </model>
+                                <model predicate="ancestor::biblStruct or       ancestor::biblFull" behaviour="text(', ')"/>
+                            </modelSequence>
+                            <modelSequence predicate="@level='s' or @level='j'">
+                                <model behaviour="inline(.)">
+                                    <rendition>font-style: italic;</rendition>
+                                </model>
+                                <model predicate="following-sibling::* and     (ancestor::biblStruct  or     ancestor::biblFull)" behaviour="text(' ')"/>
+                            </modelSequence>
+                            <modelSequence predicate="@level='u' or @level='a'">
+                                <model behaviour="inline(.)">
+                                    <rendition>font-style: italic;</rendition>
+                                </model>
+                                <model predicate="following-sibling::* and     (ancestor::biblStruct  or     ancestor::biblFull)" behaviour="text('. ')"/>
+                            </modelSequence>
+                            <model behaviour="inline(.)">
+                                <rendition>font-style: italic;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="titlePage">
+                            <model behaviour="block(.)">
+                                <rendition>    text-align: center;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="titlePart">
+                            <model behaviour="block(.)"/>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="trailer">
+                            <model behaviour="block(.)">
+                                <rendition>color: green;</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="unclear">
+                            <model behaviour="inline(.)">
+                                <rendition scope="after">content: ' [?] ';</rendition>
+                            </model>
+                        </elementSpec>
+                        <elementSpec mode="change" ident="w">
+                            <model behaviour="inline(.)"/>
+                        </elementSpec>
+                    </specGrp>
+                    <specGrp xml:id="simplechanges">
+                        <p>A small number of elements have constrained value lists added.</p>
+                        <elementSpec ident="formula" mode="change">
+                            <attList>
+                                <attDef ident="notation" mode="change">
+                                    <valList mode="add" type="semi">
+                                        <valItem ident="TeX">
+                                            <desc>Using TeX or LaTeX notation</desc>
+                                        </valItem>
+                                    </valList>
+                                </attDef>
+                            </attList>
+                        </elementSpec>
+                        <elementSpec ident="name" mode="change">
+                            <attList>
+                                <attDef ident="type" mode="change">
+                                    <valList mode="add" type="closed">
+                                        <valItem ident="person"/>
+                                        <valItem ident="forename"/>
+                                        <valItem ident="surname"/>
+                                        <valItem ident="personGenName"/>
+                                        <valItem ident="personRoleName"/>
+                                        <valItem ident="personAddName"/>
+                                        <valItem ident="nameLink"/>
+                                        <valItem ident="organisation"/>
+                                        <valItem ident="country"/>
+                                        <valItem ident="placeGeog"/>
+                                        <valItem ident="place"/>
+                                    </valList>
+                                </attDef>
+                            </attList>
+                        </elementSpec>
+                        <elementSpec ident="cell" mode="change">
+                            <attList>
+                                <attDef ident="role" mode="change">
+                                    <valList mode="add" type="closed">
+                                        <valItem ident="data">
+                                            <desc>data cell</desc>
+                                        </valItem>
+                                        <valItem ident="label">
+                                            <desc>label cell</desc>
+                      <?exactMatch LABEL?>
+                                        </valItem>
+                                        <valItem ident="sum">
+                                            <desc>row or column sum data</desc>
+                                        </valItem>
+                                        <valItem ident="total">
+                                            <desc>table total data</desc>
+                                        </valItem>
+                                    </valList>
+                                </attDef>
+                            </attList>
+                        </elementSpec>
+                        <elementSpec ident="row" mode="change">
+                            <attList>
+                                <attDef ident="role" mode="change">
+                                    <valList mode="add" type="closed">
+                                        <valItem ident="data">
+                                            <desc>data cell</desc>
+                                        </valItem>
+                                        <valItem ident="label">
+                                            <desc>label cell</desc>
+                                        </valItem>
+                                        <valItem ident="sum">
+                                            <desc>row or column sum data</desc>
+                                        </valItem>
+                                        <valItem ident="total">
+                                            <desc>table total data</desc>
+                                        </valItem>
+                                    </valList>
+                                </attDef>
+                            </attList>
+                        </elementSpec>
+                    </specGrp>
+                    <specGrp xml:id="rendition">
+                        <rendition xml:id="allcaps">text-transform: uppercase;</rendition>
+                        <rendition xml:id="blackletter">font-family: fantasy;</rendition>
+                        <rendition xml:id="bold">font-weight: bold;</rendition>
+                        <rendition xml:id="bottombraced">padding-bottom: 2pt; border-bottom: dashed gray 2pt;</rendition>
+                        <rendition xml:id="boxed">padding: 2pt; border: solid black 1pt;</rendition>
+                        <rendition xml:id="centre">text-align: center;</rendition>
+                        <rendition xml:id="cursive">font-family: cursive;</rendition>
+                        <rendition xml:id="doublestrikethrough">text-decoration: line-through;    color: red;</rendition>
+                        <rendition xml:id="doubleunderline">text-decoration: underline;    color: red;</rendition>
+                        <rendition xml:id="dropcap">font-size : 6em;
+    font-family: cursive;
+    font-weight : bold;
+    vertical-align: top;
+    height: 1em;
+    line-height: 1em;
+    float : left;
+    width : 1em;
+    color : #c00;
+    margin: 0em;
+    padding: 0px;</rendition>
+                        <rendition xml:id="float">float:right;    display: block;
+    font-size: smaller;
+    clear: right;
+    padding: 4pt;
+    width: 15%;
+</rendition>
+                        <rendition xml:id="hyphen"/>
+                        <rendition xml:id="inline">display:inline;</rendition>
+                        <rendition xml:id="display">display:block;</rendition>
+                        <rendition xml:id="italic">font-style: italic;</rendition>
+                        <rendition xml:id="larger">font-size: larger;</rendition>
+                        <rendition xml:id="left">text-align: left;</rendition>
+                        <rendition xml:id="leftbraced">padding-left: 2pt; border-left: dotted gray 2pt; </rendition>
+                        <rendition xml:id="letterspace">letter-spacing: 0.5em;</rendition>
+                        <rendition xml:id="normalstyle">font-style:roman;</rendition>
+                        <rendition xml:id="normalweight">font-weight:normal;</rendition>
+                        <rendition xml:id="right">text-align: right;</rendition>
+                        <rendition xml:id="rightbraced">padding-right: 2pt; border-right: dotted gray 2pt; </rendition>
+                        <rendition xml:id="rotateleft">-webkit-transform: rotate(90deg);    transform: rotate(90deg);</rendition>
+                        <rendition xml:id="rotateright">-webkit-transform: rotate(-90deg);    transform: rotate(-90deg);</rendition>
+                        <rendition xml:id="smallcaps">font-variant: small-caps;</rendition>
+                        <rendition xml:id="smaller">font-size: smaller;</rendition>
+                        <rendition xml:id="strikethrough">text-decoration: line-through;</rendition>
+                        <rendition xml:id="subscript">vertical-align: bottom;    font-size: smaller;</rendition>
+                        <rendition xml:id="superscript">vertical-align: super;    font-size: smaller;</rendition>
+                        <rendition xml:id="topbraced">padding-top: 2pt;  border-top: dotted gray 2pt; </rendition>
+                        <rendition xml:id="typewriter">font-family:monospace;</rendition>
+                        <rendition xml:id="underline">text-decoration: underline;</rendition>
+                        <rendition xml:id="wavyunderline">text-decoration: underline;       text-decoration-style: wavy;</rendition>
+                    </specGrp>
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
See discussion at #2238. 

[ODD](http://en.wikipedia.org/wiki/Text_Encoding_Initiative#ODD) is an XML-based vocabulary for defining schemas for Text Encoding Initiative (TEI) projects, used widely in the humanities.  ODD should be rendered using XML syntax but is currently displayed as plain text (see [this example](https://github.com/wolfgangmm/tei-simple-pm/blob/master/odd/teisimple.odd)).  There are [nearly 500 ODD files](https://github.com/search?q=extension%3Aodd+NOT+djfhdirijdskqdhd&type=Code&utf8=%E2%9C%93) in GitHub, and this number is projected to grow.