### PR TITLE
Make regex for vim modeline more lenient

### DIFF
--- a/lib/linguist/strategy/modeline.rb
+++ b/lib/linguist/strategy/modeline.rb
@@ -2,7 +2,7 @@ module Linguist
   module Strategy
     class Modeline
       EmacsModeline = /-\*-\s*(?:(?!mode)[\w-]+\s*:\s*(?:[\w+-]+)\s*;?\s*)*(?:mode\s*:)?\s*([\w+-]+)\s*(?:;\s*(?!mode)[\w-]+\s*:\s*[\w+-]+\s*)*;?\s*-\*-/i
-      VimModeline = /vim:\s*set\s*(?:ft|filetype)=(\w+):/i
+      VimModeline = /vim:\s*set.*\s(?:ft|filetype)=(\w+)\s?.*:/i
 
       # Public: Detects language based on Vim and Emacs modelines
       #

--- a/test/fixtures/Data/Modelines/ruby2
+++ b/test/fixtures/Data/Modelines/ruby2
@@ -1,0 +1,3 @@
+/* vim: set ts=8 sw=4 filetype=ruby tw=0: */
+
+# Please help how do I into setting vim modlines

--- a/test/fixtures/Data/Modelines/ruby3
+++ b/test/fixtures/Data/Modelines/ruby3
@@ -1,0 +1,3 @@
+/* vim: set ft=ruby ts=8 sw=4 tw=0: */
+
+# I am not good at humor

--- a/test/test_modelines.rb
+++ b/test/test_modelines.rb
@@ -9,6 +9,8 @@ class TestModelines < Minitest::Test
 
   def test_modeline_strategy
     assert_modeline Language["Ruby"], fixture_blob("Data/Modelines/ruby")
+    assert_modeline Language["Ruby"], fixture_blob("Data/Modelines/ruby2")
+    assert_modeline Language["Ruby"], fixture_blob("Data/Modelines/ruby3")
     assert_modeline Language["C++"], fixture_blob("Data/Modelines/seeplusplus")
     assert_modeline Language["C++"], fixture_blob("Data/Modelines/seeplusplusEmacs1")
     assert_modeline Language["C++"], fixture_blob("Data/Modelines/seeplusplusEmacs2")
@@ -27,6 +29,8 @@ class TestModelines < Minitest::Test
 
   def test_modeline_languages
     assert_equal Language["Ruby"], fixture_blob("Data/Modelines/ruby").language
+    assert_equal Language["Ruby"], fixture_blob("Data/Modelines/ruby2").language
+    assert_equal Language["Ruby"], fixture_blob("Data/Modelines/ruby3").language
     assert_equal Language["C++"], fixture_blob("Data/Modelines/seeplusplus").language
     assert_equal Language["C++"], fixture_blob("Data/Modelines/seeplusplusEmacs1").language
     assert_equal Language["C++"], fixture_blob("Data/Modelines/seeplusplusEmacs2").language


### PR DESCRIPTION
The current regex looks strictly for set lines containing only a filetype parameter. Unfortunately this doesn't play too well with files which also set additional vim settings. An example of such a file can be seen here: https://github.com/alliedmodders/sourcemod/blob/master/AMBuildScript

It'd be cool to have syntax highlighting on that file but currently that would involve making an additional line containing either the emacs style modeline or a vim modeline containing the ``ft`` exclusively. Both of these seem hacky.

I've also added two tests with more complex modelines and the filetype in different positions.
