### PR TITLE
Add ReSharper's .dotsettings to the list of XML files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3847,6 +3847,7 @@ XML:
   - .ditamap
   - .ditaval
   - .dll.config
+  - .dotsettings
   - .filters
   - .fsproj
   - .fxml


### PR DESCRIPTION
Examples of where this would be useful: https://github.com/search?p=1&q=extension%3ADotSettings+xml&type=Code&utf8=%E2%9C%93