### PR TITLE
Fix warnings

### DIFF
--- a/lib/linguist/blob.rb
+++ b/lib/linguist/blob.rb
@@ -63,7 +63,7 @@ module Linguist
     #
     # Returns an Array
     def extensions
-      basename, *segments = name.downcase.split(".")
+      _, *segments = name.downcase.split(".")
 
       segments.map.with_index do |segment, index|
         "." + segments[index..-1].join(".")

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -28,6 +28,7 @@ module Linguist
       @oid = oid
       @path = path
       @mode = mode
+      @data = nil
     end
 
     def git_attributes

--- a/lib/linguist/repository.rb
+++ b/lib/linguist/repository.rb
@@ -30,6 +30,9 @@ module Linguist
       @repository = repo
       @commit_oid = commit_oid
 
+      @old_commit_oid = nil
+      @old_stats = nil
+
       raise TypeError, 'commit_oid must be a commit SHA1' unless commit_oid.is_a?(String)
     end
 

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -42,10 +42,10 @@ module Linguist
       return unless script
 
       # "python2.6" -> "python2"
-      script.sub! /(\.\d+)$/, ''
+      script.sub!(/(\.\d+)$/, '')
 
       # #! perl -> perl
-      script.sub! /^#!\s*/, ''
+      script.sub!(/^#!\s*/, '')
 
       # Check for multiline shebang hacks that call `exec`
       if script == 'sh' &&

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -132,7 +132,7 @@ class TestBlob < Minitest::Test
   end
 
   def test_csv
-    assert fixture_blob_memory("Data/cars.csv").csv?
+    assert sample_blob_memory("CSV/cars.csv").csv?
   end
 
   def test_pdf

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -1,6 +1,6 @@
 require_relative "./helper"
 
-class TestBlob < Minitest::Test
+class TestFileBlob < Minitest::Test
   include Linguist
 
   def setup

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -81,7 +81,7 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_vendored?
     attr_commit = '351c1cc8fd57340839bdb400d7812332af80e9bd'
-    repo = linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).read_index
 
     override_vendored = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'Gemfile')
 
@@ -91,7 +91,7 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_unvendored?
     attr_commit = '351c1cc8fd57340839bdb400d7812332af80e9bd'
-    repo = linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).read_index
 
     # lib/linguist/vendor.yml defines this as vendored.
     override_unvendored = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'test/fixtures/foo.rb')
@@ -102,7 +102,7 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_documentation?
     attr_commit = "d4c8fb8a28e91f97a7e53428a365c0abbac36d3d"
-    repo = linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).read_index
 
     readme = Linguist::LazyBlob.new(rugged_repository, attr_commit, "README.md")
     arduino = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/Arduino/hello.ino")
@@ -114,7 +114,7 @@ class TestRepository < Minitest::Test
 
   def test_linguist_override_generated?
     attr_commit = "351c1cc8fd57340839bdb400d7812332af80e9bd"
-    repo = linguist_repo(attr_commit).read_index
+    linguist_repo(attr_commit).read_index
 
     rakefile = Linguist::LazyBlob.new(rugged_repository, attr_commit, "Rakefile")
 


### PR DESCRIPTION
This pull request fixes many warnings in tests.
Examples of these warnings can be seen in [recent Travis builds](https://travis-ci.org/github/linguist/jobs/117110750).

There are still a couple warnings I wasn't able to fix. In particular, `warning: setting Encoding.default_external` requires us to pass the external string encoding as an argument when calling Ruby. I'm not sure how to do that in tests.

