### PR TITLE
Dropping support for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 before_install: script/travis/before_install
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2


### PR DESCRIPTION
Official support for Ruby 1.9.3 ended in [February this year](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/) and some of our dependencies require [2.0.0 or greater](https://github.com/github/linguist/pull/2690).

Time to :wave: to Ruby 1.9.3 support.