### PR TITLE
MIT license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,6 @@
   "repository": "https://github.com/github/linguist",
   "dependencies": {
     "season": "~>5.0"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
This pull request adds a `license` field in `package.json` to remove the npm warning in tests:
`npm WARN linguist No license field.`