### PR TITLE
Reorder Perl heuristic rules

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -276,20 +276,20 @@ module Linguist
     end
 
     disambiguate ".pl" do |data|
-      if /^(use v6|(my )?class|module)/.match(data)
-        Language["Perl6"]
+      if /^[^#]+:-/.match(data)
+        Language["Prolog"]
       elsif /use strict|use\s+v?5\./.match(data)
         Language["Perl"]
-      elsif /^[^#]+:-/.match(data)
-        Language["Prolog"]
+      elsif /^(use v6|(my )?class|module)/.match(data)
+        Language["Perl6"]
       end
     end
 
     disambiguate ".pm", ".t" do |data|
-      if /^(use v6|(my )?class|module)/.match(data)
-        Language["Perl6"]
-      elsif /use strict|use\s+v?5\./.match(data)
+      if /use strict|use\s+v?5\./.match(data)
         Language["Perl"]
+      elsif /^(use v6|(my )?class|module)/.match(data)
+        Language["Perl6"]
       end
     end
 

--- a/samples/Perl6/hash.t
+++ b/samples/Perl6/hash.t
@@ -12,7 +12,6 @@ unless EVAL 'EVAL("1", :lang<perl5>)' {
 die unless
 EVAL(q/
 package My::Hash;
-use strict;
 
 sub new {
     my ($class, $ref) = @_;


### PR DESCRIPTION
This pull request fixes #2781 and mitigate the issue of Perl miss-detections.
I reordered heuristic rules by accuracy. Because of the `if/elsif` structure, I think it makes sense to place the rule in which we are most confident first.