### PR TITLE
Add language support for MAXScript

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -689,3 +689,6 @@
 [submodule "vendor/grammars/FreeMarker.tmbundle"]
 	path = vendor/grammars/FreeMarker.tmbundle
 	url = https://github.com/freemarker/FreeMarker.tmbundle
+[submodule "vendor/grammars/language-maxscript"]
+	path = vendor/grammars/language-maxscript
+	url = https://github.com/Alhadis/language-maxscript

--- a/grammars.yml
+++ b/grammars.yml
@@ -345,6 +345,8 @@ vendor/grammars/language-javascript:
 vendor/grammars/language-jsoniq/:
 - source.jq
 - source.xq
+vendor/grammars/language-maxscript:
+- source.maxscript
 vendor/grammars/language-ncl:
 - source.ncl
 vendor/grammars/language-python:

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -238,8 +238,10 @@ module Linguist
     disambiguate ".ms" do |data|
       if /^[.'][a-z][a-z](\s|$)/i.match(data)
         Language["Groff"]
-      elsif /((^|\s)move?[. ])|\.(include|globa?l)\s/.match(data)
+      elsif /(?<!\S)\.(include|globa?l)\s/.match(data) || /(?<!\/\*)(\A|\n)\s*\.[A-Za-z]/.match(data.gsub(/"([^\\"]|\\.)*"|'([^\\']|\\.)*'|\\\s*(?:--.*)?\n/, ""))
         Language["GAS"]
+      else
+        Language["MAXScript"]
       end
     end
 

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1956,6 +1956,15 @@ M:
   tm_scope: source.lisp
   ace_mode: lisp
 
+MAXScript:
+  type: programming
+  color: "#00aaaa"
+  extensions:
+  - .ms
+  - .mcr
+  tm_scope: source.maxscript
+  ace_mode: text
+
 MTML:
   type: markup
   color: "#b7e1f4"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1958,7 +1958,7 @@ M:
 
 MAXScript:
   type: programming
-  color: "#00aaaa"
+  color: "#00a6a6"
   extensions:
   - .ms
   - .mcr

--- a/samples/MAXScript/macro-1.mcr
+++ b/samples/MAXScript/macro-1.mcr
@@ -1,0 +1,29 @@
+-- Taken from an example from Autodesk's MAXScript reference:
+-- http://help.autodesk.com/view/3DSMAX/2016/ENU/?guid=__files_GUID_84E24969_C175_4389_B9A6_3B2699B66785_htm
+
+macroscript MoveToSurface
+    category: "HowTo"
+(
+    fn g_filter o = superclassof o == Geometryclass
+    fn find_intersection z_node node_to_z = (
+        local testRay = ray node_to_z.pos [0,0,-1]
+        local nodeMaxZ = z_node.max.z
+        testRay.pos.z = nodeMaxZ + 0.0001 * abs nodeMaxZ
+        intersectRay z_node testRay
+    )
+    
+    on isEnabled return selection.count > 0
+    
+    on Execute do (
+        target_mesh = pickObject message:"Pick Target Surface:" filter:g_filter
+        
+        if isValidNode target_mesh then (
+            undo "MoveToSurface" on (
+                for i in selection do (
+                    int_point = find_intersection target_mesh i
+                    if int_point != undefined then i.pos = int_point.pos
+                )--end i loop
+            )--end undo
+        )--end if
+    )--end execute
+)--end script

--- a/samples/MAXScript/macro-2.mcr
+++ b/samples/MAXScript/macro-2.mcr
@@ -1,0 +1,53 @@
+-- Taken from an example from Autodesk's MAXScript reference:
+-- http://help.autodesk.com/view/3DSMAX/2016/ENU/?guid=__files_GUID_0876DF46_FAA3_4131_838D_5739A67FF2C1_htm
+
+macroscript FreeSpline category:"HowTo" tooltip:"FreeSpline" (
+local old_pos
+local new_spline
+local second_knot_set
+
+fn get_mouse_pos pen_pos old_pen_pos = (
+	if old_pos == undefined then old_pos = old_pen_pos
+	if distance pen_pos old_pos > 10 then
+	(
+		if second_knot_set then
+			addKnot new_spline 1 #smooth #curve pen_pos
+		else
+		(
+			setKnotPoint new_spline 1 2 pen_pos
+			second_knot_set = true
+		)
+		old_pos = pen_pos
+		updateShape new_spline
+	)-- end if
+)-- end fn
+
+fn draw_new_line old_pen_pos = (
+	pickPoint mouseMoveCallback:#(get_mouse_pos,old_pen_pos)
+)
+
+undo"Free Spline"on(
+	new_spline = splineShape ()
+	old_pen_pos = pickPoint ()
+	
+	if old_pen_pos == #RightClick then
+		delete new_spline
+	else
+	(
+		select new_spline
+		new_spline.pos = old_pen_pos
+		addNewSpline new_spline
+		addKnot new_spline 1 #smooth #curve old_pen_pos
+		addKnot new_spline 1 #smooth #curve old_pen_pos
+		second_knot_set = false
+		draw_new_line old_pen_pos
+		q = querybox "Close Spline?" title:"Free Spline"
+		if q then
+		(
+			close new_spline 1
+			updateshape new_spline
+		)
+		select new_spline
+	)--end else
+)--end undo
+)--end script

--- a/samples/MAXScript/svg-renderer.ms
+++ b/samples/MAXScript/svg-renderer.ms
@@ -1,0 +1,64 @@
+-- Taken from a 3-part tutorial from Autodesk's MAXScript reference
+-- Source: http://help.autodesk.com/view/3DSMAX/2016/ENU/?guid=__files_GUID_6B5EDC11_A154_4AA7_A972_A11AC36949E9_htm
+
+fn ColourToHex col = (
+	local theComponents = #(bit.intAsHex col.r, bit.intAsHex col.g, bit.intAsHex col.b)
+	local theValue = "#"
+	for i in theComponents do 
+		theValue += (if i.count == 1 then "0" else "") + i
+	theValue
+)
+
+local st = timestamp()
+local theFileName = (getDir #userscripts + "\\PolygonRendering3.svg")
+local theSVGfile = createFile theFileName
+format "<svg xmlns=\"http://www.w3.org/2000/svg\"\n" to:theSVGfile
+format "\t\txmlns:xlink=\"http://www.w3.org/1999/xlink\">\n" to:theSVGfile
+
+local theViewTM =  viewport.getTM()
+theViewTM.row4 = [0,0,0]
+
+local theViewTM2 = viewport.getTM()
+local theViewSize = getViewSize()
+local theViewScale = getViewSize()
+theViewScale.x /= 1024.0
+theViewScale.y /= 1024.0
+	
+local theStrokeThickness = 3
+	
+gw.setTransform (matrix3 1)	
+for o in Geometry where not o.isHiddenInVpt and classof o != TargetObject do (
+	local theStrokeColour = white
+	local theFillColour = o.wirecolor
+	
+	local theMesh = snapshotAsMesh o
+	for f = 1 to theMesh.numfaces do (
+		local theNormal = normalize (getFaceNormal theMesh f)
+		
+		if (theNormal*theViewTM).z > 0 do
+		(
+			local theFace = getFace theMesh f
+			local v1 = gw.transPoint (getVert theMesh theFace.x)
+			local v2 = gw.transPoint (getVert theMesh theFace.y)
+			local v3 = gw.transPoint (getVert theMesh theFace.z)
+			
+			v1.x /= theViewScale.x 
+			v1.y /= theViewScale.y 
+			v2.x /= theViewScale.x 
+			v2.y /= theViewScale.y
+			v3.x /= theViewScale.x
+			v3.y /= theViewScale.y
+			
+			format "\t<polygon points='%,%  %,%  %,%' \n" v1.x v1.y v2.x v2.y v3.x v3.y to:theSVGfile
+			format "\tstyle='stroke:%; fill:%; stroke-width:%'/>\n" (ColourToHex theStrokeColour) (ColourToHex theFillColour) theStrokeThickness to:theSVGfile			
+		)--end if normal positive
+	)--end f loop
+)--end o loop
+
+format "</svg>\n" to:theSVGfile
+close theSVGfile
+local theSVGMap = VectorMap vectorFile:theFileName alphasource:0
+local theBitmap = bitmap theViewSize.x theViewSize.y
+renderMap theSVGMap into:theBitmap filter:true
+display theBitmap
+format "Render Time: % sec.\n" ((timestamp()-st)/1000.0)

--- a/samples/MAXScript/volume-calc.ms
+++ b/samples/MAXScript/volume-calc.ms
@@ -1,0 +1,22 @@
+fn CalculateVolumeAndCentreOfMass obj =
+(
+	local Volume= 0.0
+	local Centre= [0.0, 0.0, 0.0]
+	local theMesh = snapshotasmesh obj
+	local numFaces = theMesh.numfaces
+	for i = 1 to numFaces do
+	(
+		local Face= getFace theMesh i
+		local vert2 = getVert theMesh Face.z
+		local vert1 = getVert theMesh Face.y
+		local vert0 = getVert theMesh Face.x
+		local dV = Dot (Cross (vert1 - vert0) (vert2 - vert0)) vert0
+		Volume+= dV
+		Centre+= (vert0 + vert1 + vert2) * dV
+	)
+	delete theMesh
+	Volume /= 6
+	Centre /= 24
+	Centre /= Volume
+	#(Volume,Centre)
+)


### PR DESCRIPTION
This PR adds support for MAXScript, the built-in scripting language for [3ds Max](https://en.wikipedia.org/wiki/Autodesk_3ds_Max).

Usage
-----

MAXScript isn't exactly kicking JavaScript in terms of popularity, to say the least, but there's enough in-the-wild usage to warrant the language's inclusion on GitHub:

* [extension:ms fn](https://github.com/search?q=extension%3Ams+fn) (~6,610 results)
* [extension:ms function](https://github.com/search?q=extension%3Ams+function) (~13,470 results)

[ScriptSpot](http://www.scriptspot.com/) has been a well-known and popular resource for MAXScripts since at [least 2000](http://www.scriptspot.com/3ds-max/plugins/maxscribe), although the site's maintenance appears to have declined sharply in recent years. It's probably as good a time as any to introduce formal support for MAXScript on GitHub, which may encourage more MAXScripters to upload/share their work.

Heuristic modifications
-----------------------

MAXScript already offers a `move` function, so we can't rely on the current heuristic of identifying GAS by the presence of a `move` command.

My initial approach was to check for Assembly-like statements like the following, since it'd be a syntax error in MAXScript:

```
.LGCOMMAND
	.now
	.return
```

However, because of MAXScript's fluidity, it's unreasonable to assume lengthy statements won't be broken across multiple lines:
```
	value = colossal_plugin_struct_thing \
		.calculate this mumbo:#jumbo

	-- That has the same effect as writing this:
	value = colossal_plugin_struct_thing.calculate this mumbo:#jumbo
```


In other words, simply checking `\n\s*\.[A-Za-z]` isn't good enough; we need to account for things like escaped line-breaks and string literals/comments:

```rb
data.gsub(/"([^\\"]|\\.)*"|'([^\\']|\\.)*'/, "").gsub(/\\\s*(?:--.*)?\n/, "\n")
```

This might be slight overkill, but it irons out any potential for misclassification.



Performance
-----------

I took the time to analyse the performance of different heuristics when run against a [repository of considerable size](https://github.com/Alhadis/Linguist-Heuristics-MS) (15,609 files, 1.4 GiBs). I've averaged the speed results below, but the full stats can be [viewed here](http://pastebin.com/EmLwT0xU) for anybody who's curious.


### Original/Current `.ms` Heuristic

```
/((^|\s)move?[. ])|\.(include|globa?l)\s/.match(data)

Average speed (10 runs):
	real    39.8s
	user    38.9869s
	sys     0.8023s
```



### Amended Heuristic

```
/(?<!\S)\.(include|globa?l)\s/.match(data) || 
	/(?<!\/\*)(\A|\n)\s*\.[A-Za-z]/.match(data.gsub(/"([^\\"]|\\.)*"|'([^\\']|\\.)*'|\\\s*(?:--.*)?\n/, ""))

Average speed (10 runs):
	real    41.3077s
	user    40.3206s
	sys     0.9744s
```

### Earlier variations:
These are potentially slightly faster, but offer a little less accuracy:

```
/(?<!\S)\.(include|globa?l)\s/.match(data) ||
	/(?<!\/\*)(\A|\n)\s*\.[A-Za-z]/.match(data.sub(/"([^\\"]|\\.)*"|'([^\\']|\\.)*'/, ""))

Average speed (10 runs):
	real    40.0s
	user    39.1899s
	sys     0.7947s
```

```
/(?<!\S)\.(include|globa?l)\s/.match(data) || /(?<!\/\*)(\A|\n)\s*\.[A-Za-z]/.match(data)

Average speed (10 runs):
	real    38.9172s
	user    38.1532s
	sys     0.7561s
```
