### PR TITLE
make .hlsl the primary extension for HLSL

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1326,9 +1326,9 @@ HCL:
 HLSL:
   type: programming
   extensions:
+    - .hlsl
     - .fx
     - .fxh
-    - .hlsl
     - .hlsli
   ace_mode: text
   tm_scope: none


### PR DESCRIPTION
When I submitted the HLSL-language, I accidentally missed that the
first extension was the primary one (as is documented in the source
code, which I unfortunately missed), and instead alphabetized the
whole list.

The primary extension should be .hlsl, so let's remedy this.