### PR TITLE
Add .clang-format as a YAML file

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4000,6 +4000,8 @@ YAML:
   - .syntax
   - .yaml
   - .yaml-tmlanguage
+  filenames:
+  - .clang-format
   ace_mode: yaml
 
 YANG:

--- a/samples/YAML/filenames/.clang-format
+++ b/samples/YAML/filenames/.clang-format
@@ -1,0 +1,18 @@
+---
+# We'll use defaults from the LLVM style, but with 4 columns indentation.
+BasedOnStyle: LLVM
+IndentWidth: 4
+---
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+---
+Language: JavaScript
+# Use 100 columns for JS.
+ColumnLimit: 100
+---
+Language: Proto
+# Don't format .proto files.
+DisableFormat: true
+...


### PR DESCRIPTION
According to [clang-format documentation](http://clang.llvm.org/docs/ClangFormatStyleOptions.html) the .clang-format file is a YAML file.

[Site-wide usage](https://github.com/search?utf8=%E2%9C%93&q=filename%3A.clang-format+NOT+nothack&type=Code&ref=searchresults)