### PR TITLE
add syntax highlight for *.vue component files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -665,3 +665,6 @@
 [submodule "vendor/grammars/atom-language-purescript"]
 	path = vendor/grammars/atom-language-purescript
 	url = https://github.com/freebroccolo/atom-language-purescript
+[submodule "vendor/grammars/vue-syntax-highlight"]
+	path = vendor/grammars/vue-syntax-highlight
+	url = https://github.com/vuejs/vue-syntax-highlight

--- a/grammars.yml
+++ b/grammars.yml
@@ -544,6 +544,8 @@ vendor/grammars/turtle.tmbundle:
 - source.turtle
 vendor/grammars/verilog.tmbundle:
 - source.verilog
+vendor/grammars/vue-syntax-highlight:
+- text.html.vue
 vendor/grammars/x86-assembly-textmate-bundle:
 - source.asm.x86
 vendor/grammars/xc.tmbundle/:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3516,6 +3516,14 @@ Volt:
   tm_scope: source.d
   ace_mode: d
 
+Vue:
+  type: markup
+  color: "#2c3e50"
+  extensions:
+  - .vue
+  tm_scope: text.html.vue
+  ace_mode: html
+
 Web Ontology Language:
   type: markup
   color: "#9cc9dd"

--- a/samples/Vue/basic.vue
+++ b/samples/Vue/basic.vue
@@ -1,0 +1,21 @@
+<style>
+.red {
+  color: #f00;
+}
+</style>
+
+<template>
+<div>
+  <h2 v-class="red">{{msg}}</h2>
+</div>
+</template>
+
+<script>
+module.exports = {
+  data: function () {
+    return {
+      msg: 'Hello from Vue!'
+    }
+  }
+}
+</script>

--- a/samples/Vue/pre-processors.vue
+++ b/samples/Vue/pre-processors.vue
@@ -1,0 +1,31 @@
+<style lang="stylus">
+font-stack = Helvetica, sans-serif
+primary-color = #999
+body
+  font 100% font-stack
+  color primary-color
+</style>
+
+<template lang="jade">
+div
+  h1 {{msg}}
+  comp-a
+  comp-b
+</template>
+
+<script lang="babel">
+import compA from './components/a.vue'
+import compB from './components/b.vue'
+
+export default {
+  data () {
+    return {
+      msg: 'Hello from Babel!'
+    }
+  },
+  components: {
+    'comp-a': compA,
+    'comp-b': compB
+  }
+}
+</script>


### PR DESCRIPTION
This PR adds detection and highlighting for [Vue.js](https://github.com/yyx990803/vue) components with the `*.vue` extension, using [vue-syntax-highlight](https://github.com/vuejs/vue-syntax-highlight). Vue components encapsulate styles, template and JavaScript logic in a single file, and also support mixing different pre-processors in the same file.

- [*.vue files search result](https://github.com/search?utf8=%E2%9C%93&q=extension%3Avue+NOT+xml&type=Code&ref=searchresults)
- [Lightshow example](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fvuejs%2Fvue-syntax-highlight%2Fblob%2Fmaster%2Fvue.tmLanguage&grammar_text=&code_source=from-text&code_url=&code=%3Cstyle+lang%3D%22sass%22%3E%0D%0A%24font-stack%3A+Helvetica%2C+sans-serif%3B%0D%0A%24primary-color%3A+%23999%3B%0D%0Abody+%7B%0D%0A++font%3A+100%25+%24font-stack%3B%0D%0A++color%3A+%24primary-color%3B%0D%0A%7D%0D%0A%3C%2Fstyle%3E%0D%0A%0D%0A%3Ctemplate+lang%3D%22jade%22%3E%0D%0Adiv%0D%0A++h1+%7B%7Bmsg%7D%7D%0D%0A++comp-a%0D%0A++comp-b%0D%0A%3C%2Ftemplate%3E%0D%0A%0D%0A%3Cscript%3E%0D%0Aimport+compA+from+%27.%2Fcomponents%2Fa.vue%27%0D%0Aimport+compB+from+%27.%2Fcomponents%2Fb.vue%27%0D%0A%0D%0Aexport+default+%7B%0D%0A++data+%28%29+%7B%0D%0A++++return+%7B%0D%0A++++++msg%3A+%27Hello+from+Babel%21%27%0D%0A++++%7D%0D%0A++%7D%2C%0D%0A++components%3A+%7B%0D%0A++++%27comp-a%27%3A+compA%2C%0D%0A++++%27comp-b%27%3A+compB%0D%0A++%7D%0D%0A%7D%0D%0A%3C%2Fscript%3E%0D%0A)
  - demonstrates syntax highlighting of embedded pre-processor languages