### PR TITLE
Exclude golang's vendor/ directory from stats

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -38,6 +38,7 @@
 - erlang.mk
 
 # Go dependencies
+- vendor/
 - Godeps/_workspace/
 
 # Minified JavaScript and CSS


### PR DESCRIPTION
- Experimental support in go 1.5
- Native support in go 1.6 (go 1.6 rc1 released today)

See https://github.com/golang/go/wiki/PackageManagementTools