### PR TITLE
Append Test::More into strict.t

### DIFF
--- a/samples/Perl/strict.t
+++ b/samples/Perl/strict.t
@@ -1,4 +1,5 @@
 use Test::Base;
+use Test::More;
 
 __DATA__
 === Strict Test

--- a/samples/Perl6/test.p6
+++ b/samples/Perl6/test.p6
@@ -73,26 +73,6 @@ Here's some POD!  Wooo
 
 say('this is not!');
 
-=table
-    Of role things
-
-say('not in your table');
-#= A single line declarator "block" (with a keyword like role)
-#| Another single line declarator "block" (with a keyword like role)
-#={
-    A declarator block (with a keyword like role)
-  }
-#|{
-    Another declarator block (with a keyword like role)
-  }
-#= { A single line declarator "block" with a brace (with a keyword like role)
-#=«
-    More declarator blocks! (with a keyword like role)
-  »
-#|«
-    More declarator blocks! (with a keyword like role)
-  »
-
 say 'Moar code!';
 
 my $don't = 16;


### PR DESCRIPTION
Because, most of tap scripts on Perl5 are detected as Perl6.

![](http://go-gyazo.appspot.com/6f494a89467db0bb.png)

