### PR TITLE
Add the Calca file format, which writes all files as Markdown files.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1916,6 +1916,7 @@ Markdown:
   ace_mode: markdown
   wrap: true
   extensions:
+  - .calca
   - .md
   - .markdown
   - .mkd


### PR DESCRIPTION
There's a nice little text editor with a simple math REPL built in, and its files are supersets of Markdown. The name of the app is called [Calca](http://calca.io/). I propose this filetype be included in the linguist `languages.yml` file.

Here's a small snippet of a Calca doc:

```markdown
# My Calca Doc

I'm going to compute my grocery bill.

eggs = $3.00
bread = $2.00
milk = $4.00
subtotal = eggs + bread + milk => $9.00
coupon = 10%
total = subtotal - (subtotal * coupon) => $8.10
```

Let me know if you have any questions. Happy to answer them.