### PR TITLE
Added support for .mdpolicy XML files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3414,6 +3414,7 @@ XML:
   - .jelly
   - .kml
   - .launch
+  - .mdpolicy
   - .mm
   - .mxml
   - .nproj

--- a/samples/XML/Example.mdpolicy
+++ b/samples/XML/Example.mdpolicy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PolicySet name="Example.mdpolicy">
+  <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp">
+    <FileWidth>120</FileWidth>
+    <TabsToSpaces>False</TabsToSpaces>
+    <NoTabsAfterNonTabs>True</NoTabsAfterNonTabs>
+  </TextStylePolicy>
+  <DotNetNamingPolicy>
+    <DirectoryNamespaceAssociation>None</DirectoryNamespaceAssociation>
+    <ResourceNamePolicy>FileFormatDefault</ResourceNamePolicy>
+  </DotNetNamingPolicy>
+</PolicySet>


### PR DESCRIPTION
Used by @MonoDevelop to define standards for source code formatting. Not very popular https://github.com/search?utf8=%E2%9C%93&q=filename%3Amdpolicy&type=Code&ref=searchresults but easy to add here as it is strict XML 1.0 and is not conflicting with anything else.