### PR TITLE
Small fixes for git-linguist

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -96,24 +96,18 @@ end
 def git_linguist(args)
   incremental = true
   commit = nil
-  git_dir = nil
 
   parser = OptionParser.new do |opts|
     opts.banner = "Usage: git-linguist [OPTIONS] stats|breakdown|dump-cache|clear|disable"
 
     opts.on("-f", "--force", "Force a full rescan") { incremental = false }
-    opts.on("--git-dir=DIR", "Path to the git repository") { |v| git_dir = v }
     opts.on("--commit=COMMIT", "Commit to index") { |v| commit = v}
   end
 
   parser.parse!(args)
 
-  git_dir ||= begin
-    pwd = Dir.pwd
-    dotgit = File.join(pwd, ".git")
-    File.directory?(dotgit) ? dotgit : pwd
-  end
-
+  git_dir = `git rev-parse --git-dir`.strip
+  raise "git-linguist must be ran in a Git repository" unless $?.success?
   wrapper = GitLinguist.new(git_dir, commit, incremental)
 
   case args.pop

--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -71,17 +71,20 @@ class GitLinguist
   end
 
   def write_cache(object)
-    tmp_path = Dir::Tmpname.make_tmpname(cache_file, nil)
+    return unless File.directory? @repo_path
 
-    File.open(tmp_path, "wb") do |f|
-      marshal = Marshal.dump(object)
-      f.write(Zlib::Deflate.deflate(marshal))
+    begin
+      tmp_path = Dir::Tmpname.make_tmpname(cache_file, nil)
+      File.open(tmp_path, "wb") do |f|
+        marshal = Marshal.dump(object)
+        f.write(Zlib::Deflate.deflate(marshal))
+      end
+
+      File.rename(tmp_path, cache_file)
+    rescue => e
+      (File.unlink(tmp_path) rescue nil)
+      raise e
     end
-
-    File.rename(tmp_path, cache_file)
-    tmp_path = nil
-  ensure
-    (File.unlink(tmp_path) rescue nil) if tmp_path
   end
 
   def load_cache

--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -126,12 +126,13 @@ module Linguist
     end
 
     protected
+    MAX_TREE_SIZE = 100_000
 
     def compute_stats(old_commit_oid, cache = nil)
+      return {} if current_tree.count_recursive(MAX_TREE_SIZE) >= MAX_TREE_SIZE
+
       old_tree = old_commit_oid && Rugged::Commit.lookup(repository, old_commit_oid).tree
-
       read_index
-
       diff = Rugged::Tree.diff(repository, old_tree, current_tree)
 
       # Clear file map and fetch full diff if any .gitattributes files are changed

--- a/lib/linguist/version.rb
+++ b/lib/linguist/version.rb
@@ -1,3 +1,3 @@
 module Linguist
-  VERSION = "4.6.2"
+  VERSION = "4.6.3"
 end


### PR DESCRIPTION
1. Handle the given `$GIT_DIR` from git better
2. Do not try to scan repositories that are too large (over 100k files in the repo)

cc @github/linguist 