### PR TITLE
Change Stata grammar repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -677,3 +677,6 @@
 [submodule "vendor/grammars/language-babel"]
 	path = vendor/grammars/language-babel
 	url = https://github.com/gandm/language-babel
+[submodule "vendor/grammars/Stata.tmbundle"]
+	path = vendor/grammars/Stata.tmbundle
+	url = https://github.com/pschumm/Stata.tmbundle

--- a/.gitmodules
+++ b/.gitmodules
@@ -253,9 +253,6 @@
 [submodule "vendor/grammars/SublimeXtend"]
 	path = vendor/grammars/SublimeXtend
 	url = https://github.com/staltz/SublimeXtend
-[submodule "vendor/grammars/Stata.tmbundle"]
-	path = vendor/grammars/Stata.tmbundle
-	url = https://github.com/statatmbundle/Stata.tmbundle
 [submodule "vendor/grammars/Vala-TMBundle"]
 	path = vendor/grammars/Vala-TMBundle
 	url = https://github.com/technosophos/Vala-TMBundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -92,9 +92,6 @@ vendor/grammars/Scalate.tmbundle:
 - text.html.ssp
 vendor/grammars/Slash.tmbundle:
 - text.html.slash
-vendor/grammars/Stata.tmbundle:
-- source.mata
-- source.stata
 vendor/grammars/Stylus/:
 - source.stylus
 vendor/grammars/Sublime-Coq:

--- a/grammars.yml
+++ b/grammars.yml
@@ -92,6 +92,9 @@ vendor/grammars/Scalate.tmbundle:
 - text.html.ssp
 vendor/grammars/Slash.tmbundle:
 - text.html.slash
+vendor/grammars/Stata.tmbundle/:
+- source.mata
+- source.stata
 vendor/grammars/Stylus/:
 - source.stylus
 vendor/grammars/Sublime-Coq:


### PR DESCRIPTION
Change the repository for the Stata grammar from [statatmbundle/Stata.tmbundle](https://github.com/statatmbundle/Stata.tmbundle) (fork) to [pschumm/Stata.tmbundle](https://github.com/pschumm/Stata.tmbundle) (original repo).
The two repository are identical so it probably make more sense to use the original one :-)