### PR TITLE
Adding support for generated overrides

### DIFF
--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -4,7 +4,11 @@ require 'rugged'
 
 module Linguist
   class LazyBlob
-    GIT_ATTR = ['linguist-documentation', 'linguist-language', 'linguist-vendored']
+    GIT_ATTR = ['linguist-documentation',
+                'linguist-language',
+                'linguist-vendored',
+                'linguist-generated']
+
     GIT_ATTR_OPTS = { :priority => [:index], :skip_system => true }
     GIT_ATTR_FLAGS = Rugged::Repository::Attributes.parse_opts(GIT_ATTR_OPTS)
 
@@ -31,17 +35,25 @@ module Linguist
         name, GIT_ATTR, GIT_ATTR_FLAGS)
     end
 
-    def vendored?
-      if attr = git_attributes['linguist-vendored']
-        return boolean_attribute(attr)
-      else
-        return super
-      end
-    end
-
     def documentation?
       if attr = git_attributes['linguist-documentation']
         boolean_attribute(attr)
+      else
+        super
+      end
+    end
+
+    def generated?
+      if attr = git_attributes['linguist-generated']
+        boolean_attribute(attr)
+      else
+        super
+      end
+    end
+
+    def vendored?
+      if attr = git_attributes['linguist-vendored']
+        return boolean_attribute(attr)
       else
         super
       end

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -111,4 +111,14 @@ class TestRepository < Minitest::Test
     refute_predicate readme, :documentation?
     assert_predicate arduino, :documentation?
   end
+
+  def test_linguist_override_generated?
+    attr_commit = "351c1cc8fd57340839bdb400d7812332af80e9bd"
+    repo = linguist_repo(attr_commit).read_index
+
+    rakefile = Linguist::LazyBlob.new(rugged_repository, attr_commit, "Rakefile")
+
+    # overridden .gitattributes
+    assert rakefile.generated?
+  end
 end


### PR DESCRIPTION
This adds support for `generated?` Linguist overrides. The `generated?` check is what determines if a file is suppressed in a Pull Request view (or not).

Don't get too excited though, this currently won't change behaviour on GitHub.com but is part of a larger effort to bring first class support for Linguist Overrides throughout the GitHub experience :smile: