### PR TITLE
Add code of conduct to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,10 @@
 # Contributing
 
-Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great. The majority of contributions won't need to touch any Ruby code at all.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Linguist/opensource@github.com
 
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great. This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+
+The majority of contributions won't need to touch any Ruby code at all.
 
 ## Adding an extension to a language
 


### PR DESCRIPTION
We are intending to adopt the soon-to-be-announced [Open Code of Conduct](http://todogroup.org/opencodeofconduct) for all @github projects. This adds it to the contributing guidelines. Let me know if you have any questions or concerns.