### PR TITLE
Use a different grammar for PureScript

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -662,3 +662,6 @@
 [submodule "vendor/grammars/language-ncl"]
 	path = vendor/grammars/language-ncl
 	url = https://github.com/rpavlick/language-ncl.git
+[submodule "vendor/grammars/atom-language-purescript"]
+	path = vendor/grammars/atom-language-purescript
+	url = https://github.com/freebroccolo/atom-language-purescript

--- a/grammars.yml
+++ b/grammars.yml
@@ -176,6 +176,8 @@ vendor/grammars/assembly.tmbundle:
 - source.x86asm
 vendor/grammars/atom-fsharp/:
 - source.fsharp
+vendor/grammars/atom-language-purescript/:
+- source.purescript
 vendor/grammars/atom-salt:
 - source.python.salt
 - source.yaml.salt

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2667,7 +2667,7 @@ PureScript:
   color: "#1D222D"
   extensions:
   - .purs
-  tm_scope: source.haskell
+  tm_scope: source.purescript
   ace_mode: haskell
 
 Python:


### PR DESCRIPTION
Rather than using the Haskell grammar, use one specifically meant for PureScript - this should improve the syntax highlighting.