### PR TITLE
Fix Handlebars grammar

### DIFF
--- a/script/convert-grammars
+++ b/script/convert-grammars
@@ -195,7 +195,7 @@ def load_grammars(tmp_dir, source, all_scopes)
     end
     all_scopes[scope] = p.url
     grammar
-  end
+  end.compact
 end
 
 def install_grammars(grammars, path)

--- a/script/convert-grammars
+++ b/script/convert-grammars
@@ -188,9 +188,11 @@ def load_grammars(tmp_dir, source, all_scopes)
     scope = grammar['scopeName']
 
     if all_scopes.key?(scope)
-      $stderr.puts "WARN: Duplicated scope #{scope}\n" +
-        "  Current package: #{p.url}\n" +
-      "  Previous package: #{all_scopes[scope]}"
+      unless all_scopes[scope] == p.url
+        $stderr.puts "WARN: Duplicated scope #{scope}\n" +
+          "  Current package: #{p.url}\n" +
+          "  Previous package: #{all_scopes[scope]}"
+      end
       next
     end
     all_scopes[scope] = p.url


### PR DESCRIPTION
The Handlebars repository contains the following grammar files:

* Handlebars.tmLanguage
* Handlebars.JSON-tmLanguage
* grammars/handlebars.json (symlink to Handlebars.JSON-tmLanguage)

We were processing the .tmLanguage and the .json file and complaining about a duplicate scope. This triggered a nil-handling bug (which is now fixed), but we also shouldn't complain in this case at all. Having the same grammar in multiple formats is OK.

/cc @arfon https://github.com/github/linguist/commit/6062d3b25cbe99b8660724250436eeb249483119#commitcomment-11249896