### PR TITLE
Add some additional help text to license test

### DIFF
--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -97,7 +97,9 @@ class TestGrammars < Minitest::Test
 
   def test_submodules_have_approved_licenses
     unapproved = submodule_licenses.reject { |k,v| LICENSE_WHITELIST.include?(v) || PROJECT_WHITELIST.include?(k) }.map { |k,v| "#{k}: #{v}"}
-    assert_equal [], unapproved, "The following submodules have unapproved licenses:\n* #{unapproved.join("\n* ")}"
+    message = "The following submodules have unapproved licenses:\n* #{unapproved.join("\n* ")}\n"
+    message << "The license must be added to the LICENSE_WHITELIST in /test/test_grammars.rb once approved."
+    assert_equal [], unapproved, message
   end
 
   def test_submodules_whitelist_has_no_extra_entries

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -83,12 +83,16 @@ class TestGrammars < Minitest::Test
   def test_submodules_have_recognized_licenses
     unrecognized = submodule_licenses.select { |k,v| v.nil? && Licensee::Project.new(k).license_file }
     unrecognized.reject! { |k,v| PROJECT_WHITELIST.include?(k) }
-    assert_equal Hash.new, unrecognized, "The following submodules have unrecognized licenses:\n* #{unrecognized.keys.join("\n* ")}"
+    message = "The following submodules have unrecognized licenses:\n* #{unrecognized.keys.join("\n* ")}\n"
+    message << "Please ensure that the project's LICENSE file contains the full text of the license."
+    assert_equal Hash.new, unrecognized, message
   end
 
   def test_submodules_have_licenses
     unlicensed = submodule_licenses.select { |k,v| v.nil? }.reject { |k,v| PROJECT_WHITELIST.include?(k) }
-    assert_equal Hash.new, unlicensed, "The following submodules don't have licenses:\n* #{unlicensed.keys.join("\n* ")}"
+    message = "The following submodules don't have licenses:\n* #{unlicensed.keys.join("\n* ")}\n"
+    message << "Please ensure that the project has a LICENSE file, and that the LICENSE file contains the full text of the license."
+    assert_equal Hash.new, unlicensed, message
   end
 
   def test_submodules_have_approved_licenses


### PR DESCRIPTION
This pull request adds some additional help text to the license list, to make scenarios like the one in https://github.com/github/linguist/pull/2589 a bit friendlier for contributors.

It instructs users to add a LICENSE file, if none exists, and to add *the text* of the license to the license file, if we can't detect the license from the license file.