### PR TITLE
#import "*.h" detection for Objective-C

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -65,7 +65,7 @@ module Linguist
     end
 
     # Common heuristics
-    ObjectiveCRegex = /^[ \t]*@(interface|class|protocol|property|end|synchronized|selector|implementation)\b/
+    ObjectiveCRegex = /^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])/
 
     disambiguate ".asc" do |data|
       if /^(----[- ]BEGIN|ssh-(rsa|dss)) /.match(data)

--- a/samples/Objective-C/Siesta.h
+++ b/samples/Objective-C/Siesta.h
@@ -1,0 +1,16 @@
+//
+//  Siesta.h
+//  Siesta
+//
+//  Created by Paul on 2015/6/14.
+//  Copyright © 2015 Bust Out Solutions. MIT license.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Siesta.
+FOUNDATION_EXPORT double SiestaVersionNumber;
+
+//! Project version string for Siesta.
+FOUNDATION_EXPORT const unsigned char SiestaVersionString[];
+


### PR DESCRIPTION
Apple’s standard generated .h file for frameworks is incorrectly being identified as C++. This fix correctly identifies it as Objective-C.

The `#import` (as opposed to `#include`) directive is used by both Obj-C and Microsoft C++. However, the Microsoft version is [only for importing libraries](https://msdn.microsoft.com/en-us/library/8etzzkb6(VS.71).aspx) and would never refer to a file with an `.h` extension. If we see `#import "foo.h"` or `#import <foo.h>`, we can therefore conclude the file is Obj-C.

Helps with #1626.