### PR TITLE
Case-insensitive extension match for heuristic rules

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -56,7 +56,7 @@ module Linguist
 
     # Internal: Check if this heuristic matches the candidate languages.
     def matches?(filename)
-      @extensions.any? { |ext| filename.end_with?(ext) }
+      @extensions.any? { |ext| filename.downcase.end_with?(ext) }
     end
 
     # Internal: Perform the heuristic
@@ -351,7 +351,7 @@ module Linguist
       end
     end
 
-    disambiguate ".r", ".R" do |data|
+    disambiguate ".r" do |data|
       if /\bRebol\b/i.match(data)
         Language["Rebol"]
       elsif data.include?("<-")


### PR DESCRIPTION
This pull request makes the extension match for heuristic rules case-insensitive.
I didn't seem coherent since the detection by extension is case-insensitive (see #2533).

I noticed it wasn't with the [new heuristic](https://github.com/github/linguist/pull/2533/files#diff-e56a8d50b1a75fc4212ffb3504faa007R354) from @arfon.

[`samples/R/hello-r.R`](https://github.com/github/linguist/blob/master/samples/R/hello-r.R) is, indirectly, a test for this.