### PR TITLE
Use negative lookbehind when tokenizing string literals

### DIFF
--- a/lib/linguist/tokenizer.rb
+++ b/lib/linguist/tokenizer.rb
@@ -86,13 +86,13 @@ module Linguist
           if s.peek(1) == "\""
             s.getch
           else
-            s.skip_until(/[^\\]"/)
+            s.skip_until(/(?<!\\)"/)
           end
         elsif s.scan(/'/)
           if s.peek(1) == "'"
             s.getch
           else
-            s.skip_until(/[^\\]'/)
+            s.skip_until(/(?<!\\)'/)
           end
 
         # Skip number literals


### PR DESCRIPTION
This can double the speed of tokenizing large RTF files that use `\'hh` escape sequences.

/cc @josh @vmg @github/linguist 