### PR TITLE
Extensions for the Bazel build system are written in a Python dialect

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2579,6 +2579,7 @@ Python:
   - .tac
   - .wsgi
   - .xpy
+  - .bzl
   filenames:
   - BUILD
   - SConscript


### PR DESCRIPTION
called Skylark, using the extension .bzl.