### PR TITLE
Treat Go dependency tree as generated and vendored code

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -56,6 +56,7 @@ module Linguist
       generated_net_specflow_feature_file? ||
       composer_lock? ||
       node_modules? ||
+      go_vendor? ||
       godeps? ||
       generated_by_zephir? ||
       minified_files? ||
@@ -278,6 +279,14 @@ module Linguist
     # Returns true or false.
     def node_modules?
       !!name.match(/node_modules\//)
+    end
+
+    # Internal: Is the blob part of the Go vendor/ tree,
+    # not meant for humans in pull requests.
+    #
+    # Returns true or false.
+    def go_vendor?
+      !!name.match(/vendor\//)
     end
 
     # Internal: Is the blob part of Godeps/,

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -245,6 +245,10 @@ class TestBlob < Minitest::Test
 
     assert sample_blob("node_modules/grunt/lib/grunt.js").generated?
 
+    # Go vendored dependencies
+    assert sample_blob("vendor/vendor.json").generated?
+    assert sample_blob("vendor/github.com/kr/s3/sign.go").generated?
+
     # Godep saved dependencies
     assert sample_blob("Godeps/Godeps.json").generated?
     assert sample_blob("Godeps/_workspace/src/github.com/kr/s3/sign.go").generated?


### PR DESCRIPTION
This PR is like #1549, but as of Go 1.5, the go tool has a vendoring mechanism, and it uses `vendor` as the directory name.

For more details on the Go 1.5 vendor functionality, see
https://groups.google.com/d/msg/golang-dev/74zjMON9glU/4lWCRDCRZg0J
and the description of the change introducing the feature,
https://go.googlesource.com/go/+/183cc0cd41