### PR TITLE
Add MSBuild's .proj to the list of XML files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3870,6 +3870,7 @@ XML:
   - .osm
   - .plist
   - .pluginspec
+  - .proj
   - .props
   - .ps1xml
   - .psc1


### PR DESCRIPTION
In addition to filetypes like `.csproj` and `.fsproj`, plain old `.proj` can also be used for building MSBuild-based projects.

[Here's](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aproj+Project+msbuild&type=Code&ref=searchresults) an example of some code that would benefit from this, which appears to be about 24k files. In contrast, if you look at `.proj` files that [are not XML](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aproj+NOT+Project&type=Code&ref=searchresults), most of them appear to be binary.

cc: @arfon 
