### PR TITLE
Treat Carthage path as vendored

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -163,6 +163,9 @@
 
 ## Obj-C ##
 
+# Carthage
+- ^Carthage/
+
 # Cocoapods
 - ^Pods/
 

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -422,6 +422,9 @@ class TestBlob < Minitest::Test
     # Normalize
     assert sample_blob("some/asset/path/normalize.css").vendored?
 
+    # Carthage
+    assert sample_blob('Carthage/blah').vendored?
+
     # Cocoapods
     assert sample_blob('Pods/blah').vendored?
 
@@ -473,7 +476,7 @@ class TestBlob < Minitest::Test
     # Sphinx docs
     assert sample_blob("docs/_build/asset.doc").vendored?
     assert sample_blob("docs/theme/file.css").vendored?
-    
+
     # Vagrant
     assert sample_blob("puphpet/file.pp").vendored?
   end


### PR DESCRIPTION
Hi, I have Carthage dependency in [my project](https://github.com/evgenyneu/moa). My project is written in Swift, but the vendored dependency is Obj-C. That results in Github treating my project as Obj-C.

Carthage is a framework manager for iOS/Swift: https://github.com/Carthage/Carthage