### PR TITLE
Updates for the Puppet language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2653,7 +2653,7 @@ Public Key:
 
 Puppet:
   type: programming
-  color: "#332A77"
+  color: "#302B6D"
   extensions:
   - .pp
   filenames:

--- a/samples/Puppet/hiera_include.pp
+++ b/samples/Puppet/hiera_include.pp
@@ -1,0 +1,1 @@
+hiera_include('classes')


### PR DESCRIPTION
This PR resolves two issues with the Puppet language in Linguist:
  - Updates the language color based on the [Puppet Labs style guide](https://puppetlabs.com/styleguide/brand#color)
  - Adds an additional sample to prevent files containing only the line `hiera_include('classes')` from being categorized as Pascal

For an example of the Pascal mis-classification, please see https://github.com/garethr/puppet-mesos-example/search?l=pascal