### PR TITLE
Use a Crystal grammar over the Ruby grammar for Crystal files.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -653,3 +653,6 @@
 [submodule "vendor/grammars/SMT.tmbundle"]
 	path = vendor/grammars/SMT.tmbundle
 	url = https://github.com/SRI-CSL/SMT.tmbundle.git
+[submodule "vendor/grammars/language-crystal"]
+	path = vendor/grammars/language-crystal
+	url = https://github.com/k2b6s9j/language-crystal

--- a/grammars.yml
+++ b/grammars.yml
@@ -314,6 +314,8 @@ vendor/grammars/language-clojure:
 vendor/grammars/language-coffee-script:
 - source.coffee
 - source.litcoffee
+vendor/grammars/language-crystal:
+- source.crystal
 vendor/grammars/language-csharp:
 - source.cs
 - source.csx

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -670,7 +670,7 @@ Crystal:
   extensions:
   - .cr
   ace_mode: ruby
-  tm_scope: source.ruby
+  tm_scope: source.crystal
   interpreters:
   - crystal
 


### PR DESCRIPTION
The Crystal does have several little differences which distinguish it from Ruby. Thus it needs it's own grammar.