### PR TITLE
Add App.config + NuGet.config to the XML file list

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3916,6 +3916,8 @@ XML:
   filenames:
   - .classpath
   - .project
+  - App.config
+  - NuGet.config
   - Settings.StyleCop
   - Web.Debug.config
   - Web.Release.config

--- a/test/fixtures/Data/app.config
+++ b/test/fixtures/Data/app.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+  </startup>
+</configuration>


### PR DESCRIPTION
#### Changes

- Files named `App.config` and `NuGet.config` have been added to the list of XML files.

#### Rationale

- There are [virtually no](https://github.com/search?utf8=%E2%9C%93&q=filename%3ANuGet.config+NOT+xml+NOT+config+NOT+settings+NOT+configuration+NOT+solution&type=Code&ref=searchresults) files on GitHub named `NuGet.config` that aren't XML.

- There are about [32k](https://github.com/search?utf8=%E2%9C%93&q=filename%3AApp.config+NOT+xml+NOT+version+NOT+configuration&type=Code&ref=searchresults) files named `App.config` that aren't related to .NET projects, and approximately [926k](https://github.com/search?utf8=%E2%9C%93&q=filename%3AApp.config&type=Code&ref=searchresults) that are.

cc: @arfon (sorry if I spammed your inbox haha :smile:)