### PR TITLE
YAML extensions for TextMate and Sublime Text grammars

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3718,6 +3718,7 @@ YAML:
   - .yml
   - .reek
   - .rviz
+  - .syntax
   - .yaml
   - .yaml-tmlanguage
   ace_mode: yaml

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3719,6 +3719,7 @@ YAML:
   - .reek
   - .rviz
   - .yaml
+  - .yaml-tmlanguage
   ace_mode: yaml
 
 Yacc:

--- a/samples/YAML/Ansible.YAML-tmLanguage
+++ b/samples/YAML/Ansible.YAML-tmLanguage
@@ -1,0 +1,38 @@
+# [PackageDev] target_format: plist, ext: tmLanguage
+---
+name: Ansible
+scopeName: source.ansible
+fileTypes: []
+uuid: 787ae642-b4ae-48b1-94e9-f935bec43a8f
+
+patterns:
+- name: comment.line.number-sign.ansible
+  match: (?:^ *|\G *)((#).*)
+  captures:
+    '1': {name: comment.line.number-sign.ansible}
+    '2': {name: punctuation.definition.comment.line.ansible}
+
+- name: storage.type.ansible
+  match: (\{\{ *[^\{\}]+ *\}\})|(\$\{[^\{\}]+\})
+
+- name: keyword.other.ansible
+  match: \- (name\:|include\:) (.*)|(^(- |\s*)\w+\:)
+  captures:
+    '2': {name: string.quoted.double.ansible}
+
+- name: variable.complex.ansible
+  contentName: string.other.ansible
+  begin: (\w+)(=)\"?
+  beginCaptures:
+    '1': {name: entity.other.attribute-name.ansible}
+    '2': {name: text}
+  end: \"?\s
+  patterns:
+    - include: $self
+    - name: constant.other.ansible
+      match: .
+
+- name: string.quoted.double.ansible
+  match: ^(\[[0-9a-zA-Z_-]+(((\:)children)*)\])
+  captures:
+    '2': {name: variable.parameter.ansible}

--- a/samples/YAML/source.r-console.syntax
+++ b/samples/YAML/source.r-console.syntax
@@ -1,0 +1,16 @@
+--- 
+name: R Console
+fileTypes: []
+
+scopeName: source.r-console
+uuid: F629C7F3-823B-4A4C-8EEE-9971490C5710
+patterns: 
+- name: source.r.embedded.r-console
+  begin: "^> "
+  beginCaptures: 
+    "0": 
+      name: punctuation.section.embedded.r-console
+  end: \n|\z
+  patterns: 
+  - include: source.r
+keyEquivalent: ^~R


### PR DESCRIPTION
This pull request adds the extensions `.YAML-tmLanguage` and `.syntax` to the YAML entry.
This extensions are used respectively for Sublime Text and TextMate grammars.

[`.syntax` files on GitHub](https://github.com/search?utf8=%E2%9C%93&q=extension%3Asyntax+filetypes&type=Code&ref=searchresults).
I can't perform the same kind of search for `.YAML-tmLanguages` files because there's a bug with upper-case extensions (already reported). [This search](https://github.com/search?p=2&q=name+scopeName+fileTypes+uuid+---&ref=searchresults&type=Code&utf8=%E2%9C%93) shows a good number of `.YAML-tmLanguage` files though.