### PR TITLE
Improve NL/NewLisp disambiguation heuristic

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -275,7 +275,7 @@ module Linguist
     end
 
     disambiguate "NL", "NewLisp" do |data|
-      if /^g3 /.match(data)
+      if /^(b|g)[0-9]+ /.match(data)
         Language["NL"]
       else
         Language["NewLisp"]


### PR DESCRIPTION
The proposed PR improves disambiguation between NL and NewLisp formats fixing cases like [this](https://github.com/rwcarlsen/pswarm/blob/c51c223e7834c7eb297d4ba96540cee50371ab29/nl/hs35mod.nl).