### PR TITLE
New extensions for consistency with Markup

### DIFF
--- a/HACKING.rst.txt
+++ b/HACKING.rst.txt
@@ -1,0 +1,329 @@
+Contributing to SciPy
+=====================
+
+This document aims to give an overview of how to contribute to SciPy.  It
+tries to answer commonly asked questions, and provide some insight into how the
+community process works in practice.  Readers who are familiar with the SciPy
+community and are experienced Python coders may want to jump straight to the
+`git workflow`_ documentation.
+
+
+Contributing new code
+---------------------
+
+If you have been working with the scientific Python toolstack for a while, you
+probably have some code lying around of which you think "this could be useful
+for others too".  Perhaps it's a good idea then to contribute it to SciPy or
+another open source project.  The first question to ask is then, where does
+this code belong?  That question is hard to answer here, so we start with a
+more specific one: *what code is suitable for putting into SciPy?*
+Almost all of the new code added to scipy has in common that it's potentially
+useful in multiple scientific domains and it fits in the scope of existing
+scipy submodules.  In principle new submodules can be added too, but this is
+far less common.  For code that is specific to a single application, there may
+be an existing project that can use the code.  Some scikits (`scikit-learn`_,
+`scikits-image`_, `statsmodels`_, etc.) are good examples here; they have a
+narrower focus and because of that more domain-specific code than SciPy.
+
+Now if you have code that you would like to see included in SciPy, how do you
+go about it?  After checking that your code can be distributed in SciPy under a
+compatible license (see FAQ for details), the first step is to discuss on the
+scipy-dev mailing list.  All new features, as well as changes to existing code,
+are discussed and decided on there.  You can, and probably should, already
+start this discussion before your code is finished.
+
+Assuming the outcome of the discussion on the mailing list is positive and you
+have a function or piece of code that does what you need it to do, what next?
+Before code is added to SciPy, it at least has to have good documentation, unit
+tests and correct code style.  
+
+1. Unit tests
+    In principle you should aim to create unit tests that exercise all the code
+    that you are adding.  This gives some degree of confidence that your code
+    runs correctly, also on Python versions and hardware or OSes that you don't
+    have available yourself.  An extensive description of how to write unit
+    tests is given in the NumPy `testing guidelines`_.
+
+2. Documentation
+    Clear and complete documentation is essential in order for users to be able
+    to find and understand the code.  Documentation for individual functions
+    and classes -- which includes at least a basic description, type and
+    meaning of all parameters and returns values, and usage examples in
+    `doctest`_ format -- is put in docstrings.  Those docstrings can be read
+    within the interpreter, and are compiled into a reference guide in html and
+    pdf format.  Higher-level documentation for key (areas of) functionality is
+    provided in tutorial format and/or in module docstrings.  A guide on how to
+    write documentation is given in `how to document`_.
+
+3. Code style
+    Uniformity of style in which code is written is important to others trying
+    to understand the code.  SciPy follows the standard Python guidelines for
+    code style, `PEP8`_.  In order to check that your code conforms to PEP8,
+    you can use the `pep8 package`_ style checker.  Most IDEs and text editors
+    have settings that can help you follow PEP8, for example by translating
+    tabs by four spaces.  Using `pyflakes`_ to check your code is also a good
+    idea.
+
+At the end of this document a checklist is given that may help to check if your
+code fulfills all requirements for inclusion in SciPy. 
+
+Another question you may have is: *where exactly do I put my code*?  To answer
+this, it is useful to understand how the SciPy public API (application
+programming interface) is defined.  For most modules the API is two levels
+deep, which means your new function should appear as
+``scipy.submodule.my_new_func``.  ``my_new_func`` can be put in an existing or
+new file under ``/scipy/<submodule>/``, its name is added to the ``__all__``
+dict in that file (which lists all public functions in the file), and those
+public functions are then imported in  ``/scipy/<submodule>/__init__.py``.  Any
+private functions/classes should have a leading underscore (``_``) in their
+name.  A more detailed description of what the public API of SciPy is, is given
+in `SciPy API`_.
+
+Once you think your code is ready for inclusion in SciPy, you can send a pull
+request (PR) on Github.  We won't go into the details of how to work with git
+here, this is described well in the `git workflow`_ section of the NumPy
+documentation and in the Github help pages.  When you send the PR for a new
+feature, be sure to also mention this on the scipy-dev mailing list.  This can
+prompt interested people to help review your PR.  Assuming that you already got
+positive feedback before on the general idea of your code/feature, the purpose
+of the code review is to ensure that the code is correct, efficient and meets
+the requirements outlined above.  In many cases the code review happens
+relatively quickly, but it's possible that it stalls.  If you have addressed
+all feedback already given, it's perfectly fine to ask on the mailing list
+again for review (after a reasonable amount of time, say a couple of weeks, has
+passed).  Once the review is completed, the PR is merged into the "master"
+branch of SciPy.
+
+The above describes the requirements and process for adding code to SciPy.  It
+doesn't yet answer the question though how decisions are made exactly.  The
+basic answer is: decisions are made by consensus, by everyone who chooses to
+participate in the discussion on the mailing list.  This includes developers,
+other users and yourself.  Aiming for consensus in the discussion is important
+-- SciPy is a project by and for the scientific Python community.  In those
+rare cases that agreement cannot be reached, the `maintainers`_ of the module
+in question can decide the issue.
+
+
+Contributing by helping maintain existing code
+----------------------------------------------
+
+The previous section talked specifically about adding new functionality to
+SciPy.  A large part of that discussion also applies to maintenance of existing
+code.  Maintenance means fixing bugs, improving code quality or style,
+documenting existing functionality better, adding missing unit tests, keeping
+build scripts up-to-date, etc.  The SciPy `Trac`_ bug tracker contains all
+reported bugs, build/documentation issues, etc.  Fixing issues described in
+Trac tickets helps improve the overall quality of SciPy, and is also a good way
+of getting familiar with the project.  You may also want to fix a bug because
+you ran into it and need the function in question to work correctly.
+
+The discussion on code style and unit testing above applies equally to bug
+fixes.  It is usually best to start by writing a unit test that shows the
+problem, i.e. it should pass but doesn't.  Once you have that, you can fix the
+code so that the test does pass.  That should be enough to send a PR for this
+issue.  Unlike when adding new code, discussing this on the mailing list may
+not be necessary - if the old behavior of the code is clearly incorrect, no one
+will object to having it fixed.  It may be necessary to add some warning or
+deprecation message for the changed behavior.  This should be part of the
+review process.
+
+
+Other ways to contribute
+------------------------
+
+There are many ways to contribute other than contributing code.  Participating
+in discussions on the scipy-user and scipy-dev *mailing lists* is a contribution
+in itself.  The `scipy.org`_ *website* contains a lot of information on the
+SciPy community and can always use a new pair of hands.  A redesign of this
+website is ongoing, see `scipy.github.com`_.  The redesigned website is a
+static site based on Sphinx, the sources for it are
+also on Github at `scipy.org-new`_.
+
+The SciPy *documentation* is constantly being improved by many developers and
+users.  You can contribute by sending a PR on Github that improves the
+documentation, but there's also a `documentation wiki`_ that is very convenient
+for making edits to docstrings (and doesn't require git knowledge).  Anyone can
+register a username on that wiki, ask on the scipy-dev mailing list for edit
+rights and make edits.  The documentation there is updated every day with the
+latest changes in the SciPy master branch, and wiki edits are regularly
+reviewed and merged into master.  Another advantage of the documentation wiki
+is that you can immediately see how the reStructuredText (reST) of docstrings
+and other docs is rendered as html, so you can easily catch formatting errors.
+
+Code that doesn't belong in SciPy itself or in another package but helps users
+accomplish a certain task is valuable.  `SciPy Central`_ is the place to share
+this type of code (snippets, examples, plotting code, etc.).
+
+
+Useful links, FAQ, checklist
+----------------------------
+
+Checklist before submitting a PR
+````````````````````````````````
+
+  - Are there unit tests with good code coverage?
+  - Do all public function have docstrings including examples?
+  - Is the code style correct (PEP8, pyflakes)
+  - Is the new functionality tagged with ``.. versionadded:: X.Y.Z`` (with
+    X.Y.Z the version number of the next release - can be found in setup.py)?
+  - Is the new functionality mentioned in the release notes of the next
+    release?
+  - Is the new functionality added to the reference guide?
+  - In case of larger additions, is there a tutorial or more extensive
+    module-level description?
+  - In case compiled code is added, is it integrated correctly via setup.py
+    (and preferably also Bento/Numscons configuration files)?
+  - If you are a first-time contributor, did you add yourself to THANKS.txt?
+    Please note that this is perfectly normal and desirable - the aim is to
+    give every single contributor credit, and if you don't add yourself it's
+    simply extra work for the reviewer (or worse, the reviewer may forget).
+  - Did you check that the code can be distributed under a BSD license?
+
+
+Useful SciPy documents
+``````````````````````
+
+  - The `how to document`_ guidelines
+  - NumPy/SciPy `testing guidelines`_
+  - `SciPy API`_
+  - SciPy `maintainers`_
+  - NumPy/SciPy `git workflow`_
+
+
+FAQ
+```
+
+*I based my code on existing Matlab/R/... code I found online, is this OK?*
+
+It depends.  SciPy is distributed under a BSD license, so if the code that you
+based your code on is also BSD licensed or has a BSD-compatible license (MIT,
+Apache, ...) then it's OK.  Code which is GPL-licensed, has no clear license,
+requires citation or is free for academic use only can't be included in SciPy.
+Therefore if you copied existing code with such a license or made a direct
+translation to Python of it, your code can't be included.  See also `license
+compatibility`_.
+
+
+*How do I set up SciPy so I can edit files, run the tests and make commits?*
+
+The simplest method is setting up an in-place build.  To create your local git
+repo and do the in-place build::
+
+  $ git clone https://github.com/scipy/scipy.git scipy
+  $ cd scipy
+  $ python setup.py build_ext -i
+
+Then you need to either set up a symlink in your site-packages or add this
+directory to your PYTHONPATH environment variable, so Python can find it.  Some
+IDEs (Spyder for example) have utilities to manage PYTHONPATH.  On Linux and OS
+X, you can for example edit your .bash_login file to automatically add this dir
+on startup of your terminal.  Add the line::
+
+  export PYTHONPATH="$HOME/scipy:${PYTHONPATH}"
+
+Alternatively, to set up the symlink, use (prefix only necessary if you want to
+use your local instead of global site-packages dir)::
+
+  $ python setupegg.py develop --prefix=${HOME}
+ 
+To test that everything works, start the interpreter (not inside the scipy/
+source dir) and run the tests::
+
+  $ python
+  >>> import scipy as sp
+  >>> sp.test()
+
+Now editing a Python source file in SciPy allows you to immediately test and
+use your changes, by simply restarting the interpreter.
+
+Note that while the above procedure is the most straightforward way to get
+started, you may want to look into using Bento or numscons for faster and more
+flexible building, or virtualenv to maintain development environments for
+multiple Python versions.
+
+
+*How do I set up a development version of SciPy in parallel to a released
+version that I use to do my job/research?*
+
+One simple way to achieve this is to install the released version in
+site-packages, by using a binary installer or pip for example, and set up the
+development version with an in-place build in a virtualenv.  First install
+`virtualenv`_ and `virtualenvwrapper`_, then create your virtualenv (named
+scipy-dev here) with::
+
+  $ mkvirtualenv scipy-dev
+
+Now, whenever you want to switch to the virtual environment, you can use the
+command ``workon scipy-dev``, while the command ``deactivate`` exits from the
+virtual environment and brings back your previous shell.  With scipy-dev
+activated, follow the in-place build with the symlink install above to actually
+install your development version of SciPy.
+
+
+*Can I use a programming language other than Python to speed up my code?*
+
+Yes.  The languages used in SciPy are Python, Cython, C, C++ and Fortran.  All
+of these have their pros and cons.  If Python really doesn't offer enough
+performance, one of those languages can be used.  Important concerns when
+using compiled languages are maintainability and portability.  For
+maintainability, Cython is clearly preferred over C/C++/Fortran.  Cython and C
+are more portable than C++/Fortran.  A lot of the existing C and Fortran code
+in SciPy is older, battle-tested code that was only wrapped in (but not
+specifically written for) Python/SciPy.  Therefore the basic advice is: use
+Cython.  If there's specific reasons why C/C++/Fortran should be preferred,
+please discuss those reasons first.
+
+
+*There's overlap between Trac and Github, which do I use for what?*
+
+Trac_ is the bug tracker, Github_ the code repository.  Before the SciPy code
+repository moved to Github, the preferred way to contribute code was to create
+a patch and attach it to a Trac ticket.  The overhead of this approach is much
+larger than sending a PR on Github, so please don't do this anymore.  Use Trac
+for bug reports, Github for patches.
+
+
+.. _scikit-learn: http://scikit-learn.org
+
+.. _scikits-image: http://scikits-image.org/
+
+.. _statsmodels: http://statsmodels.sourceforge.net/
+
+.. _testing guidelines: https://github.com/numpy/numpy/blob/master/doc/TESTS.rst.txt
+
+.. _how to document: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+
+.. _pep8 package: http://pypi.python.org/pypi/pep8
+
+.. _pyflakes: http://pypi.python.org/pypi/pyflakes
+
+.. _SciPy API: http://docs.scipy.org/doc/scipy/reference/api.html
+
+.. _git workflow: http://docs.scipy.org/doc/numpy/dev/gitwash/index.html
+
+.. _maintainers: https://github.com/scipy/scipy/blob/master/doc/MAINTAINERS.rst.txt
+
+.. _Trac: http://projects.scipy.org/scipy/timeline
+
+.. _Github: https://github.com/scipy/scipy
+
+.. _scipy.org: http://scipy.org/
+
+.. _scipy.github.com: http://scipy.github.com/
+
+.. _scipy.org-new: https://github.com/scipy/scipy.org-new
+
+.. _documentation wiki: http://docs.scipy.org/scipy/Front%20Page/
+
+.. _SciPy Central: http://scipy-central.org/
+
+.. _license compatibility: http://www.scipy.org/License_Compatibility
+
+.. _doctest: http://www.doughellmann.com/PyMOTW/doctest/
+
+.. _virtualenv: http://www.virtualenv.org/
+
+.. _virtualenvwrapper: http://www.doughellmann.com/projects/virtualenvwrapper/
+

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2108,6 +2108,7 @@ MediaWiki:
   wrap: true
   extensions:
   - .mediawiki
+  - .wiki
   tm_scope: text.html.mediawiki
   ace_mode: text
 

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3967,6 +3967,8 @@ reStructuredText:
   extensions:
   - .rst
   - .rest
+  - .rest.txt
+  - .rst.txt
   ace_mode: text
 
 wisp:

--- a/samples/MediaWiki/README.wiki
+++ b/samples/MediaWiki/README.wiki
@@ -1,0 +1,694 @@
+﻿﻿= Name =
+
+'''nginx_tcp_proxy_module''' - support TCP proxy with Nginx
+
+= Installation =
+
+Download the latest stable version of the release tarball of this module from [http://github.com/yaoweibin/nginx_tcp_proxy_module github]
+
+Grab the nginx source code from [http://nginx.org/ nginx.org], for example, the version 1.2.1 (see nginx compatibility), and then build the source with this module:
+
+<geshi lang="bash">
+    $ wget 'http://nginx.org/download/nginx-1.2.1.tar.gz'
+    $ tar -xzvf nginx-1.2.1.tar.gz
+    $ cd nginx-1.2.1/
+    $ patch -p1 < /path/to/nginx_tcp_proxy_module/tcp.patch
+
+    $ ./configure --add-module=/path/to/nginx_tcp_proxy_module
+
+    $ make
+    $ make install
+</geshi>
+    
+
+= Synopsis =
+
+<geshi lang="nginx">
+http {
+
+    server {
+        listen 80;
+
+        location /status {
+            tcp_check_status;
+        }
+    }
+}
+</geshi>
+
+<geshi lang="nginx">
+
+#You can also include tcp_proxy.conf file individually
+
+#include /path/to/tcp_proxy.conf;
+
+tcp {
+
+    upstream cluster {
+        # simple round-robin
+        server 192.168.0.1:80;
+        server 192.168.0.2:80;
+
+        check interval=3000 rise=2 fall=5 timeout=1000;
+
+        #check interval=3000 rise=2 fall=5 timeout=1000 type=ssl_hello;
+
+        #check interval=3000 rise=2 fall=5 timeout=1000 type=http;
+        #check_http_send "GET / HTTP/1.0\r\n\r\n";
+        #check_http_expect_alive http_2xx http_3xx;
+    }
+
+    server {
+        listen 8888;
+
+        proxy_pass cluster;
+    }
+}
+</geshi>
+
+= Description =
+
+This module actually include many modules: ngx_tcp_module, ngx_tcp_core_module, ngx_tcp_upstream_module, ngx_tcp_proxy_module, ngx_tcp_websocket_module, ngx_tcp_ssl_module, ngx_tcp_upstream_ip_hash_module. All these modules work together to support TCP proxy with Nginx. I also added other features: ip_hash, upstream server health check, status monitor.
+
+The motivation of writing these modules is Nginx's high performance and robustness. At first, I developed this module just for general TCP proxy. And now, this module is frequently used in websocket reverse proxying. 
+
+Note, You can't use the same listening port with HTTP modules. 
+
+= Directives =
+
+== ngx_tcp_moodule ==
+
+=== tcp ===
+
+'''syntax:''' ''tcp {...}''
+
+'''default:''' ''none''
+
+'''context:''' ''main''
+
+'''description:''' All the tcp related directives are contained in the tcp block.
+
+
+'''ngx_tcp_core_moodule'''
+
+=== server ===
+
+'''syntax:''' ''server {...}''
+
+'''default:''' ''none''
+
+'''context:''' ''tcp''
+
+'''description:''' All the specific server directives are contained in the server block.
+
+=== listen ===
+
+'''syntax:''' ''listen address:port [ bind | ssl | default]''
+
+'''default:''' ''none''
+
+'''context:''' ''server''
+
+'''description:''' The same as [http://wiki.nginx.org/NginxMailCoreModule#listen listen]. The parameter of default means the default server if you have several server blocks with the same port.
+
+=== access_log ===
+
+'''syntax:''' ''access_log path [buffer=size] | off'' 
+
+'''default:''' ''access_log logs/tcp_access.log''
+
+'''context:''' ''tcp, server''
+
+'''description:''' Set the access.log. Each record's format is like this:
+
+<pre>
+
+log_time worker_process_pid client_ip host_ip accept_time upstream_ip bytes_read bytes_write
+
+2011/08/02 06:19:07 [5972] 127.0.0.1 0.0.0.0:1982 2011/08/02 06:18:19 172.19.0.129:80 80 236305
+
+</pre>
+
+* ''log_time'': The current time when writing this log. The log action is called when the proxy session is closed.
+* ''worker_process_pid'': the pid of worker process
+* ''client_ip'': the client ip
+* ''host_ip'': the server ip and port
+* ''accept_time'': the time when the server accepts client's connection
+* ''upstream_ip'': the upstream server's ip
+* ''bytes_read'': the bytes read from client
+* ''bytes_write'': the bytes written to client
+
+=== allow ===
+
+'''syntax:''' ''allow [ address | CIDR | all ]'' 
+
+'''default:''' ''none''
+
+'''context:''' ''server''
+
+'''description:''' Directive grants access for the network or addresses indicated.
+
+=== deny ===
+
+'''syntax:''' ''deny [ address | CIDR | all ]''
+
+'''default:''' ''none''
+
+'''context:''' ''server''
+
+'''description:''' Directive grants access for the network or addresses indicated.
+
+=== so_keepalive ===
+
+'''syntax:''' ''so_keepalive on|off''
+
+'''default:''' ''off''
+
+'''context:''' ''main, server''
+
+'''description:''' The same as [http://wiki.nginx.org/NginxMailCoreModule#so_keepalive so_keepalive].
+
+=== tcp_nodelay ===
+
+'''syntax:''' ''tcp_nodelay on|off''
+
+'''default:''' ''on''
+
+'''context:''' ''main, server''
+
+'''description:''' The same as [http://wiki.nginx.org/NginxHttpCoreModule#tcp_nodelay tcp_nodelay].
+
+=== timeout ===
+
+'''syntax:''' ''timeout milliseconds''
+
+'''default:''' ''60000''
+
+'''context:''' ''main, server''
+
+'''description:''' set the timeout value with clients.
+
+=== server_name ===
+
+'''syntax:''' ''server_name name''
+
+'''default:''' ''The name of the host, obtained through gethostname()''
+
+'''context:''' ''tcp, server''
+
+'''description:''' The same as [http://wiki.nginx.org/NginxMailCoreModule#server_name server_name]. You can specify several server name in different server block with the same port. They can be used in websocket module.
+
+=== resolver ===
+
+'''syntax:''' ''resolver address''
+
+'''default:''' ''none''
+
+'''context:''' ''tcp, server''
+
+'''description:''' DNS server
+
+=== resolver_timeout ===
+
+'''syntax:''' ''resolver_timeout time''
+
+'''default:''' ''30s''
+
+'''context:''' ''tcp, server''
+
+'''description:''' Resolver timeout in seconds.
+
+
+== ngx_tcp_upstream_module ==
+
+=== upstream ===
+
+'''syntax:''' ''upstream {...}''
+
+'''default:''' ''none''
+
+'''context:''' ''tcp''
+
+'''description:''' All the upstream directives are contained in this  block. The upstream server will be dispatched with round robin by default. 
+
+=== server ===
+
+'''syntax:''' ''server name [parameters]''
+
+'''default:''' ''none''
+
+'''context:''' ''upstream''
+
+'''description:''' Most of the parameters are the same as [http://wiki.nginx.org/NginxHttpUpstreamModule#server server]. Default port is 80.  
+
+=== check ===
+
+'''syntax:''' ''check interval=milliseconds [fall=count] [rise=count] [timeout=milliseconds] [type=tcp|ssl_hello|smtp|mysql|pop3|imap]''
+
+'''default:''' ''none, if parameters omitted, default parameters are interval=30000 fall=5 rise=2 timeout=1000''
+
+'''context:''' ''upstream''
+
+'''description:''' Add the health check for the upstream servers. At present, the check method is a simple tcp connect.
+
+The parameters' meanings are:
+
+* ''interval'': the check request's interval time.
+* ''fall''(fall_count): After fall_count check failures, the server is marked down. 
+* ''rise''(rise_count): After rise_count check success, the server is marked up. 
+* ''timeout'': the check request's timeout.
+* ''type'': the check protocol type:
+# ''tcp'' is a simple tcp socket connect and peek one byte. 
+# ''ssl_hello'' sends a client ssl hello packet and receives the server ssl hello packet.
+# ''http'' sends a http request packet, receives and parses the http response to diagnose if the upstream server is alive.  
+# ''smtp'' sends a smtp request packet, receives and parses the smtp response to diagnose if the upstream server is alive. The response begins with '2' should be an OK response. 
+# ''mysql'' connects to the mysql server, receives the greeting response to diagnose if the upstream server is alive.  
+# ''pop3'' receives and parses the pop3 response to diagnose if the upstream server is alive. The response begins with '+' should be an OK response.
+# ''imap'' connects to the imap server, receives the greeting response to diagnose if the upstream server is alive.  
+
+=== check_http_send ===
+
+'''syntax:''' ''check_http_send http_packet''
+
+'''default:''' ''"GET / HTTP/1.0\r\n\r\n"''
+
+'''context:''' ''upstream''
+
+'''description:''' If you set the check type is http, then the check function will sends this http packet to check the upstream server.
+
+=== check_http_expect_alive ===
+
+'''syntax:''' ''check_http_expect_alive [ http_2xx | http_3xx | http_4xx | http_5xx ]''
+
+'''default:''' ''http_2xx | http_3xx''
+
+'''context:''' ''upstream''
+
+'''description:''' These status codes indicate the upstream server's http response is OK, the backend is alive.
+
+=== check_smtp_send ===
+
+'''syntax:''' ''check_smtp_send smtp_packet''
+
+'''default:''' ''"HELO smtp.localdomain\r\n"''
+
+'''context:''' ''upstream''
+
+'''description:''' If you set the check type is smtp, then the check function will sends this smtp packet to check the upstream server.
+
+=== check_smtp_expect_alive ===
+
+'''syntax:''' ''check_smtp_expect_alive [smtp_2xx | smtp_3xx | smtp_4xx | smtp_5xx]''
+
+'''default:''' ''smtp_2xx''
+
+'''context:''' ''upstream''
+
+'''description:''' These status codes indicate the upstream server's smtp response is OK, the backend is alive.
+
+=== check_shm_size ===
+
+'''syntax:''' ''check_shm_size size''
+
+'''default:''' ''(number_of_checked_upstream_blocks + 1) * pagesize''
+
+'''context:''' ''tcp''
+
+'''description:''' If you store hundreds of servers in one upstream block, the shared memory for health check may be not enough, you can enlarged it by this directive.
+
+=== tcp_check_status ===
+
+'''syntax:''' ''tcp_check_status''
+
+'''default:''' ''none''
+
+'''context:''' ''location''
+
+'''description:''' Display the health checking servers' status by HTTP. This directive is set in the http block.
+
+The table field meanings are:
+
+* ''Index'': The server index in the check table 
+* ''Name'' : The upstream server name
+* ''Status'': The marked status of the server.
+* ''Busyness'': The number of connections which are connecting to the server.
+* ''Rise counts'': Count the successful checking
+* ''Fall counts'': Count the unsuccessful checking
+* ''Access counts'': Count the times accessing to this server
+* ''Check type'': The type of the check packet
+
+
+'''ngx_tcp_upstream_busyness_module'''
+
+=== busyness ===
+
+'''syntax:''' ''busyness''
+
+'''default:''' ''none''
+
+'''context:''' ''upstream''
+
+'''description:''' the upstream server will be dispatched by backend servers' busyness.
+
+
+'''ngx_tcp_upstream_ip_hash_module'''
+
+=== ip_hash ===
+
+'''syntax:''' ''ip_hash''
+
+'''default:''' ''none''
+
+'''context:''' ''upstream''
+
+'''description:''' the upstream server will be dispatched by ip_hash.
+
+
+== ngx_tcp_proxy_module ==
+
+=== proxy_pass ===
+
+'''syntax:''' ''proxy_pass host:port''
+
+'''default:''' ''none''
+
+'''context:''' ''server''
+
+'''description:''' proxy the request to the backend server. Default port is 80.
+
+=== proxy_buffer ===
+
+'''syntax:''' ''proxy_buffer size''
+
+'''default:''' ''4k''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the size of proxy buffer.
+
+=== proxy_connect_timeout ===
+
+'''syntax:''' ''proxy_connect_timeout miliseconds''
+
+'''default:''' ''60000''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the timeout value of connection to backends.
+
+=== proxy_read_timeout ===
+
+'''syntax:''' ''proxy_read_timeout miliseconds''
+
+'''default:''' ''60000''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the timeout value of reading from backends.
+
+=== proxy_send_timeout ===
+
+'''syntax:''' ''proxy_send_timeout miliseconds''
+
+'''default:''' ''60000''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the timeout value of sending to backends.
+
+
+== ngx_tcp_websocket_module ==
+
+=== websocket_pass ===
+
+'''syntax:''' ''websocket_pass [path] host:port''
+
+'''default:''' ''none''
+
+'''context:''' ''server''
+
+'''description:''' proxy the websocket request to the backend server. Default port is 80. You can specify several different paths in the same server block.
+
+=== websocket_buffer ===
+
+'''syntax:''' ''websocket_buffer size''
+
+'''default:''' ''4k''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the size of proxy buffer.
+
+=== websocket_connect_timeout ===
+
+'''syntax:''' ''websocket_connect_timeout miliseconds''
+
+'''default:''' ''60000''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the timeout value of connection to backends.
+
+=== websocket_read_timeout ===
+
+'''syntax:''' ''websocket_read_timeout miliseconds''
+
+'''default:''' ''60000''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the timeout value of reading from backends. Your timeout will be the minimum of this and the *timeout* parameter, so if you want a long timeout for your websockets, make sure to set both paramaters.
+
+=== websocket_send_timeout ===
+
+'''syntax:''' ''websocket_send_timeout miliseconds''
+
+'''default:''' ''60000''
+
+'''context:''' ''tcp, server''
+
+'''description:''' set the timeout value of sending to backends.
+
+
+== ngx_tcp_ssl_module ==
+
+The default config file includes this ngx_tcp_ssl_module. If you want to just compile nginx without ngx_tcp_ssl_module, copy the ngx_tcp_proxy_module/config_without_ssl to ngx_tcp_proxy_module/config,  reconfigrure and compile nginx.
+
+=== ssl ===
+
+'''syntax:''' ''ssl [on|off] ''
+
+'''default:''' ''ssl off''
+
+'''context:''' ''tcp, server''
+
+Enables SSL for a server.
+
+=== ssl_certificate ===
+
+'''syntax:''' ''ssl_certificate file''
+
+'''default:''' ''ssl_certificate cert.pem''
+
+'''context:''' ''tcp, server''
+
+This directive specifies the file containing the certificate, in PEM format. This file can contain also other certificates and the server private key.
+
+=== ssl_certificate_key ===
+
+'''syntax:''' ''ssl_certificate_key file''
+
+'''default:''' ''ssl_certificate_key cert.pem''
+
+'''context:''' ''tcp, server''
+
+This directive specifies the file containing the private key, in PEM format.
+
+=== ssl_client_certificate ===
+
+'''syntax:''' ''ssl_client_certificate file''
+
+'''default:''' ''none''
+
+'''context:''' ''tcp, server''
+
+This directive specifies the file containing the CA (root) certificate, in PEM format, that is used for validating client certificates.
+
+=== ssl_dhparam ===
+
+'''syntax:''' ''ssl_dhparam file''
+
+'''default:''' ''none''
+
+'''context:''' ''tcp, server''
+
+This directive specifies a file containing Diffie-Hellman key agreement protocol cryptographic parameters, in PEM format, utilized for exchanging session keys between server and client.
+
+=== ssl_ciphers ===
+
+'''syntax:''' ''ssl_ciphers openssl_cipherlist_spec''
+
+'''default:''' ''ssl_ciphers HIGH:!aNULL:!MD5''
+
+'''context:''' ''tcp, server''
+
+This directive describes the list of cipher suites the server supports for establishing a secure connection. Cipher suites are specified in the [http://openssl.org/docs/apps/ciphers.html OpenSSL] cipherlist format, for example:
+
+<geshi lang="nginx">
+ssl_ciphers  ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP;
+</geshi>
+
+The complete cipherlist supported by the currently installed version of OpenSSL in your platform can be obtained by issuing the command:
+<pre>
+openssl ciphers
+</pre>
+
+=== ssl_crl ===
+
+'''syntax:''' ''ssl_crl file''
+
+'''default:''' ''none''
+
+'''context:''' ''tcp, server''
+
+This directive specifies the filename of a Certificate Revocation List, in PEM format, which is used to check the revocation status of certificates.
+
+=== ssl_prefer_server_ciphers ===
+
+'''syntax:''' ''ssl_prefer_server_ciphers [on|off] ''
+
+'''default:''' ''ssl_prefer_server_ciphers off''
+
+'''context:''' ''tcp, server''
+
+The server requires that the cipher suite list for protocols SSLv3 and TLSv1 are to be preferred over the client supported cipher suite list.
+
+=== ssl_protocols ===
+
+'''syntax:''' ''ssl_protocols [SSLv2] [SSLv3] [TLSv1] [TLSv1.1] [TLSv1.2]''
+
+'''default:''' ''ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2''
+
+'''context:''' ''tcp, server''
+
+This directive enables the protocol versions specified.
+
+=== ssl_verify_client ===
+
+'''syntax:''' ''ssl_verify_client on|off|optional''
+
+'''default:''' ''ssl_verify_client off''
+
+'''context:''' ''tcp, server''
+
+This directive enables the verification of the client identity. Parameter 'optional' checks the client identity using its certificate in case it was made available to the server.
+
+=== ssl_verify_depth ===
+
+'''syntax:''' ''ssl_verify_depth number''
+
+'''default:''' ''ssl_verify_depth 1''
+
+'''context:''' ''tcp, server''
+
+This directive sets how deep the server should go in the client provided certificate chain in order to verify the client identity.
+
+=== ssl_session_cache ===
+
+'''syntax:''' ''ssl_session_cache off|none|builtin:size and/or shared:name:size''
+
+'''default:''' ''ssl_session_cache off''
+
+'''context:''' ''tcp, server''
+
+The directive sets the types and sizes of caches to store the SSL sessions.
+
+The cache types are:
+
+* off -- Hard off: nginx says explicitly to a client that sessions can not reused.
+* none -- Soft off: nginx says to a client that session can be resued, but nginx actually never reuses them. This is workaround for some mail clients as ssl_session_cache may be used in mail proxy as well as in HTTP server.
+* builtin -- the OpenSSL builtin cache, is used inside one worker process only. The cache size is assigned in the number of the sessions. Note: there appears to be a memory fragmentation issue using this method, please take that into consideration when using this. See "References" below.
+* shared -- the cache is shared between all worker processes. The size of the cache is assigned in bytes: 1 MB cache can contain roughly 4000 sessions. Each shared cache must be given an arbitrary name. A shared cache with a given name can be used in several virtual hosts.
+It's possible to use both types of cache &mdash; builtin and shared &mdash; simultaneously, for example:
+
+<geshi lang="nginx">
+ssl_session_cache  builtin:1000  shared:SSL:10m;
+</geshi>
+
+Bear in mind however, that using only shared cache, i.e., without builtin, should be more effective.
+
+=== ssl_session_timeout ===
+
+'''syntax:''' ''ssl_session_timeout time''
+
+'''default:''' ''ssl_session_timeout 5m''
+
+'''context:''' ''tcp, server''
+
+This directive defines the maximum time during which the client can re-use the previously negotiated cryptographic parameters of the secure session that is stored in the SSL cache.
+
+= Compatibility =
+
+* My test bed is 0.7.65+
+
+= Notes =
+
+The http_response_parse.rl and smtp_response_parse.rl are [http://www.complang.org/ragel/ ragel] scripts , you can edit the script and compile it like this:
+
+<geshi lang="bash">
+    $ ragel -G2 http_response_parse.rl
+    $ ragel -G2 smtp_response_parse.rl
+</geshi>
+
+= TODO =
+
+* refact this module, make it more extendable for adding third-party modules
+* manipulate header like http module's proxy_set_header
+* built-in variable support
+* custom log format
+* syslog support
+* FTP/IRC proxying
+
+= Known Issues =
+
+* This module can't use the same listening port with the HTTP module.
+
+= Changelogs =
+
+== v0.2.0 ==
+
+* add ssl proxy module
+* add websocket proxy module
+* add upstream busyness module
+* add tcp access log module
+
+== v0.19 ==
+
+* add many check methods
+
+== v0.1 ==
+
+* first release
+
+= Authors =
+
+Weibin Yao(姚伟斌) ''yaoweibin at gmail dot com''
+
+= Copyright & License =
+
+This README template copy from [http://github.com/agentzh agentzh].
+
+I borrowed a lot of code from upstream and mail module from the nginx 0.7.* core. This part of code is copyrighted by Igor Sysoev. And the health check part is borrowed the design of Jack Lindamood's healthcheck module [http://github.com/cep21/healthcheck_nginx_upstreams healthcheck_nginx_upstreams];
+
+This module is licensed under the BSD license.
+
+Copyright (C) 2013 by Weibin Yao <yaoweibin@gmail.com>.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This pull request adds the `.wiki` file extension to Mediawiki.
There are [around 373,000 `.wiki` files on GitHub](https://github.com/search?utf8=%E2%9C%93&q=extension%3Awiki+NOT+dkfjkfdjkd).

These files are [already recognized and rendered](https://github.com/github/markup#markups) as Mediawiki files by github/markup. This change would make Linguist consistent with Markup (in order to [use Linguist as the detection engine for Markup](https://github.com/github/markup/pull/537) in a second time).

EDIT: I added `.rst.txt` and `.rest.txt` for reStructuredText since they follow the same logic, ie. they're already recognized by github/markup.