### PR TITLE
Change PHP group to HTML for TWIG

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3262,7 +3262,7 @@ Turtle:
 
 Twig:
   type: markup
-  group: PHP
+  group: HTML
   extensions:
   - .twig
   tm_scope: text.html.twig


### PR DESCRIPTION
`Twig` should be in `HTML` group like `jade`, `slim` and other template languages