### PR TITLE
Vim and Emacs modelines are two alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,18 @@ project-docs/* linguist-documentation
 docs/formatter.rb linguist-documentation=false
 ```
 
-### Using Emacs and Vim modelines
+### Using Emacs or Vim modelines
 
-Alternatively, you can use Vim and Emacs style modelines to set the language for a single file. Modelines can be placed anywhere within a file and are respected when determining how to syntax-highlight a file on GitHub.com
+Alternatively, you can use Vim or Emacs style modelines to set the language for a single file. Modelines can be placed anywhere within a file and are respected when determining how to syntax-highlight a file on GitHub.com
 
+##### Vim
 ```
-Vim
 vim: set filetype=prolog:
 vim: set ft=cpp:
+```
 
-Emacs
+##### Emacs
+```
 -*- mode: php;-*-
 ```
 


### PR DESCRIPTION
I saw one user included both Vim and Emacs modelines in a file.  Of course, there's nothing wrong with that, but it may not have been the intention to support both editors.

This change should make the documentation more clear that there are two distinct options.