### PR TITLE
Adding support for recognizing F* files  ... no syntax highlighting yet

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -947,6 +947,18 @@ F#:
   tm_scope: source.fsharp
   ace_mode: text
 
+F*:
+  type: programming
+  color: "#b845fc"
+  search_term: fstar
+  aliases:
+  - fstar
+  extensions:
+  - .fst
+  - .fsti
+  tm_scope: none
+  ace_mode: text
+
 FLUX:
   type: programming
   color: "#88ccff"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -955,7 +955,6 @@ F*:
   - fstar
   extensions:
   - .fst
-  - .fsti
   tm_scope: none
   ace_mode: text
 

--- a/samples/F*/qsc.fst
+++ b/samples/F*/qsc.fst
@@ -1,0 +1,93 @@
+(*--build-config
+    options:--admit_fsi Set --z3timeout 20;
+    other-files:set.fsi heap.fst st.fst all.fst list.fst
+  --*)
+module QuickSort
+open List
+#set-options "--initial_ifuel 2 --initial_fuel 1 --max_ifuel 2 --max_fuel 1"
+
+(* Specification of sortedness according to some comparison function f *)
+val sorted: ('a -> 'a -> Tot bool) -> list 'a -> Tot bool
+let rec sorted f l = match l with
+    | [] -> true
+    | [x] -> true
+    | x::y::xs -> f x y && sorted f (y::xs)
+
+
+type total_order (a:Type) (f: (a -> a -> Tot bool)) =
+    (forall a. f a a)                                           (* reflexivity   *)
+    /\ (forall a1 a2. (f a1 a2 /\ f a2 a1)  ==> a1 == a2)       (* anti-symmetry *)
+    /\ (forall a1 a2 a3. f a1 a2 /\ f a2 a3 ==> f a1 a3)        (* transitivity  *)
+    /\ (forall a1 a2. f a1 a2 \/ f a2 a1)                       (* totality      *)
+
+
+val count : 'a -> list 'a -> Tot nat
+let rec count (x:'a) (l:list 'a) = match l with
+  | hd::tl -> (if hd=x then 1 else 0) + count x tl
+  | [] -> 0
+
+
+val mem_count : x:'a -> l:list 'a ->
+      Lemma (requires True) (ensures (mem x l == (count x l > 0)))
+      [SMTPat (mem x l)] (decreases l)
+let rec mem_count x l = match l with
+  | [] -> ()
+  | _::tl -> mem_count x tl
+
+
+val append_count: l:list 'a -> m:list 'a -> x:'a
+               -> Lemma (requires True)
+                        (ensures (count x (append l m) = (count x l + count x m)))
+                        [SMTPat (count x (append l m))]
+let rec append_count l m x = match l with
+  | [] -> ()
+  | hd::tl -> append_count tl m x
+
+
+val partition: ('a -> Tot bool) -> list 'a -> Tot (list 'a * list 'a)
+let rec partition p = function
+  | [] -> [], []
+  | hd::tl ->
+     let l1, l2 = partition p tl in
+     if p hd
+     then hd::l1, l2
+     else l1, hd::l2
+
+opaque logic type trigger (#a:Type) (x:a) = True
+val partition_lemma: f:('a -> Tot bool) -> l:list 'a -> Lemma (requires True)
+      (ensures (forall hi lo. (hi, lo) = partition f l
+                ==>  (length l = length hi + length lo
+                 /\ (forall x.{:pattern (trigger x)}
+                              trigger x ==>
+                               (mem x hi ==> f x)
+                           /\  (mem x lo ==> not (f x))
+                           /\  (count x l = count x hi + count x lo)))))
+      [SMTPat (partition f l)]
+let rec partition_lemma f l = match l with
+    | [] -> ()
+    | hd::tl -> cut (trigger hd); partition_lemma f tl
+
+
+val sorted_app_lemma: #a:Type
+                      -> f:(a -> a -> Tot bool){total_order a f}
+                      -> l1:list a{sorted f l1}
+                      -> l2:list a{sorted f l2}
+                      -> pivot:a
+                      -> Lemma (requires ((forall y.{:pattern (trigger y)} trigger y ==>
+                                                        ((mem y l1 ==> not (f pivot y))
+                                                      /\ (mem y l2 ==> f pivot y)))))
+                               (ensures (sorted f (append l1 (pivot::l2))))
+                               [SMTPat (sorted f (append l1 (pivot::l2)))]
+let rec sorted_app_lemma f l1 l2 pivot = match l1 with
+    | [] -> if is_Cons l2 then cut (trigger (Cons.hd l2)) else ()
+    | hd::tl -> cut (trigger hd); sorted_app_lemma f tl l2 pivot
+
+val sort: f:('a -> 'a -> Tot bool){total_order 'a f}
+       -> l:list 'a
+       -> Tot (m:list 'a{sorted f m /\ (forall i.{:pattern trigger i} trigger i ==> (count i l = count i m))})
+              (decreases (length l))
+let rec sort f = function
+  | [] -> []
+  | pivot::tl ->
+    let hi, lo = partition (f pivot) tl in
+    append (sort f lo) (pivot::(sort f hi))


### PR DESCRIPTION
F* is an ML-like functional programming language aimed at program verification:
https://en.wikipedia.org/wiki/F*_(programming_language)
https://www.fstar-lang.org/

Here is a PR adding support for recognizing F* files based on their extension (`.fst` and `.fsti`). These extensions are not currently in `languages.yml`.

Here is a GitHub search result showing in-the-wild usage:
https://github.com/search?l=&q=module+extension%3Afst&ref=advsearch&type=Code&utf8=%E2%9C%93

This PR only provides support for recognizing F* files based on extension. We're also working on contributing F* syntax highlighting back to ace editor:
https://github.com/FStarLang/FStar/issues/333
https://www.fstar-lang.org/ace/mode-fstar.js
and we also have an Atom grammar we could contribute:
https://github.com/FStarLang/atom-fstar/blob/master/grammars/fstar.cson