### PR TITLE
Make RAML a markup language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2778,7 +2778,7 @@ R:
   ace_mode: r
 
 RAML:
-  type: data
+  type: markup
   ace_mode: yaml
   tm_scope: source.yaml
   color: "#77d9fb"


### PR DESCRIPTION
RAML was originally merged as a data language, but this seems like an incorrect definition. I changed it to be markup instead, which will also result in RAML appearing in repo statistics.

For example, API Blueprint is another similar API definition language that was recently merged as `markup`. 