### PR TITLE
Add Libraries & Libs to vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -15,6 +15,10 @@
 # Dependencies
 - ^[Dd]ependencies/
 
+# Libraries
+- ^[Ll]ib(s)?/
+- ^[Ll]ibraries/
+
 # C deps
 #  https://github.com/joyent/node
 - ^deps/


### PR DESCRIPTION
This removes the following from being checked by linguist:
* libs
* Libs
* lib
* libs
* Libraries
* libraries

These are usually only used for libraries for a project, and not the project itself.