### PR TITLE
Parse HCL as Ruby, not JavaScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1273,8 +1273,8 @@ HCL:
   extensions:
     - .hcl
     - .tf
-  ace_mode: javascript
-  tm_scope: source.json
+  ace_mode: ruby
+  tm_scope: source.ruby
 
 HTML:
   type: markup


### PR DESCRIPTION
cc @sethvargo 

https://github.com/github/linguist/pull/1899

Before we get a proper HCL grammar, I believe it's much better to parse HCL as Ruby, so at least people don't see the annoying red background everywhere:

![screen shot 2015-07-30 at 11 32 25](https://cloud.githubusercontent.com/assets/287584/8981252/b672fb1e-36ae-11e5-80dc-32d6a692c942.png)