### PR TITLE
Catch `ENOENT` in `clear_cache`

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -50,6 +50,7 @@ class GitLinguist
 
   def clear_language_stats
     File.unlink(cache_file)
+  rescue Errno::ENOENT
   end
 
   def disable_language_stats


### PR DESCRIPTION
There's no need for `clear_cache` to fail if the cache doesn't exist,
either because we call `clear_cache` twice or because no cache was
previously written on this particular repo.

/cc @vmg, who wrote `bin/git-linguist`