### PR TITLE
Add .phps extension for PHP

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2441,6 +2441,7 @@ PHP:
   - .php3
   - .php4
   - .php5
+  - .phps
   - .phpt
   filenames:
   - Phakefile

--- a/samples/PHP/mail.phps
+++ b/samples/PHP/mail.phps
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This example shows sending a message using PHP's mail() function.
+ */
+
+require '../PHPMailerAutoload.php';
+
+//Create a new PHPMailer instance
+$mail = new PHPMailer;
+//Set who the message is to be sent from
+$mail->setFrom('from@example.com', 'First Last');
+//Set an alternative reply-to address
+$mail->addReplyTo('replyto@example.com', 'First Last');
+//Set who the message is to be sent to
+$mail->addAddress('whoto@example.com', 'John Doe');
+//Set the subject line
+$mail->Subject = 'PHPMailer mail() test';
+//Read an HTML message body from an external file, convert referenced images to embedded,
+//convert HTML into a basic plain-text alternative body
+$mail->msgHTML(file_get_contents('contents.html'), dirname(__FILE__));
+//Replace the plain text body with one created manually
+$mail->AltBody = 'This is a plain-text message body';
+//Attach an image file
+$mail->addAttachment('images/phpmailer_mini.png');
+
+//send the message, check for errors
+if (!$mail->send()) {
+    echo "Mailer Error: " . $mail->ErrorInfo;
+} else {
+    echo "Message sent!";
+}


### PR DESCRIPTION
**.phps** stands for "PHP Source"

Useful to show examples of PHP code. A properly-configured server will output a .phps file as is, with color-formated source code instead of the HTML that would normally be generated.

[Usage in GitHub](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aphps+NOT+nothack&type=Code)

[Source of example file](https://github.com/PHPMailer/PHPMailer/blob/master/examples/mail.phps)