### PR TITLE
Add BUCK filename to Python in languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -474,7 +474,7 @@ CSS:
   color: "#563d7c"
   extensions:
   - .css
-  
+
 CSV:
   type: data
   ace_mode: text
@@ -2854,6 +2854,7 @@ Python:
   - .wsgi
   - .xpy
   filenames:
+  - BUCK
   - BUILD
   - SConscript
   - SConstruct

--- a/samples/Python/filenames/BUCK
+++ b/samples/Python/filenames/BUCK
@@ -1,0 +1,31 @@
+include_defs('//tools/build.defs')
+
+gerrit_war(name = 'gerrit')
+gerrit_war(name = 'gwtgerrit',   ui = 'ui_dbg')
+gerrit_war(name = 'headless',    ui = None)
+gerrit_war(name = 'chrome',      ui = 'ui_chrome')
+gerrit_war(name = 'firefox',     ui = 'ui_firefox')
+gerrit_war(name = 'safari',      ui = 'ui_safari')
+gerrit_war(name = 'polygerrit',  ui = 'polygerrit')
+gerrit_war(name = 'withdocs', docs = True)
+gerrit_war(name = 'release',  ui = 'ui_optdbg_r', docs = True, context = ['//plugins:core'],  visibility = ['//tools/maven:'])
+
+API_DEPS = [
+  '//gerrit-acceptance-framework:acceptance-framework',
+  '//gerrit-acceptance-framework:acceptance-framework-src',
+  '//gerrit-acceptance-framework:acceptance-framework-javadoc',
+  '//gerrit-extension-api:extension-api',
+  '//gerrit-extension-api:extension-api-src',
+  '//gerrit-extension-api:extension-api-javadoc',
+  '//gerrit-plugin-api:plugin-api',
+  '//gerrit-plugin-api:plugin-api-src',
+  '//gerrit-plugin-api:plugin-api-javadoc',
+  '//gerrit-plugin-gwtui:gwtui-api',
+  '//gerrit-plugin-gwtui:gwtui-api-src',
+  '//gerrit-plugin-gwtui:gwtui-api-javadoc',
+]
+
+zip_file(
+  name = 'api',
+  srcs = API_DEPS,
+)

--- a/samples/Python/filenames/BUILD
+++ b/samples/Python/filenames/BUILD
@@ -1,0 +1,45 @@
+package(default_visibility = ["//scripts/release:__pkg__"])
+
+filegroup(
+    name = "git",
+    srcs = glob([".git/**"]),
+)
+
+filegroup(
+    name = "dummy",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "bazel-*/**",
+            "output/**",
+            ".*/**",
+        ],
+    ) + [
+        "//examples:srcs",
+        "//scripts:srcs",
+        "//site:srcs",
+        "//src:srcs",
+        "//tools:srcs",
+        "//third_party:srcs",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+load("//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "bazel-srcs",
+    files = [":srcs"],
+    strip_prefix = ".",
+    # Public but bazel-only visibility.
+    visibility = ["//:__subpackages__"],
+)
+
+load("//tools/build_rules/go:def.bzl", "go_prefix")
+
+go_prefix("github.com/bazelbuild/bazel")


### PR DESCRIPTION
BUCK is the filename for the build files of the Facebook Buck build system. BUCK files are valid Python files.

Eg.:
  https://github.com/GerritCodeReview/gerrit/blob/master/BUCK

Also add a missing sample for Pants / Bazel BUILD files. They are also valid Python files.