### PR TITLE
Sass is an actual language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2985,7 +2985,7 @@ SAS:
 SCSS:
   type: markup
   tm_scope: source.scss
-  group: CSS
+  group: Sass
   ace_mode: scss
   extensions:
   - .scss
@@ -3087,7 +3087,6 @@ SaltStack:
 Sass:
   type: markup
   tm_scope: source.sass
-  group: CSS
   extensions:
   - .sass
   ace_mode: sass


### PR DESCRIPTION
I'd like to request that Sass/SCSS both be removed from the CSS group and have it's own group created. Sass has a ton of usage these days, outranking a lot of the other 'top level' languages, and while it's a server-side preprocessor, both of it's syntaxes are full blown languages at this point and think they deserve differentiation from their W3C brethren.

Thanks!