### PR TITLE
Classification of props file

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -313,6 +313,14 @@ module Linguist
       end
     end
 
+    disambiguate ".props" do |data|
+      if /^(\s*)(<Project|<Import|<Property|<?xml|xmlns)/i.match(data)
+        Language["XML"]
+      elsif /\w+\s*=\s*/i.match(data)
+        Language["INI"]
+      end
+    end
+
     disambiguate ".r" do |data|
       if /\bRebol\b/i.match(data)
         Language["Rebol"]

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3810,6 +3810,7 @@ XML:
   - .osm
   - .plist
   - .pluginspec
+  - .props
   - .ps1xml
   - .psc1
   - .pt

--- a/samples/XML/Default.props
+++ b/samples/XML/Default.props
@@ -1,0 +1,29 @@
+<!--
+***********************************************************************************************
+Default.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Import Before -->
+  <Import Condition="Exists('$(MSBuildThisFileDirectory)ImportBefore\Default')" Project="$(MSBuildThisFileDirectory)ImportBefore\Default\*.props" />
+  
+  <PropertyGroup>
+    <TargetOsAndVersion>Windows Phone Silverlight 8.1</TargetOsAndVersion>
+    <RealOSVersion>6.3</RealOSVersion>
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v120</PlatformToolset>
+
+    <_PlatformToolsetFriendlyNameFor_v120>Windows Phone Silverlight 8.1 (v120)</_PlatformToolsetFriendlyNameFor_v120>
+    <_PlatformToolsetShortNameFor_v120>Windows Phone Silverlight 8.1</_PlatformToolsetShortNameFor_v120>
+  </PropertyGroup>
+
+  <!-- Import After -->
+  <Import Condition="Exists('$(MSBuildThisFileDirectory)ImportAfter\Default')" Project="$(MSBuildThisFileDirectory)ImportAfter\Default\*.props" />
+</Project>


### PR DESCRIPTION
* Initially treat as XML
* Disambiguate from ini (key-value pair style with `=`)
* If the file is neither XML-style nor INI, classify as SQL

Fix #2852