### PR TITLE
Recognise END statement in FORTRAN files.

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -131,7 +131,7 @@ module Linguist
     disambiguate ".for", ".f" do |data|
       if /^: /.match(data)
         Language["Forth"]
-      elsif /^([c*][^a-z]|      (subroutine|program)\s|\s*!)/i.match(data)
+      elsif /^([c*][^abd-z]|      (subroutine|program|end)\s|\s*!)/i.match(data)
         Language["FORTRAN"]
       end
     end


### PR DESCRIPTION
This adds the `END` statement to the Fortran/Forth heuristic.

Also allows Fortran comments `CCC` as seen here: https://github.com/search?q=language%3Afortran+ccc&type=Code

Fixes bad detection of these files:
https://github.com/jeiros/FORTRAN_course/search?l=forth