### PR TITLE
Haml is independent of HTML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1357,7 +1357,6 @@ Hack:
   tm_scope: text.html.php
 
 Haml:
-  group: HTML
   type: markup
   extensions:
   - .haml


### PR DESCRIPTION
I'm just on a tear today separating out my languages... ;)

My argument is that Haml should be independent of HTML, because it doesn't look at all like HTML, has a ton of other features, helpers, etc that make it different than HTML.

Also, Handlebars is considered distinct from HTML, and then so should Haml.

.haml: 1.1 million files https://github.com/search?utf8=%E2%9C%93&q=extension%3Ahaml+NOT+nothack&type=Code&ref=searchresults
.hbs: 300k https://github.com/search?utf8=%E2%9C%93&q=extension%3Ahbs+NOT+nothack&type=Code&ref=searchresults
.handlebars: 98k https://github.com/search?utf8=%E2%9C%93&q=extension%3Ahandlebars+NOT+nothack&type=Code&ref=searchresults

We'd really like to be able to track usage of Haml around the internet better than is indicated by keeping it as just a flavour of HTML.

Thanks!