### PR TITLE
Don't blow up if empty string/nil passed to alias methods

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -150,6 +150,7 @@ module Linguist
     #
     # Returns the Language or nil if none was found.
     def self.find_by_name(name)
+      return nil if name.to_s.empty?
       name && (@name_index[name.downcase] || @name_index[name.split(',').first.downcase])
     end
 
@@ -164,6 +165,7 @@ module Linguist
     #
     # Returns the Language or nil if none was found.
     def self.find_by_alias(name)
+      return nil if name.to_s.empty?
       name && (@alias_index[name.downcase] || @alias_index[name.split(',').first.downcase])
     end
 

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -275,6 +275,11 @@ class TestLanguage < Minitest::Test
     assert_equal Language['Rust'], Language.find_by_alias('rust,no_run')
   end
 
+  def test_doesnt_blow_up_with_blank_lookup
+    assert_equal nil, Language.find_by_alias('')
+    assert_equal nil, Language.find_by_name(nil)
+  end
+
   def test_name
     assert_equal 'Perl',   Language['Perl'].name
     assert_equal 'Python', Language['Python'].name


### PR DESCRIPTION
https://github.com/github/linguist/pull/2447 introduced a small issue that if `nil` or a blank string was passed to the `Language.find_by...` methods they would blow up.

This fix simply returns quickly if `nil` or an empty string are passed into either method.