### PR TITLE
Tighten up OCaml heuristic

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -267,7 +267,7 @@ module Linguist
     end
 
     disambiguate "OCaml", "Standard ML" do |data|
-      if /module|let rec |match\s+(\S+\s)+with/.match(data)
+      if /(^\s*module)|let rec |match\s+(\S+\s)+with/.match(data)
         Language["OCaml"]
       elsif /=> |case\s+(\S+\s)+of/.match(data)
         Language["Standard ML"]


### PR DESCRIPTION
Only match `module` at the beginning of a line.

Matching anywhere yields [false positives](https://github.com/search?q=language%3Asml+module+-extension%3Asig+-extension%3Acache&type=Code).