### PR TITLE
Recognizing Jenkinsfile as Groovy source

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1310,6 +1310,8 @@ Groovy:
   - .gvy
   interpreters:
   - groovy
+  filenames:
+  - Jenkinsfile
 
 Groovy Server Pages:
   type: programming

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -302,3 +302,6 @@
 
 # Android Google APIs
 - (^|/)\.google_apis/
+
+# Jenkins Pipeline
+- ^Jenkinsfile$

--- a/samples/Groovy/filenames/Jenkinsfile
+++ b/samples/Groovy/filenames/Jenkinsfile
@@ -1,0 +1,46 @@
+jettyUrl = 'http://localhost:8081/'
+
+def servers
+
+stage 'Dev'
+node {
+    checkout scm
+    servers = load 'servers.groovy'
+    mvn '-o clean package'
+    dir('target') {stash name: 'war', includes: 'x.war'}
+}
+
+stage 'QA'
+parallel(longerTests: {
+    runTests(servers, 30)
+}, quickerTests: {
+    runTests(servers, 20)
+})
+
+stage name: 'Staging', concurrency: 1
+node {
+    servers.deploy 'staging'
+}
+
+input message: "Does ${jettyUrl}staging/ look good?"
+
+stage name: 'Production', concurrency: 1
+node {
+    sh "wget -O - -S ${jettyUrl}staging/"
+    echo 'Production server looks to be alive'
+    servers.deploy 'production'
+    echo "Deployed to ${jettyUrl}production/"
+}
+
+def mvn(args) {
+    sh "${tool 'Maven 3.x'}/bin/mvn ${args}"
+}
+
+def runTests(servers, duration) {
+    node {
+        checkout scm
+        servers.runWithServer {id ->
+            mvn "-o -f sometests test -Durl=${jettyUrl}${id}/ -Dduration=${duration}"
+        }
+    }
+}

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -522,6 +522,9 @@ class TestBlob < Minitest::Test
     assert sample_blob("myapp/My Template.xctemplate/___FILEBASENAME___.h").vendored?
     assert sample_blob("myapp/My Images.xcassets/some/stuff.imageset/Contents.json").vendored?
     assert !sample_blob("myapp/MyData.json").vendored?
+
+    # Jenkins
+    assert sample_blob("Jenkinsfile").vendored?
   end
 
   def test_documentation


### PR DESCRIPTION
`Jenkinsfile` is the conventional name for a Groovy-syntax script containing build instructions for the Jenkins continuous integration server using the Pipeline feature. [Details](https://github.com/jenkinsci/workflow-plugin/blob/7d2004ea482418f84c3f221d3f55dff20e8ada44/TUTORIAL.md#creating-multibranch-projects) and [context](https://issues.jenkins-ci.org/browse/JENKINS-31152).

Look to be about a couple hundred [known files](https://github.com/search?utf8=%E2%9C%93&q=Jenkinsfile+in%3Apath&type=Code&ref=searchresults) out there. To date the trick for getting syntax highlighting has been to use `#!groovy` as [here](https://github.com/jenkinsci/pipeline-examples/blob/0a7aa6180e14fd17901a514c5e6bb356e416f41f/global-library-examples/global-function/Jenkinsfile#L1).

For my colleagues: @reviewbybees esp. @kohsuke who selected this filename.