### PR TITLE
HTTPS links for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -676,7 +676,7 @@
 	url = https://github.com/CausalityLtd/sublime-pony
 [submodule "vendor/grammars/X10"]
 	path = vendor/grammars/X10
-	url = git@github.com:x10-lang/x10-highlighting.git
+	url = https://github.com/x10-lang/x10-highlighting
 [submodule "vendor/grammars/language-babel"]
 	path = vendor/grammars/language-babel
 	url = https://github.com/gandm/language-babel
@@ -691,7 +691,7 @@
 	url = https://github.com/freemarker/FreeMarker.tmbundle
 [submodule "vendor/grammars/MagicPython"]
 	path = vendor/grammars/MagicPython
-	url = git@github.com:MagicStack/MagicPython.git
+	url = https://github.com/MagicStack/MagicPython
 [submodule "vendor/grammars/language-click"]
 	path = vendor/grammars/language-click
 	url = https://github.com/stenverbois/language-click.git
@@ -706,4 +706,4 @@
 	url = https://github.com/erkyrath/language-inform7
 [submodule "vendor/grammars/atom-language-stan"]
 	path = vendor/grammars/atom-language-stan
-	url = git@github.com:jrnold/atom-language-stan.git
+	url = https://github.com/jrnold/atom-language-stan

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -113,6 +113,20 @@ class TestGrammars < Minitest::Test
     assert_equal [], licensed, msg
   end
 
+  def test_submodules_use_https_links
+    File.open(".gitmodules", "r") do |fh|
+      ssh_submodules = []
+      fh.each_line do |line|
+        if matches = line.match(/url = (git@.*)/)
+          submodule_link = matches.captures[0]
+          ssh_submodules.push(submodule_link)
+        end
+      end
+      msg = "The following submodules don't have an HTTPS link:\n* #{ssh_submodules.join("\n* ")}"
+      assert_equal [], ssh_submodules, msg
+    end
+  end
+
   private
 
   def submodule_paths


### PR DESCRIPTION
This pull request changes three links to submodules that were previously using SSH links.
As reported in #2801, users without an SSH key registered on GitHub will fail to clone submodules with an SSH link.

~~This is still missing a test to make sure we don't add submodules with SSH links again.~~
Working on that.