### PR TITLE
Snakemake files have Python syntax

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2783,6 +2783,9 @@ Python:
   - .tac
   - .wsgi
   - .xpy
+  - .rules
+  - .snakefile
+  - .snake
   filenames:
   - BUILD
   - SConscript


### PR DESCRIPTION
In #1834 the filename `Snakefile` was added to the list of Python filenames.

Here, I propose to add 3 file extensions for [Snakemake][1]. All 3 of these file extensions are unique to Python.

The author of Snakemake lists the following [file extensions for Snakefiles][2]:

- .rules
- .snakefile
- .snake

and the following filenames:

- Snakefile

Aside: In the future, when Snakemake is more mature, it may be sensible to provide a language grammar based on Python and customized for Snakemake. Currently, I favor highlighting Snakemake files like Python files.

[1]: https://bitbucket.org/snakemake/snakemake/wiki/Home
[2]: https://bitbucket.org/snakemake/snakemake/wiki/FAQ#markdown-header-how-do-i-enable-syntax-highlighting-in-vim-for-snakefiles