### PR TITLE
Tighten RenderScript/Rust disambiguation

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -283,10 +283,10 @@ module Linguist
     end
 
     disambiguate "Rust", "RenderScript" do |data|
-      if /^(use |fn |mod |pub |macro_rules|impl|#!?\[)/.match(data)
-        Language["Rust"]
-      elsif /#include|#pragma\s+(rs|version)|__attribute__/.match(data)
+      if /^#pragma\s+version/.match(data)
         Language["RenderScript"]
+      else
+        Language["Rust"]
       end
     end
 


### PR DESCRIPTION
RenderScript files are required to have `#pragma version(1)`, and only someone deliberately trying to mislead a filetype classifier will put it in Rust code at the start of a line, so that really is the only check needed, and defaulting to Rust is then sound.

This follows on from #2424; #2425 fixed the immediate problem, but this provides a better classification; it’s entirely possible to have a Rust file with only constants defined, for example, which the previous check would fail to catch.

These heuristics are [the same as ohcount’s][1], which were [discussed at some length][2].

[1]: https://github.com/blackducksw/ohcount/blob/d54514399013f2f9566baf40edd0e801b27fe17b/src/detector.c#L870..L897
[2]: https://github.com/blackducksw/ohcount/pull/30