### PR TITLE
New .al extension for Perl

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2439,6 +2439,7 @@ Perl:
   color: "#0298c3"
   extensions:
   - .pl
+  - .al
   - .cgi
   - .fcgi
   - .perl

--- a/samples/Perl/getchar.al
+++ b/samples/Perl/getchar.al
@@ -1,0 +1,13 @@
+# NOTE: Derived from ../../lib/POSIX.pm.
+# Changes made here will be lost when autosplit is run again.
+# See AutoSplit.pm.
+package POSIX;
+
+#line 318 "../../lib/POSIX.pm (autosplit into ../../lib/auto/POSIX/getchar.al)"
+sub getchar {
+    usage "getchar()" if @_ != 0;
+    CORE::getc(STDIN);
+}
+
+# end of POSIX::getchar
+1;


### PR DESCRIPTION
This pull request adds support for `.al` for Perl as discussed in #2362.
There are [more than 87,900 `.al` files](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aal+NOT+ebkfhdkbdkfbfnv) on GitHub. [Almost all of them](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aal+my+OR+sub&type=Code&ref=searchresults) are Perl.