### PR TITLE
Support for YAML .sublime-syntax extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3963,6 +3963,7 @@ YAML:
   - .yml
   - .reek
   - .rviz
+  - .sublime-syntax
   - .syntax
   - .yaml
   - .yaml-tmlanguage

--- a/samples/YAML/HexInspect.sublime-syntax
+++ b/samples/YAML/HexInspect.sublime-syntax
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Hex Inspect
+file_extensions: []
+hidden: true
+scope: source.inspect
+contexts:
+  main:
+    - match: '([\w\-]+)\s*(:)\s*'
+      captures:
+        1: support.function.key.inspect
+        2: support.function.punctuation.inspect
+      push:
+        - meta_scope: item.inspect
+        - match: '([\d\-\w]+)'
+          captures:
+            1: data.inspect
+          pop: true
+    - match: '^(\s*[\w\-\s]+)\s*(:)\s*'
+      captures:
+        1: keyword.title.inspect
+        2: keyword.title-punctuation.inspect
+      push:
+        - meta_scope: item.inspect
+        - match: $
+          pop: true
+        - match: '[\w\s]+'
+          scope: title-info.inspect


### PR DESCRIPTION
This pull request adds support for the YAML extension `.sublime-syntax` as discussed in #2850.