### PR TITLE
Bringing back Assembly highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -665,3 +665,6 @@
 [submodule "vendor/grammars/SublimePuppet"]
 	path = vendor/grammars/SublimePuppet
 	url = https://github.com/russCloak/SublimePuppet
+[submodule "vendor/grammars/sublimeassembly"]
+	path = vendor/grammars/sublimeassembly
+	url = https://github.com/Nessphoro/sublimeassembly

--- a/grammars.yml
+++ b/grammars.yml
@@ -531,6 +531,8 @@ vendor/grammars/sublime_cobol:
 vendor/grammars/sublime_man_page_support:
 - source.man
 - text.groff
+vendor/grammars/sublimeassembly/:
+- source.assembly
 vendor/grammars/sublimeprolog/:
 - source.prolog
 - source.prolog.eclipse

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -230,7 +230,7 @@ Assembly:
   - .a51
   - .inc
   - .nasm
-  tm_scope: none
+  tm_scope: source.assembly
   ace_mode: assembly_x86
 
 Augeas:

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -7,7 +7,7 @@ class TestGrammars < Minitest::Test
   PROJECT_WHITELIST = [
     # Dual MIT and GPL license
     "vendor/grammars/language-csharp",
-
+    "vendor/grammars/sublimeassembly"
   ].freeze
 
   # List of allowed SPDX license names

--- a/vendor/licenses/grammar/SublimePuppet.txt
+++ b/vendor/licenses/grammar/SublimePuppet.txt
@@ -1,0 +1,26 @@
+---
+type: grammar
+name: SublimePuppet
+license: mit
+---
+The MIT License (MIT)
+
+Copyright (c) 2014 Peter Souter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/licenses/grammar/sublimeassembly.txt
+++ b/vendor/licenses/grammar/sublimeassembly.txt
@@ -1,0 +1,12 @@
+---
+type: grammar
+name: sublimeassembly
+license: bsd-3
+curated: true
+---
+
+Copyright (c) 2015, Pavlo Malynin All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. * Neither the name of Pavlo Malynin nor the names of the contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
- [Example of highlighting](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2FNessphoro%2Fsublimeassembly%2Fblob%2Fmaster%2FAssembly%2520x86.JSON-tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fgithub%2Flinguist%2Fblob%2Fmaster%2Fsamples%2FAssembly%2Flib.inc&code=)

/ cc https://github.com/github/linguist/issues/2885