### PR TITLE
github-linguist-grammars 4.6.2

### DIFF
--- a/lib/linguist/version.rb
+++ b/lib/linguist/version.rb
@@ -1,3 +1,3 @@
 module Linguist
-  VERSION = "4.6.1"
+  VERSION = "4.6.2"
 end


### PR DESCRIPTION
Bumps github-linguist-grammars version to pull in a syntax highlighting fix for JS: https://github.com/atom/language-javascript/pull/227

Fixes this from happening; an entire file could have gotten marked in red as an error:

<img width="920" alt="screen shot 2015-09-21 at 5 48 52 pm" src="https://cloud.githubusercontent.com/assets/887/10002468/90cade0e-60a7-11e5-9aa1-02c90bab80b4.png">

/cc @vmg I will still need rubygems permissions for "github-linguist-grammars", not "github-linguist", thanks :bow: 