### PR TITLE
Add sproto language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -689,3 +689,6 @@
 [submodule "vendor/grammars/FreeMarker.tmbundle"]
 	path = vendor/grammars/FreeMarker.tmbundle
 	url = https://github.com/freemarker/FreeMarker.tmbundle
+[submodule "vendor/grammars/sproto"]
+	path = vendor/grammars/sproto
+	url = https://github.com/m2q1n9/atom-sproto-syntax

--- a/grammars.yml
+++ b/grammars.yml
@@ -479,6 +479,8 @@ vendor/grammars/smali-sublime/smali.tmLanguage:
 - source.smali
 vendor/grammars/smalltalk-tmbundle:
 - source.smalltalk
+vendor/grammars/sproto:
+- source.sproto
 vendor/grammars/sql.tmbundle:
 - source.sql
 vendor/grammars/st2-zonefile:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3909,6 +3909,13 @@ reStructuredText:
   - .rest
   ace_mode: text
 
+sproto:
+  type: programming
+  color: "#268bd2"
+  extensions:
+  - .sproto
+  ace_mode: text
+
 wisp:
   type: programming
   ace_mode: clojure

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3911,7 +3911,7 @@ reStructuredText:
 
 sproto:
   type: programming
-  color: "#268bd2"
+  color: "#248842"
   extensions:
   - .sproto
   ace_mode: text

--- a/samples/sproto/test.sproto
+++ b/samples/sproto/test.sproto
@@ -1,0 +1,26 @@
+
+# This is a comment.
+
+.Person {	# . means a user defined type
+    name 0 : string	# string is a build-in type.
+    id 1 : integer
+    email 2 : string
+
+    .PhoneNumber {	# user defined type can be nest.
+        number 0 : string
+        type 1 : integer
+    }
+
+    phone 3 : *PhoneNumber	# *PhoneNumber means an array of PhoneNumber.
+}
+
+.AddressBook {
+    person 0 : *Person(id)	# (id) is optional, means Person.id is main index.
+}
+
+foobar 1 {	# define a new protocol (for RPC used) with tag 1
+    request Person	# Associate the type Person with foobar.request
+    response {	# define the foobar.response type
+        ok 0 : boolean
+    }
+}


### PR DESCRIPTION
Add [sproto](https://github.com/cloudwu/sproto) new language syntax highlighting support.
see also:
https://github.com/m2q1n9/atom-sproto-syntax
https://github.com/m2q1n9/sproto-mode
