### PR TITLE
Fixing incorrect detection of the NewLisp language

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -222,6 +222,15 @@ module Linguist
       end
     end
 
+    disambiguate "Text", "NewLisp" do |data|
+      if /^\s*\(define /.match(data)
+        Language["NewLisp"]
+      else
+        Language["Text"]
+      end
+    end
+
+
     disambiguate "TypeScript", "XML" do |data|
       if data.include?("<TS ")
         Language["XML"]

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3164,6 +3164,7 @@ Text:
   extensions:
   - .txt
   - .fr
+  - .nl
   tm_scope: none
   ace_mode: text
 

--- a/samples/Text/corpus_1000.nl
+++ b/samples/Text/corpus_1000.nl
@@ -1,0 +1,2 @@
+tot slot is er nog het gebrek aan transparantie .
+wie de verantwoordelijkheid draagt , wie de eigenaren zijn en wie de eigenlijke beslissingen neemt wordt tot elke prijs aan het oog onttrokken .


### PR DESCRIPTION
The proposed sample file that contains tokenized Dutch words has been wrongly recognized as a NewLisp code in my repository.

This patch is a try to fix this ambiguity.