### PR TITLE
Update PureScript submodule (moved repo, grammar tweak)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -658,7 +658,7 @@
 	url = https://github.com/rpavlick/language-ncl.git
 [submodule "vendor/grammars/atom-language-purescript"]
 	path = vendor/grammars/atom-language-purescript
-	url = https://github.com/freebroccolo/atom-language-purescript
+	url = https://github.com/purescript-contrib/atom-language-purescript
 [submodule "vendor/grammars/vue-syntax-highlight"]
 	path = vendor/grammars/vue-syntax-highlight
 	url = https://github.com/vuejs/vue-syntax-highlight


### PR DESCRIPTION
Updated grammar to support triple-quoted strings properly:
https://github.com/purescript-contrib/atom-language-purescript/commit/0c53f8162e40f2942d3df53c928c8ce597be3e12

atom-language-purescript repo has been moved to purescript-contrib org,
update the URL.