### PR TITLE
Shell: Add shell-script alias for recognizing Emacs modelines

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3274,6 +3274,7 @@ Shell:
   color: "#89e051"
   aliases:
   - sh
+  - shell-script
   - bash
   - zsh
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3285,6 +3285,7 @@ Shell:
   - .command
   - .fcgi
   - .ksh
+  - .sh.in
   - .tmux
   - .tool
   - .zsh


### PR DESCRIPTION
Bunch of files that would benefit from this here: https://github.com/scop/bash-completion/tree/master/completions