### PR TITLE
Clarified that only nonprimary extensions should be sorted

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -8,7 +8,8 @@
 #                     Use "text" if a mode does not exist.
 # wrap              - Boolean wrap to enable line wrapping (default: false)
 # extensions        - An Array of associated extensions (the first one is
-#                     considered the primary extension)
+#                     considered the primary extension, the others should be
+#                     listed alphabetically)
 # interpreters      - An Array of associated interpreters
 # searchable        - Boolean flag to enable searching (defaults to true)
 # search_term       - Deprecated: Some languages maybe indexed under a

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -9,7 +9,7 @@ class TestPedantic < Minitest::Test
     assert_sorted LANGUAGES.keys
   end
 
-  def test_extensions_are_sorted
+  def test_nonprimary_extensions_are_sorted
     LANGUAGES.each do |name, language|
       extensions = language['extensions']
       assert_sorted extensions[1..-1].map(&:downcase) if extensions && extensions.size > 1


### PR DESCRIPTION
While preparing a different, unrelated pull request I was confused that the test `extensions_are_sorted` failed, since the first extension is interpreted as the primary one (and therefore should not be sorted among the other, nonprimary extensions).

Turns out that the test (correctly) only checks that the nonprimary extensions are sorted. This pull request renames the test to `nonprimary_extensions_are_sorted`, thus better documenting its purpose, and adds a short comment to `languages.yml`.