### PR TITLE
Add SuperCollider grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,6 +85,9 @@
 [submodule "vendor/grammars/language-shellscript"]
 	path = vendor/grammars/language-shellscript
 	url = https://github.com/atom/language-shellscript
+[submodule "vendor/grammars/language-supercollider"]
+	path = vendor/grammars/language-supercollider
+	url = https://github.com/supercollider/language-supercollider
 [submodule "vendor/grammars/language-yaml"]
 	path = vendor/grammars/language-yaml
 	url = https://github.com/atom/language-yaml

--- a/grammars.yml
+++ b/grammars.yml
@@ -354,6 +354,8 @@ vendor/grammars/language-python:
 vendor/grammars/language-shellscript:
 - source.shell
 - text.shell-session
+vendor/grammars/language-supercollider:
+- source.supercollider
 vendor/grammars/language-xbase:
 - source.harbour
 vendor/grammars/language-yaml:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3336,9 +3336,12 @@ SuperCollider:
   type: programming
   color: "#46390b"
   extensions:
-  - .scd
   - .sc
-  tm_scope: none
+  - .scd
+  interpreters:
+  - sclang
+  - scsynth
+  tm_scope: source.supercollider
   ace_mode: text
 
 Swift:

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -57,6 +57,7 @@ class TestLanguage < Minitest::Test
     assert_equal Language['Shell'], Language.find_by_alias('sh')
     assert_equal Language['Shell'], Language.find_by_alias('shell')
     assert_equal Language['Shell'], Language.find_by_alias('zsh')
+    assert_equal Language['SuperCollider'], Language.find_by_alias('supercollider')
     assert_equal Language['TeX'], Language.find_by_alias('tex')
     assert_equal Language['TypeScript'], Language.find_by_alias('ts')
     assert_equal Language['VimL'], Language.find_by_alias('vim')
@@ -119,6 +120,7 @@ class TestLanguage < Minitest::Test
     assert_equal 'vim',           Language['VimL'].search_term
     assert_equal 'jsp',           Language['Java Server Pages'].search_term
     assert_equal 'rst',           Language['reStructuredText'].search_term
+    assert_equal 'supercollider', Language['SuperCollider'].search_term
   end
 
   def test_popular
@@ -138,6 +140,7 @@ class TestLanguage < Minitest::Test
     assert_equal :programming, Language['Ruby'].type
     assert_equal :programming, Language['TypeScript'].type
     assert_equal :programming, Language['Makefile'].type
+    assert_equal :programming, Language['SuperCollider'].type
   end
 
   def test_markup
@@ -227,7 +230,8 @@ class TestLanguage < Minitest::Test
       "python" => "Python",
       "python2" => "Python",
       "python3" => "Python",
-      "sbcl" => "Common Lisp"
+      "sbcl" => "Common Lisp",
+      "sclang" => "SuperCollider"
     }.each do |interpreter, language|
       assert_equal [Language[language]], Language.find_by_interpreter(interpreter)
     end
@@ -339,6 +343,7 @@ class TestLanguage < Minitest::Test
     assert Language['Perl'].extensions.include?('.pl')
     assert Language['Python'].extensions.include?('.py')
     assert Language['Ruby'].extensions.include?('.rb')
+    assert Language['SuperCollider'].extensions.include?('.scd')
   end
 
   def test_primary_extension
@@ -349,6 +354,7 @@ class TestLanguage < Minitest::Test
     assert_equal '.coffee', Language['CoffeeScript'].primary_extension
     assert_equal '.t', Language['Turing'].primary_extension
     assert_equal '.ts', Language['TypeScript'].primary_extension
+    assert_equal '.sc', Language['SuperCollider'].primary_extension
   end
 
   def test_eql


### PR DESCRIPTION
plus a few minor language support updates including:

- recognize `sclang` and `scsynth` interpreters
- set `tm_scope: source.supercollider`
- reorder extensions so that `.sc` is primary