### PR TITLE
Change D color to match the website

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -720,7 +720,7 @@ Cython:
 
 D:
   type: programming
-  color: "#fcd46d"
+  color: "#2e2424"
   extensions:
   - .d
   - .di

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -720,7 +720,7 @@ Cython:
 
 D:
   type: programming
-  color: "#2e2424"
+  color: "#ba595e"
   extensions:
   - .d
   - .di


### PR DESCRIPTION
The original yellow color doesn't fit D very well, and it looks an awful lot like the color for JavaScript. This changes it to the color used on the website's sidebar, a nice dark maroon: http://www.colorpicker.com/2e2324