### PR TITLE
add tests/fixtures to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -224,7 +224,7 @@
 - ^readme$
 
 # Test fixtures
-- ^[Tt]est/fixtures/
+- ^[Tt]ests?/fixtures/
 
 # PhoneGap/Cordova
 - (^|/)cordova([^.]*)\.js$

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -421,6 +421,7 @@ class TestBlob < Minitest::Test
     # Test fixtures
     assert sample_blob("test/fixtures/random.rkt").vendored?
     assert sample_blob("Test/fixtures/random.rkt").vendored?
+    assert sample_blob("tests/fixtures/random.rkt").vendored?
 
     # Cordova/PhoneGap
     assert sample_blob("cordova.js").vendored?


### PR DESCRIPTION
My repo https://github.com/lepture/mistune is detected as HTML.

I've moved those HTML files to fixtures directory(https://github.com/lepture/mistune/commit/54197e12e2e4547e24ae5508f09f5516ebb8a8bc), but it won't work. I've checked this repo, it seems that only `test/fixtures/` is ignored.