### PR TITLE
Support .rs.in as a file extension for Rust files.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3081,6 +3081,7 @@ Rust:
   color: "#dea584"
   extensions:
   - .rs
+  - .rs.in
   ace_mode: rust
 
 SAS:


### PR DESCRIPTION
When using syntax extensions in stable or beta Rust channels using the syntex package, it is common to use the file extension .rs.in for the source file, and .rs for the generated file.