### PR TITLE
New JSX language under JavaScript group

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -677,3 +677,6 @@
 [submodule "vendor/grammars/X10"]
 	path = vendor/grammars/X10
 	url = git@github.com:x10-lang/x10-highlighting.git
+[submodule "vendor/grammars/language-babel"]
+	path = vendor/grammars/language-babel
+	url = https://github.com/gandm/language-babel

--- a/grammars.yml
+++ b/grammars.yml
@@ -314,6 +314,9 @@ vendor/grammars/json.tmbundle:
 - source.json
 vendor/grammars/kotlin-sublime-package:
 - source.Kotlin
+vendor/grammars/language-babel/:
+- source.js.jsx
+- source.regexp.babel
 vendor/grammars/language-clojure:
 - source.clojure
 vendor/grammars/language-coffee-script:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1575,6 +1575,14 @@ JSONiq:
   - .jq
   tm_scope: source.jq
 
+JSX:
+  type: programming
+  group: JavaScript
+  extensions:
+  - .jsx
+  tm_scope: source.js.jsx
+  ace_mode: javascript
+
 Jade:
   group: HTML
   type: markup
@@ -1628,7 +1636,6 @@ JavaScript:
   - .jsfl
   - .jsm
   - .jss
-  - .jsx
   - .njs
   - .pac
   - .sjs

--- a/samples/JSX/sample.jsx
+++ b/samples/JSX/sample.jsx
@@ -1,0 +1,23 @@
+'use strict';
+
+const React = require('react')
+
+module.exports = React.createClass({
+  render: function() {
+    let {feeds, log} = this.props;
+
+    log.info(feeds);
+    return <div className="feed-list">
+      <h3>News Feed's</h3>
+      <ul>
+        {feeds.map(function(feed) {
+          return <li key={feed.name} className={feed.fetched ? 'loaded' : 'loading'}>
+            {feed.data && feed.data.length > 0 ?
+              <span>{feed.name} <span className='light'>({feed.data.length})</span></span>
+              : 'feed.name' }
+          </li>
+        })}
+      </ul>
+    </div>;
+  }
+});


### PR DESCRIPTION
A specific grammar is needed to highlight `.jsx` files.
Thus, these files are now grouped under a distinct language but still in the JavaScript group.
See discussion at atom/language-javascript#220 for background.

Current highlighting of JSX code:
```js
'use strict';

const React = require('react')

module.exports = React.createClass({
  render: function() {
    let {feeds, log} = this.props;

    log.info(feeds);
    return <div className="feed-list">
      <h3>News Feed's</h3>
      <ul>
        {feeds.map(function(feed) {
          return <li key={feed.name} className={feed.fetched ? 'loaded' : 'loading'}>
            {feed.data && feed.data.length > 0 ?
              <span>{feed.name} <span className='light'>({feed.data.length})</span></span>
              : 'feed.name' }
          </li>
        })}
      </ul>
    </div>;
  }
});
```