### PR TITLE
Support for the YANG modeling language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -707,3 +707,6 @@
 [submodule "vendor/grammars/atom-language-stan"]
 	path = vendor/grammars/atom-language-stan
 	url = https://github.com/jrnold/atom-language-stan
+[submodule "vendor/grammars/language-yang"]
+	path = vendor/grammars/language-yang
+	url = https://github.com/DzonyKalafut/language-yang.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -372,6 +372,8 @@ vendor/grammars/language-xbase:
 - source.harbour
 vendor/grammars/language-yaml:
 - source.yaml
+vendor/grammars/language-yang/:
+- source.yang
 vendor/grammars/latex.tmbundle:
 - text.bibtex
 - text.log.latex

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3901,6 +3901,13 @@ YAML:
   - .yaml-tmlanguage
   ace_mode: yaml
 
+YANG:
+  type: data
+  extensions:
+  - .yang
+  tm_scope: none
+  ace_mode: text
+
 Yacc:
   type: programming
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3905,7 +3905,7 @@ YANG:
   type: data
   extensions:
   - .yang
-  tm_scope: none
+  tm_scope: source.yang
   ace_mode: text
 
 Yacc:

--- a/samples/YANG/sfc-lisp-impl.yang
+++ b/samples/YANG/sfc-lisp-impl.yang
@@ -1,0 +1,55 @@
+module sfc-lisp-impl {
+
+  yang-version 1;
+  namespace "urn:opendaylight:params:xml:ns:yang:controller:config:sfc-lisp:impl";
+  prefix "sfc-lisp-impl";
+
+  import config { prefix config; revision-date 2013-04-05; }
+  import rpc-context { prefix rpcx; revision-date 2013-06-17; }
+  import opendaylight-md-sal-binding { prefix mdsal; revision-date 2013-10-28; }
+
+
+  description
+      "This module contains the base YANG definitions for
+      sfc-lisp implementation.";
+
+  revision "2015-04-27" {
+      description
+          "Initial revision.";
+  }
+
+  // This is the definition of the service implementation as a module identity
+  identity sfc-lisp-impl {
+      base config:module-type;
+
+      // Specifies the prefix for generated java classes.
+      config:java-name-prefix SfcLisp;
+  }
+
+
+  // Augments the 'configuration' choice node under modules/module.
+  augment "/config:modules/config:module/config:configuration" {
+    case sfc-lisp-impl {
+      when "/config:modules/config:module/config:type = 'sfc-lisp-impl'";
+
+      //wires in the data-broker service
+      container data-broker {
+        uses config:service-ref {
+          refine type {
+              mandatory false;
+              config:required-identity mdsal:binding-async-data-broker;
+          }
+        }
+      }
+
+      container rpc-registry {
+        uses config:service-ref {
+          refine type {
+              mandatory true;
+              config:required-identity mdsal:binding-rpc-registry;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds support for the YANG modeling language.
There are [around 11,600 `.yang` files on GitHub](https://github.com/search?o=desc&q=extension%3Ayang+NOT+dkfjdkfdkfn&ref=searchresults&s=indexed&type=Code&utf8=%E2%9C%93).
I used [DzonyKalafut/language-yang](https://github.com/DzonyKalafut/language-yang) as the grammar. [Here is an example of the result in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2FDzonyKalafut%2Flanguage-yang%2Fblob%2Fmaster%2Fgrammars%2Fyang.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fopendaylight%2Fsfc%2Fblob%2F98b276a1a125067e0223ae53ef846a4e399d1de3%2Fsfclisp%2Fsrc%2Fmain%2Fyang%2Fsfc-lisp-impl.yang&code=).