### PR TITLE
Handle SSH links to submodules in Travis

### DIFF
--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -17,6 +17,9 @@ else
   bundle config build.charlock_holmes --with-icu-dir=$(pwd)/vendor/debs
 fi
 
+# Replace SSH links to submodules by HTTPS links.
+sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+
 git submodule init
 git submodule sync --quiet
 script/fast-submodule-update


### PR DESCRIPTION
Travis doesn't handle very well SSH links to submodules. So far, two users had this issue when implementing pull requests. See [this Travis build](https://travis-ci.org/github/linguist/jobs/60855088#L1479) for instance.

This pull request fixes it by replacing `git@` links on the fly.