### PR TITLE
Django as an alias for HTML+Django

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1328,6 +1328,7 @@ HTML+Django:
   - .mustache
   - .jinja
   aliases:
+  - django
   - html+django/jinja
   - html+jinja
   - htmldjango


### PR DESCRIPTION
This pull request adds `django` as an alias for `HTML+Django`.
Discussed in #2695.