### PR TITLE
TextMate scope for RMarkdown

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2813,7 +2813,7 @@ RMarkdown:
   ace_mode: markdown
   extensions:
   - .rmd
-  tm_scope: none
+  tm_scope: source.gfm
 
 Racket:
   type: programming


### PR DESCRIPTION
Probably an edge case, but it can be useful for RMarkdown code snippets in Markdown documents.