### PR TITLE
git-linguist: Print PWD

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -111,7 +111,7 @@ def git_linguist(args)
   parser.parse!(args)
 
   git_dir = `git rev-parse --git-dir`.strip
-  raise "git-linguist must be ran in a Git repository" unless $?.success?
+  raise "git-linguist must be ran in a Git repository (#{Dir.pwd})" unless $?.success?
   wrapper = GitLinguist.new(git_dir, commit, incremental)
 
   case args.pop


### PR DESCRIPTION
Print the current directory when `git-linguist` is being ran outside of a Git directory.

We'll pick this up on the next release.

cc @arfon