### PR TITLE
Make Common Lisp heuristic case insensitive.

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -129,7 +129,7 @@ module Linguist
     end
 
     disambiguate "Common Lisp", "OpenCL", "Cool" do |data|
-      if data.include?("(defun ")
+      if /^\s*\((defun|in-package|defpackage) /i.match(data)
         Language["Common Lisp"]
       elsif /^class/x.match(data)
         Language["Cool"]
@@ -215,7 +215,7 @@ module Linguist
     end
 
     disambiguate "Common Lisp", "NewLisp" do |data|
-      if /^\s*\((defun|in-package|defpackage) /.match(data)
+      if /^\s*\((defun|in-package|defpackage) /i.match(data)
         Language["Common Lisp"]
       elsif /^\s*\(define /.match(data)
         Language["NewLisp"]

--- a/samples/Common Lisp/hello.lisp
+++ b/samples/Common Lisp/hello.lisp
@@ -1,0 +1,2 @@
+(DEFUN HELLO ()
+  (PRINT 'HELLO))


### PR DESCRIPTION
Some Common Lisp files are misidentified as NewLisp.  This is mostly because the heuristics don't recognize `(DEFUN` in Common Lisp files:

https://github.com/search?q=language%3Anewlisp+%22defun%22+-extension%3Anl&type=Code