### PR TITLE
Accommodate samples whose primary name contains / by checking aliases

### DIFF
--- a/lib/linguist/samples.rb
+++ b/lib/linguist/samples.rb
@@ -75,7 +75,8 @@ module Linguist
       db['filenames'] = {}
 
       each do |sample|
-        language_name = sample[:language]
+        language = Language[sample[:language]]
+        language_name = language ? language.name : sample[:language]
 
         if sample[:extname]
           db['extnames'][language_name] ||= []

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -595,7 +595,9 @@ class TestBlob < Minitest::Test
     Samples.each do |sample|
       blob = sample_blob(sample[:path])
       assert blob.language, "No language for #{sample[:path]}"
-      assert_equal sample[:language], blob.language.name, blob.name
+      names = [blob.language.name] + blob.language.aliases
+      assert names.include?(sample[:language]),
+             "#{blob.name}: Expected #{names} to include #{sample[:language]}"
     end
 
     # Test language detection for files which shouldn't be used as samples

--- a/test/test_classifier.rb
+++ b/test/test_classifier.rb
@@ -45,7 +45,7 @@ class TestClassifier < Minitest::Test
 
   def test_classify_ambiguous_languages
     Samples.each do |sample|
-      language  = Linguist::Language.find_by_name(sample[:language])
+      language  = Linguist::Language[sample[:language]]
       languages = Language.find_by_filename(sample[:path]).map(&:name)
       next unless languages.length > 1
 


### PR DESCRIPTION
This came up when creating #2667, but I didn't want it to be an impediment to merging that PR.  However, I decided to open this in case there was interest in supporting slashes in the primary names of languages.  It would be nice, at least presentation-wise.