### PR TITLE
Add .xproj to list of XML file extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3797,6 +3797,7 @@ XML:
   - .xliff
   - .xmi
   - .xml.dist
+  - .xproj
   - .xsd
   - .xul
   - .zcml


### PR DESCRIPTION
- `.props` is a VS property file that's formatted in XML. [Sample](https://github.com/dotnet/corefx/blob/master/dir.props).
- `.xproj` is the new ASP.NET 5/DNX file that's used to manage a project (similar to csproj). [Sample](https://github.com/ufcpp/UfcppSample/blob/master/Chapters/Resource/ClassOrStruct/ClassOrStruct.xproj).