### PR TITLE
Added support for Lektor content files and .lektorproject

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1475,8 +1475,8 @@ IGOR Pro:
 INI:
   type: data
   extensions:
-  - .cfg
   - .ini
+  - .cfg
   - .lektorproject
   - .prefs
   - .pro

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1475,8 +1475,9 @@ IGOR Pro:
 INI:
   type: data
   extensions:
-  - .ini
   - .cfg
+  - .ini
+  - .lektorproject
   - .prefs
   - .pro
   - .properties
@@ -1819,6 +1820,14 @@ Lean:
   - .lean
   - .hlean
   ace_mode: lean
+
+Lektor:
+  type: prose
+  ace_mode: markdown
+  wrap: true
+  extensions:
+  - .lr
+  tm_scope: source.gfm
 
 Less:
   type: markup


### PR DESCRIPTION
This commit adds support for Lektor content files to linguist.  Lektor content files have the `.lr` extension which does not conflict with anything in linguist.  These files contain key/value pairs where most multi line values follow typically markdown syntax.

It also adds an alias for INI files for `.lektorproject`.

For information about lektor see https://github.com/lektor/lektor