### PR TITLE
Add Minecraft Forge Config as a language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2016,6 +2016,11 @@ Mercury:
   - .moo
   tm_scope: source.mercury
   ace_mode: prolog
+  
+Minecraft Forge Config:
+  type: data
+  extensions:
+  - .cfg
 
 MiniD: # Legacy
   type: programming


### PR DESCRIPTION
These file are used in the creation of modded Minecraft installation, they hold the configuration options for the mods and how they will operate during gameplay.

I've written a grammar for syntax highlighting, but sadly only for Atom... If only the GitHub website used Atom grammars...