### PR TITLE
Add .arpa to DNS Zone.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -754,6 +754,7 @@ DNS Zone:
   type: data
   extensions:
   - .zone
+  - .arpa
   tm_scope: text.zone_file
   ace_mode: text
 

--- a/samples/DNS Zone/sample.arpa
+++ b/samples/DNS Zone/sample.arpa
@@ -1,0 +1,13 @@
+$ORIGIN 0.0.0.c.2.1.0.3.0.0.2.1.e.f.f.3.ip6.arpa.
+$TTL     60
+@ 	 IN SOA ns root (
+	     2002042901 ; SERIAL
+	     7200       ; REFRESH
+	     600        ; RETRY
+	     36000000   ; EXPIRE
+	     120        ; MINIMUM
+	     )
+
+	    NS	 ns.example.com.
+
+c.a.7.e.d.7.e.f.f.f.0.2.8.0.a.0 PTR  sip01.example.com.


### PR DESCRIPTION
Addition to #2554.  There are [753](https://github.com/search?q=extension%3Aarpa+soa+OR+root+OR+CNAME) `.arpa` files which are zone files.

(There are also [1163](https://github.com/search?q=extension%3Aarpa+NOT+soa+NOT+root+NOT+CNAME) `.arpa` files with some other content.  This in on par with the `.zone` file extension: [2698](https://github.com/search?q=extension%3Azone+soa+OR+root+OR+CNAME) vs [4084](https://github.com/search?q=extension%3Azone+NOT+soa+NOT+root+NOT+CNAME).)