### PR TITLE
Add colors for some languages.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -703,7 +703,7 @@ Cuda:
   - .cuh
   tm_scope: source.cuda-c++
   ace_mode: c_cpp
-  color: "#98DB22"
+  color: "#1C201C"
 
 Cycript:
   type: programming
@@ -1210,7 +1210,7 @@ Gradle:
   - .gradle
   tm_scope: source.groovy.gradle
   ace_mode: text
-  color: "#95CB51"
+  color: "#4B0283"
 
 Grammatical Framework:
   type: programming
@@ -1778,7 +1778,7 @@ Less:
   - .less
   tm_scope: source.css.less
   ace_mode: less
-  color: "#3B5E93"
+  color: "#83BB83"
 
 Lex:
   type: programming
@@ -1988,7 +1988,7 @@ Markdown:
   - .mkdown
   - .ron
   tm_scope: source.gfm
-  color: "#EEEEEE"
+  color: "#80B729"
 
 Mask:
   type: markup
@@ -2217,7 +2217,7 @@ Nginx:
   aliases:
   - nginx configuration file
   ace_mode: text
-  color: "#11AA11"
+  color: "#9469E9"
 
 Nimrod:
   type: programming
@@ -2276,7 +2276,7 @@ NumPy:
   - .numsc
   tm_scope: none
   ace_mode: text
-  color: "#489FD9"
+  color: "#9C8AF9"
 
 OCaml:
   type: programming
@@ -3694,7 +3694,7 @@ XML:
   - Web.Release.config
   - Web.config
   - packages.config
-  color: "#36BBF3"
+  color: "#E88E88"
 
 XPages:
   type: programming
@@ -3740,7 +3740,7 @@ XSLT:
   - .xsl
   tm_scope: text.xml.xsl
   ace_mode: xml
-  color: "#1F87CE"
+  color: "#EB8CEB"
 
 Xojo:
   type: programming
@@ -3783,7 +3783,7 @@ Yacc:
   - .yy
   tm_scope: source.bison
   ace_mode: text
-  color: "#A33890"
+  color: "#F011F0"
 
 Zephir:
   type: programming
@@ -3866,7 +3866,7 @@ reStructuredText:
   - .rst
   - .rest
   ace_mode: text
-  color: "#444444"
+  color: "#B3BCBC"
 
 wisp:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -694,7 +694,7 @@ Cucumber:
   aliases:
   - gherkin
   ace_mode: text
-  color: "#2EF336"
+  color: "#5B2063"
 
 Cuda:
   type: programming
@@ -1988,7 +1988,7 @@ Markdown:
   - .mkdown
   - .ron
   tm_scope: source.gfm
-  color: "#DB0274"
+  color: "#083FA1"
 
 Mask:
   type: markup
@@ -2525,7 +2525,7 @@ Parrot Internal Representation:
 
 Pascal:
   type: programming
-  color: "#0B1999"
+  color: "#3846C6"
   extensions:
   - .pas
   - .dfm

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -631,7 +631,7 @@ Common Lisp:
 
 Component Pascal:
   type: programming
-  color: "#b0ce4e"
+  color: "#c1df5f"
   extensions:
   - .cp
   - .cps
@@ -703,7 +703,7 @@ Cuda:
   - .cuh
   tm_scope: source.cuda-c++
   ace_mode: c_cpp
-  color: "#76B900"
+  color: "#87CA11"
 
 Cycript:
   type: programming
@@ -1210,7 +1210,7 @@ Gradle:
   - .gradle
   tm_scope: source.groovy.gradle
   ace_mode: text
-  color: "#84BA40"
+  color: "#95CB51"
 
 Grammatical Framework:
   type: programming
@@ -1714,7 +1714,7 @@ LLVM:
   extensions:
   - .ll
   ace_mode: text
-  color: "#689DD7"
+  color: "#79AEE8"
 
 LOLCODE:
   type: programming
@@ -1778,7 +1778,7 @@ Less:
   - .less
   tm_scope: source.css.less
   ace_mode: less
-  color: "#2A4D82"
+  color: "#3B5E93"
 
 Lex:
   type: programming
@@ -1988,7 +1988,7 @@ Markdown:
   - .mkdown
   - .ron
   tm_scope: source.gfm
-  color: "#DDDDDD"
+  color: "#EEEEEE"
 
 Mask:
   type: markup
@@ -2027,7 +2027,7 @@ Maven POM:
   filenames:
   - pom.xml
   ace_mode: xml
-  color: "#FF6804"
+  color: "#007915"
 
 Max:
   type: programming
@@ -2217,7 +2217,7 @@ Nginx:
   aliases:
   - nginx configuration file
   ace_mode: text
-  color: "#009900"
+  color: "#11AA11"
 
 Nimrod:
   type: programming
@@ -2276,7 +2276,7 @@ NumPy:
   - .numsc
   tm_scope: none
   ace_mode: text
-  color: "#378EC8"
+  color: "#489FD9"
 
 OCaml:
   type: programming
@@ -2779,7 +2779,7 @@ QMake:
 
 R:
   type: programming
-  color: "#198ce7"
+  color: "#2A9DF8"
   aliases:
   - R
   - Rscript
@@ -3694,7 +3694,7 @@ XML:
   - Web.Release.config
   - Web.config
   - packages.config
-  color: "#25AAE2"
+  color: "#36BBF3"
 
 XPages:
   type: programming
@@ -3740,7 +3740,7 @@ XSLT:
   - .xsl
   tm_scope: text.xml.xsl
   ace_mode: xml
-  color: "#0E76BD"
+  color: "#1F87CE"
 
 Xojo:
   type: programming
@@ -3773,7 +3773,7 @@ YAML:
   - .yaml
   - .yaml-tmlanguage
   ace_mode: yaml
-  color: "#FF0000"
+  color: "#001111"
 
 Yacc:
   type: programming
@@ -3783,7 +3783,7 @@ Yacc:
   - .yy
   tm_scope: source.bison
   ace_mode: text
-  color: "#92278F"
+  color: "#A33890"
 
 Zephir:
   type: programming
@@ -3866,7 +3866,7 @@ reStructuredText:
   - .rst
   - .rest
   ace_mode: text
-  color: "#000000"
+  color: "#444444"
 
 wisp:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -703,7 +703,7 @@ Cuda:
   - .cuh
   tm_scope: source.cuda-c++
   ace_mode: c_cpp
-  color: "#87CA11"
+  color: "#98DB22"
 
 Cycript:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -153,6 +153,7 @@ Ant Build System:
   - ant.xml
   - build.xml
   ace_mode: xml
+  color: "#A82C7C"
 
 ApacheConf:
   type: markup
@@ -182,6 +183,7 @@ AppleScript:
   interpreters:
   - osascript
   ace_mode: applescript
+  color: "#F2F1F1"
 
 Arc:
   type: programming
@@ -289,6 +291,7 @@ Batchfile:
   - .cmd
   tm_scope: source.dosbatch
   ace_mode: batchfile
+  color: "#92C2FF"
 
 Befunge:
   type: programming
@@ -303,6 +306,7 @@ Bison:
   extensions:
   - .bison
   ace_mode: text
+  color: "#6A463F"
 
 BitBake:
   type: programming
@@ -690,6 +694,7 @@ Cucumber:
   aliases:
   - gherkin
   ace_mode: text
+  color: "#00A818"
 
 Cuda:
   type: programming
@@ -698,6 +703,7 @@ Cuda:
   - .cuh
   tm_scope: source.cuda-c++
   ace_mode: c_cpp
+  color: "#76B900"
 
 Cycript:
   type: programming
@@ -1204,6 +1210,7 @@ Gradle:
   - .gradle
   tm_scope: source.groovy.gradle
   ace_mode: text
+  color: "#84BA40"
 
 Grammatical Framework:
   type: programming
@@ -1355,6 +1362,7 @@ Hack:
   - .hh
   - .php
   tm_scope: text.html.php
+  color: "#878787"
 
 Haml:
   group: HTML
@@ -1363,6 +1371,7 @@ Haml:
   - .haml
   - .haml.deface
   ace_mode: haml
+  color: "#ECE2A9"
 
 Handlebars:
   type: markup
@@ -1705,6 +1714,7 @@ LLVM:
   extensions:
   - .ll
   ace_mode: text
+  color: "#689DD7"
 
 LOLCODE:
   type: programming
@@ -1768,6 +1778,7 @@ Less:
   - .less
   tm_scope: source.css.less
   ace_mode: less
+  color: "#2A4D82"
 
 Lex:
   type: programming
@@ -1977,6 +1988,7 @@ Markdown:
   - .mkdown
   - .ron
   tm_scope: source.gfm
+  color: "#DDDDDD"
 
 Mask:
   type: markup
@@ -2015,6 +2027,7 @@ Maven POM:
   filenames:
   - pom.xml
   ace_mode: xml
+  color: "#FF6804"
 
 Max:
   type: programming
@@ -2204,6 +2217,7 @@ Nginx:
   aliases:
   - nginx configuration file
   ace_mode: text
+  color: "#009900"
 
 Nimrod:
   type: programming
@@ -2262,6 +2276,7 @@ NumPy:
   - .numsc
   tm_scope: none
   ace_mode: text
+  color: "#378EC8"
 
 OCaml:
   type: programming
@@ -2794,6 +2809,7 @@ RDoc:
   extensions:
   - .rdoc
   tm_scope: text.rdoc
+  color: "#333333"
 
 REALbasic:
   type: programming
@@ -2991,6 +3007,7 @@ SCSS:
   ace_mode: scss
   extensions:
   - .scss
+  color: "#CF649A"
 
 SMT:
   type: programming
@@ -3093,6 +3110,7 @@ Sass:
   extensions:
   - .sass
   ace_mode: sass
+  color: "#CF649A"
 
 Scala:
   type: programming
@@ -3676,6 +3694,7 @@ XML:
   - Web.Release.config
   - Web.config
   - packages.config
+  color: "#25AAE2"
 
 XPages:
   type: programming
@@ -3721,6 +3740,7 @@ XSLT:
   - .xsl
   tm_scope: text.xml.xsl
   ace_mode: xml
+  color: "#0E76BD"
 
 Xojo:
   type: programming
@@ -3753,6 +3773,7 @@ YAML:
   - .yaml
   - .yaml-tmlanguage
   ace_mode: yaml
+  color: "#FF0000"
 
 Yacc:
   type: programming
@@ -3762,6 +3783,7 @@ Yacc:
   - .yy
   tm_scope: source.bison
   ace_mode: text
+  color: "#92278F"
 
 Zephir:
   type: programming
@@ -3844,6 +3866,7 @@ reStructuredText:
   - .rst
   - .rest
   ace_mode: text
+  color: "#000000"
 
 wisp:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2525,7 +2525,7 @@ Parrot Internal Representation:
 
 Pascal:
   type: programming
-  color: "#C1DF5F"
+  color: "#E3F171"
   extensions:
   - .pas
   - .dfm

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -795,7 +795,6 @@ Dart:
 
 Diff:
   type: data
-  color: "#88dddd"
   extensions:
   - .diff
   - .patch
@@ -3461,7 +3460,6 @@ Unified Parallel C:
 Unity3D Asset:
   type: data
   ace_mode: yaml
-  color: "#ab69a1"
   extensions:
   - .anim
   - .asset
@@ -3818,7 +3816,6 @@ eC:
 edn:
   type: data
   ace_mode: clojure
-  color: "#db5855"
   extensions:
   - .edn
   tm_scope: source.clojure

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -291,7 +291,7 @@ Batchfile:
   - .cmd
   tm_scope: source.dosbatch
   ace_mode: batchfile
-  color: "#92C2FF"
+  color: "#A3D300"
 
 Befunge:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -153,7 +153,6 @@ Ant Build System:
   - ant.xml
   - build.xml
   ace_mode: xml
-  color: "#C64A9A"
 
 ApacheConf:
   type: markup
@@ -1210,7 +1209,6 @@ Gradle:
   - .gradle
   tm_scope: source.groovy.gradle
   ace_mode: text
-  color: "#4B0283"
 
 Grammatical Framework:
   type: programming
@@ -2027,7 +2025,6 @@ Maven POM:
   filenames:
   - pom.xml
   ace_mode: xml
-  color: "#007915"
 
 Max:
   type: programming
@@ -3694,7 +3691,6 @@ XML:
   - Web.Release.config
   - Web.config
   - packages.config
-  color: "#E88E88"
 
 XPages:
   type: programming
@@ -3773,7 +3769,6 @@ YAML:
   - .yaml
   - .yaml-tmlanguage
   ace_mode: yaml
-  color: "#56789A"
 
 Yacc:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -694,7 +694,7 @@ Cucumber:
   aliases:
   - gherkin
   ace_mode: text
-  color: "#2EC636"
+  color: "#2EF336"
 
 Cuda:
   type: programming
@@ -1714,7 +1714,7 @@ LLVM:
   extensions:
   - .ll
   ace_mode: text
-  color: "#97CC06"
+  color: "#185619"
 
 LOLCODE:
   type: programming
@@ -1988,7 +1988,7 @@ Markdown:
   - .mkdown
   - .ron
   tm_scope: source.gfm
-  color: "#AED547"
+  color: "#DB0274"
 
 Mask:
   type: markup
@@ -2525,7 +2525,7 @@ Parrot Internal Representation:
 
 Pascal:
   type: programming
-  color: "#DEEC6C"
+  color: "#0B1999"
   extensions:
   - .pas
   - .dfm
@@ -2809,7 +2809,7 @@ RDoc:
   extensions:
   - .rdoc
   tm_scope: text.rdoc
-  color: "#515151"
+  color: "#8E84BF"
 
 REALbasic:
   type: programming
@@ -3773,7 +3773,7 @@ YAML:
   - .yaml
   - .yaml-tmlanguage
   ace_mode: yaml
-  color: "#001111"
+  color: "#56789A"
 
 Yacc:
   type: programming
@@ -3783,7 +3783,7 @@ Yacc:
   - .yy
   tm_scope: source.bison
   ace_mode: text
-  color: "#1E3F1E"
+  color: "#4B6C4B"
 
 Zephir:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -631,7 +631,7 @@ Common Lisp:
 
 Component Pascal:
   type: programming
-  color: "#EFFD7D"
+  color: "#B0CE4E"
   extensions:
   - .cp
   - .cps
@@ -2525,7 +2525,7 @@ Parrot Internal Representation:
 
 Pascal:
   type: programming
-  color: "#3846C6"
+  color: "#C1DF5F"
   extensions:
   - .pas
   - .dfm

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -153,7 +153,7 @@ Ant Build System:
   - ant.xml
   - build.xml
   ace_mode: xml
-  color: "#A82C7C"
+  color: "#C64A9A"
 
 ApacheConf:
   type: markup
@@ -183,7 +183,7 @@ AppleScript:
   interpreters:
   - osascript
   ace_mode: applescript
-  color: "#F2F1F1"
+  color: "#101F1F"
 
 Arc:
   type: programming
@@ -291,7 +291,7 @@ Batchfile:
   - .cmd
   tm_scope: source.dosbatch
   ace_mode: batchfile
-  color: "#A3D300"
+  color: "#C1F12E"
 
 Befunge:
   type: programming
@@ -631,7 +631,7 @@ Common Lisp:
 
 Component Pascal:
   type: programming
-  color: "#c1df5f"
+  color: "#EFFD7D"
   extensions:
   - .cp
   - .cps
@@ -694,7 +694,7 @@ Cucumber:
   aliases:
   - gherkin
   ace_mode: text
-  color: "#00A818"
+  color: "#2EC636"
 
 Cuda:
   type: programming
@@ -703,7 +703,7 @@ Cuda:
   - .cuh
   tm_scope: source.cuda-c++
   ace_mode: c_cpp
-  color: "#1C201C"
+  color: "#3A4E3A"
 
 Cycript:
   type: programming
@@ -1714,7 +1714,7 @@ LLVM:
   extensions:
   - .ll
   ace_mode: text
-  color: "#79AEE8"
+  color: "#97CC06"
 
 LOLCODE:
   type: programming
@@ -1778,7 +1778,7 @@ Less:
   - .less
   tm_scope: source.css.less
   ace_mode: less
-  color: "#83BB83"
+  color: "#A1D9A1"
 
 Lex:
   type: programming
@@ -1988,7 +1988,7 @@ Markdown:
   - .mkdown
   - .ron
   tm_scope: source.gfm
-  color: "#80B729"
+  color: "#AED547"
 
 Mask:
   type: markup
@@ -2525,7 +2525,7 @@ Parrot Internal Representation:
 
 Pascal:
   type: programming
-  color: "#b0ce4e"
+  color: "#DEEC6C"
   extensions:
   - .pas
   - .dfm
@@ -2779,7 +2779,7 @@ QMake:
 
 R:
   type: programming
-  color: "#2A9DF8"
+  color: "#198CE7"
   aliases:
   - R
   - Rscript
@@ -2809,7 +2809,7 @@ RDoc:
   extensions:
   - .rdoc
   tm_scope: text.rdoc
-  color: "#333333"
+  color: "#515151"
 
 REALbasic:
   type: programming
@@ -3783,7 +3783,7 @@ Yacc:
   - .yy
   tm_scope: source.bison
   ace_mode: text
-  color: "#F011F0"
+  color: "#1E3F1E"
 
 Zephir:
   type: programming


### PR DESCRIPTION
These are effected languages and the reason behind the proposed colors:

- Ant Build System: The color of logo (http://ant.apache.org/images/project-logo.gif).
- AppleScript: AppleScript editor logo (https://en.wikipedia.org/wiki/AppleScript#/media/File:AppleScript_Editor_Logo.png).
- Batchfile: Batch file icon in Windows (https://en.wikipedia.org/wiki/Batch_file#/media/File:Batch_file_icon_in_Windows_Vista.png).
- Bison: A color taken from a bison (https://en.wikipedia.org/wiki/Bison#/media/File:Americanbison.jpg).
- Cucumber: Official logo color (https://cucumber.io/images/cucumber-logo.svg).
- Cuda: Nvidia(creator of CUDA) logo color (http://www.nvidia.com/content/includes/redesign2010/images/redesign10/nvidia_logo.png).
- Gradle: Official Gradle logo color (https://gradle.org/wp-content/uploads/2015/03/GradleLogoReg.png).
- Hack: Hack logo color (http://hacklang.org/wp-content/themes/hack/hack.png).
- Haml: Haml logo color (http://haml.info/images/haml.png).
- LLVM: Eye color of the dragon logo of LLVM (http://llvm.org/img/DragonMedium.png).
- Less: Less logo color (http://lesscss.org/public/img/logo.png).
- Markdown: The Daring Fireball logo color (http://daringfireball.net/graphics/logos/).
- Maven POM: The maven logo color (https://en.wikipedia.org/wiki/Apache_Maven#/media/File:Maven_logo.svg).
- Nginx: The nginx logo color (http://nginx.org/nginx.png).
- NumPy: The NumPy logo color (http://www.numpy.org/_static/numpy_logo.png).
- RDoc: I couldn'd find any logo, so have used the color of the name of RDoc in the official site (http://docs.seattlerb.org/rdoc/).
- SCSS: The Sass logo color (http://sass-lang.com/assets/img/logos/logo-b6e1ef6e.svg).
- Sass: The Sass logo color (http://sass-lang.com/assets/img/logos/logo-b6e1ef6e.svg).
- XML: A random color.
- XSLT: A random color.
- YAML: The color of the name of YAML in the official site (http://yaml.org/).
- Yacc: A random color.
- reStructuredText: The official logo color (http://docutils.sourceforge.net/rst.png).