### PR TITLE
Add stan extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -701,3 +701,6 @@
 [submodule "vendor/grammars/language-renpy"]
 	path = vendor/grammars/language-renpy
 	url = https://github.com/williamd1k0/language-renpy.git
+[submodule "vendor/grammars/atom-language-stan"]
+	path = vendor/grammars/atom-language-stan
+	url = git@github.com:jrnold/atom-language-stan.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -187,6 +187,8 @@ vendor/grammars/atom-fsharp/:
 - source.fsharp.fsx
 vendor/grammars/atom-language-purescript/:
 - source.purescript
+vendor/grammars/atom-language-stan/:
+- source.stan
 vendor/grammars/atom-salt:
 - source.python.salt
 - source.yaml.salt

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3361,7 +3361,7 @@ Stan:
   extensions:
   - .stan
   ace_mode: text
-  tm_scope: none
+  tm_scope: source.stan
 
 Standard ML:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3355,6 +3355,12 @@ Squirrel:
   tm_scope: source.c++
   ace_mode: c_cpp
 
+Stan:
+  type: programming
+  extensions:
+  - .stan
+  ace_mode: text
+
 Standard ML:
   type: programming
   color: "#dc566d"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3360,6 +3360,7 @@ Stan:
   extensions:
   - .stan
   ace_mode: text
+  tm_scope: none
 
 Standard ML:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3357,6 +3357,7 @@ Squirrel:
 
 Stan:
   type: programming
+  color: "#b2011d"
   extensions:
   - .stan
   ace_mode: text

--- a/samples/Stan/congress.stan
+++ b/samples/Stan/congress.stan
@@ -1,0 +1,14 @@
+data {
+  int<lower=0> N;
+  vector[N] incumbency_88;
+  vector[N] vote_86;
+  vector[N] vote_88;
+}
+parameters {
+  vector[3] beta;
+  real<lower=0> sigma;
+}
+model {
+    vote_88 ~ normal(beta[1] + beta[2] * vote_86
+                     + beta[3] * incumbency_88,sigma);
+}

--- a/samples/Stan/dogs.stan
+++ b/samples/Stan/dogs.stan
@@ -1,0 +1,31 @@
+data {
+  int<lower=0> n_dogs;
+  int<lower=0> n_trials;
+  int<lower=0,upper=1> y[n_dogs,n_trials];
+}
+parameters {
+  vector[3] beta;
+}
+transformed parameters {
+  matrix[n_dogs,n_trials] n_avoid;
+  matrix[n_dogs,n_trials] n_shock;
+  matrix[n_dogs,n_trials] p;
+
+  for (j in 1:n_dogs) {
+    n_avoid[j,1] <- 0;
+    n_shock[j,1] <- 0;
+    for (t in 2:n_trials) {
+      n_avoid[j,t] <- n_avoid[j,t-1] + 1 - y[j,t-1];
+      n_shock[j,t] <- n_shock[j,t-1] + y[j,t-1];
+    }
+    for (t in 1:n_trials)
+      p[j,t] <- beta[1] + beta[2] * n_avoid[j,t] + beta[3] * n_shock[j,t];
+  }
+}
+model {
+  beta ~ normal(0, 100);
+  for (i in 1:n_dogs) {
+    for (j in 1:n_trials)
+      y[i,j] ~ bernoulli_logit(p[i,j]);
+  }
+}

--- a/samples/Stan/schools.stan
+++ b/samples/Stan/schools.stan
@@ -1,0 +1,26 @@
+data {
+  int<lower=0> N;
+  vector[N] y;
+  vector[N] sigma_y;
+}
+parameters {
+  vector[N] eta;
+  real mu_theta;
+  real<lower=0,upper=100> sigma_eta;
+  real xi;
+}
+transformed parameters {
+  real<lower=0> sigma_theta;
+  vector[N] theta;
+
+  theta <- mu_theta + xi * eta;
+  sigma_theta <- fabs(xi) / sigma_eta;
+}
+model {
+  mu_theta ~ normal(0, 100);
+  sigma_eta ~ inv_gamma(1, 1); //prior distribution can be changed to uniform
+
+  eta ~ normal(0, sigma_eta);
+  xi ~ normal(0, 5);
+  y ~ normal(theta,sigma_y);
+}


### PR DESCRIPTION
Add support to recognize Stan model files (extension `.stan`). [Stan](https://github.com/stan-dev/stan/) is a probabilistic programming language. The extension `.stan` does not conflict with any existing extensions in `languages.yml`. Here is the relevant search: https://github.com/search?utf8=%E2%9C%93&q=extension%3Astan+NOT+nothack&type=Code&ref=searchresults