### PR TITLE
Make filename: Kbuild

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1881,6 +1881,7 @@ Makefile:
   - .mk
   filenames:
   - GNUmakefile
+  - Kbuild
   - Makefile
   - makefile
   interpreters:

--- a/samples/Makefile/filenames/Kbuild
+++ b/samples/Makefile/filenames/Kbuild
@@ -1,0 +1,23 @@
+# Fail on warnings - also for files referenced in subdirs
+# -Werror can be disabled for specific files using:
+# CFLAGS_<file.o> := -Wno-error
+subdir-ccflags-y := -Werror
+
+# platform specific definitions
+include arch/mips/Kbuild.platforms
+obj-y := $(platform-y)
+
+# make clean traverses $(obj-) without having included .config, so
+# everything ends up here
+obj- := $(platform-)
+
+# mips object files
+# The object files are linked as core-y files would be linked
+
+obj-y += kernel/
+obj-y += mm/
+obj-y += net/
+
+ifdef CONFIG_KVM
+obj-y += kvm/
+endif


### PR DESCRIPTION
`Kbuild` is a common filename for makefiles in Linux:
https://github.com/search?q=filename%3Akbuild

The syntax is, by convention, a small subset of the *GNU Make* language.
