### PR TITLE
Analyse an individual file using repository information.

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -37,7 +37,16 @@ if File.directory?(path)
     end
   end
 elsif File.file?(path)
-  blob = Linguist::FileBlob.new(path, Dir.pwd)
+  if (ARGV[0])
+    base = ARGV[0]
+    rugged = Rugged::Repository.new(base)
+    relpath = path.sub("#{base}/", '')
+    oid = rugged.blob_at(rugged.head.target_id, relpath).oid
+    blob = Linguist::LazyBlob.new(rugged, oid, path)
+  else
+    blob = Linguist::FileBlob.new(path, Dir.pwd)
+  end
+
   type = if blob.text?
     'Text'
   elsif blob.image?


### PR DESCRIPTION
Running *Linguist* on an individual file will not take `.gitattributes` into account.  This affects the search index.

I looked into fixing this, and came up with this pull request.  It may well be wrong in many ways, so I'm mostly putting it up as a conversation item.  It turns out it will not help with the index, but perhaps it can be useful anyway.

In short, I added an optional directory argument after the file name.  If supplied, a `LazyBlob` will be created instead of a`FileBlob`.