### PR TITLE
Fix regex in .rpy disambiguate

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -330,7 +330,7 @@ module Linguist
     end
 
     disambiguate ".rpy" do |data|
-      if /(^(import|from|class|def)[\s\S])/m.match(data)
+      if /(^(import|from|class|def)\s)/m.match(data)
         Language["Python"]
       else
         Language["Ren'Py"]


### PR DESCRIPTION
I wrote the regex wrongly, matching `define` (which is not python) and not only `def`.
I'm sorry for the mistake. :pensive: