### PR TITLE
Remove Batch from Shell group

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -267,7 +267,6 @@ Awk:
 
 Batchfile:
   type: programming
-  group: Shell
   search_term: bat
   aliases:
   - bat

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -79,7 +79,6 @@ class TestLanguage < Minitest::Test
     assert_equal Language['Java'], Language['Java Server Pages'].group
     assert_equal Language['Python'], Language['Cython'].group
     assert_equal Language['Python'], Language['NumPy'].group
-    assert_equal Language['Shell'], Language['Batchfile'].group
     assert_equal Language['Shell'], Language['Gentoo Ebuild'].group
     assert_equal Language['Shell'], Language['Gentoo Eclass'].group
     assert_equal Language['Shell'], Language['Tcsh'].group


### PR DESCRIPTION
This pull request removes Batch from the Shell group as discussed in #1483.