### PR TITLE
Add JRuby executable example, fixes #2412

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2847,6 +2847,8 @@ Ruby:
   - ruby
   - macruby
   - rake
+  - jruby
+  - rbx
   filenames:
   - .pryrc
   - Appraisals

--- a/samples/Ruby/jruby
+++ b/samples/Ruby/jruby
@@ -1,3 +1,0 @@
-#!/usr/bin/env jruby
-
-puts "This is a JRuby executable example."

--- a/samples/Ruby/jruby
+++ b/samples/Ruby/jruby
@@ -1,0 +1,3 @@
+#!/usr/bin/env jruby
+
+puts "This is a JRuby executable example."

--- a/samples/Ruby/rexpl
+++ b/samples/Ruby/rexpl
@@ -1,0 +1,4 @@
+#!/usr/bin/env rbx
+$: << 'lib'
+require 'rexpl'
+Rexpl::Environment.run

--- a/samples/Ruby/shoes-swt
+++ b/samples/Ruby/shoes-swt
@@ -1,0 +1,11 @@
+#!/usr/bin/env jruby
+lib_directory = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH << lib_directory
+
+if File.exist?("Gemfile")
+  require "bundler/setup"
+  Bundler.require
+end
+
+require 'shoes/ui/cli'
+Shoes::CLI.new("swt").run ARGV


### PR DESCRIPTION
This is supposed to fix JRuby executable detection. See #2412 for details.