### PR TITLE
Add .inc file extension to Sourcepawn

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3142,6 +3142,7 @@ SourcePawn:
   - sourcemod
   extensions:
   - .sp
+  - .inc
   - .sma
   tm_scope: source.sp
   ace_mode: text


### PR DESCRIPTION
`.inc` file extensions are used as include files for Sourcepawn.