### PR TITLE
Add octave as an alias for Matlab syntax

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2043,6 +2043,8 @@ Mathematica:
 Matlab:
   type: programming
   color: "#bb92ac"
+  aliases:
+  - octave
   extensions:
   - .matlab
   - .m


### PR DESCRIPTION
Since Octave is a clone of Matlab, the syntax is exactly the same
and hence it is desirable for highlighting to be exactly the same
as well.
Adding octave as an alias for Matlab will trivially provide support
for highlighting Octave code, and will ensure the two languages
always use the same syntax highlighting rules.

Here is [how much Octave code there is on GitHub](https://github.com/search?l=&q=octave+language%3AMatlab&ref=advsearch&type=Code&utf8=%E2%9C%93).