### PR TITLE
Fixing up shebang detection to match new tokenizer behaviour

### DIFF
--- a/test/test_shebang.rb
+++ b/test/test_shebang.rb
@@ -38,6 +38,7 @@ class TestShebang < Minitest::Test
     assert_interpreter "perl", "#! perl"
 
     assert_interpreter "ruby", "#!/bin/sh\n\n\nexec ruby $0 $@"
-  end
 
+    assert_interpreter "sh", "#! /usr/bin/env A=003 B=149 C=150 D=xzd E=base64 F=tar G=gz H=head I=tail sh"
+  end
 end


### PR DESCRIPTION
Since https://github.com/github/linguist/pull/1604 the build has been broken :crying_cat_face: 

The change to the tokenizer behaviour [here](https://github.com/github/linguist/blob/edadca9085ba69f907b44e142fa7b45520367f96/lib/linguist/tokenizer.rb#L145) and the new sample file with a shebang that looked like this:

```
#! /usr/bin/env A=003 B=149 C=150 D=xzd E=base64 F=tar G=gz H=head I=tail sh
```

meant that the shebang extraction in [shebang.rb] (https://github.com/github/linguist/blob/master/lib/linguist/shebang.rb#L20-L51) was returning `A=003` as the interpreter (when it should be `sh`).

This pull request brings the shebang detection in `tokenizer.rb` and `shebang.rb` into parity to fix the current build failure. Given how similar these methods are they should basically be the same. I'm saving that for another day.