### PR TITLE
Add color for the PL/SQL language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2443,6 +2443,7 @@ PLSQL:
   type: programming
   ace_mode: sql
   tm_scope: source.plsql.oracle
+  color: "#dad8d8"
   extensions:
   - .pls
   - .pkb


### PR DESCRIPTION
I have added color to the PL/SQL language: #dad8d8. I take this color from a window background which evokes the interface of the language. Also I searched for this color code in this file but I couldn't find any match.