### PR TITLE
Add new strategy using .gitattributes

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -11,6 +11,7 @@ require 'linguist/samples'
 require 'linguist/file_blob'
 require 'linguist/blob_helper'
 require 'linguist/strategy/filename'
+require 'linguist/strategy/gitattributes'
 require 'linguist/strategy/modeline'
 require 'linguist/shebang'
 
@@ -89,6 +90,7 @@ module Linguist
 
     STRATEGIES = [
       Linguist::Strategy::Modeline,
+      Linguist::Strategy::Gitattributes,
       Linguist::Shebang,
       Linguist::Strategy::Filename,
       Linguist::Heuristics,

--- a/lib/linguist/strategy/gitattributes.rb
+++ b/lib/linguist/strategy/gitattributes.rb
@@ -1,0 +1,14 @@
+require 'rugged'
+
+module Linguist
+  module Strategy
+    class Gitattributes
+      # Public: Detects language based on .gitattributes
+      def self.call(blob, _ = nil)
+        repo = Rugged::Repository.discover(File.dirname(blob.path))
+        attr = repo.attributes(blob.path)
+        Language.find_by_alias attr['linguist-language']
+      end
+    end
+  end
+end


### PR DESCRIPTION
This tiny patch implements a strategy using the `linguist-language` attribute present in `.gitattributes`, if the file is in a `git` repo.  See #1792.

The implementation is so trivial that I wonder if there are any reasons for not having implemented this before (performance?).

If there is a willingness to accept this PR, I will add tests and clean up the patch.