### PR TITLE
Add ".es" to recognised ECMAScript extensions

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -127,6 +127,14 @@ module Linguist
         Language["ECL"]
       end
     end
+    
+    disambiguate ".es" do |data|
+      if /^\s*(?:%%|main\s*\(.*?\)\s*->)/.match(data)
+        Language["Erlang"]
+      elsif /(?:\/\/|("|')use strict\1|export\s+default\s|\/\*.*?\*\/)/m.match(data)
+        Language["JavaScript"]
+      end
+    end
 
     disambiguate ".for", ".f" do |data|
       if /^: /.match(data)

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1694,6 +1694,7 @@ JavaScript:
   - .js
   - ._js
   - .bones
+  - .es
   - .es6
   - .frag
   - .gs

--- a/samples/Erlang/170-os-daemons.es
+++ b/samples/Erlang/170-os-daemons.es
@@ -1,0 +1,26 @@
+#! /usr/bin/env escript
+
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+loop() ->
+	loop(io:read("")).
+
+loop({ok, _}) ->
+	loop(io:read(""));
+loop(eof) ->
+	stop;
+loop({error, Reason}) ->
+	throw({error, Reason}).
+
+main([]) ->
+	loop().

--- a/samples/Erlang/release
+++ b/samples/Erlang/release
@@ -1,3 +1,4 @@
+#!/usr/bin/env escript
 %%!
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
 % ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:

--- a/samples/Erlang/release.es
+++ b/samples/Erlang/release.es
@@ -1,4 +1,3 @@
-#!/usr/bin/env escript
 %%!
 %-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
 % ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
@@ -119,4 +118,3 @@ execute_overlay([{copy, In, Out} | Rest], Vars, BaseDir, TargetDir) ->
 
 exit_code(ExitCode) ->
     erlang:halt(ExitCode, [{flush, true}]).
-

--- a/samples/Erlang/single-context.es
+++ b/samples/Erlang/single-context.es
@@ -1,0 +1,104 @@
+#! /usr/bin/env escript
+% This file is part of Emonk released under the MIT license. 
+% See the LICENSE file for more information.
+
+main([]) ->
+	start(64, 1000);
+main([N]) ->
+	start(list_to_integer(N), 1000);
+main([N, M]) ->
+	start(list_to_integer(N), list_to_integer(M)).
+
+
+start(N, M) ->
+	code:add_pathz("test"),
+	code:add_pathz("ebin"),
+	{ok, Ctx} = emonk:create_ctx(),
+	{ok, undefined} = emonk:eval(Ctx, js()),
+	run(Ctx, N, M),
+	wait(N).
+
+run(_, 0, _) ->
+	ok;
+run(Ctx, N, M) ->
+	Self = self(),
+	Pid = spawn(fun() -> do_js(Self, Ctx, M) end),
+	io:format("Spawned: ~p~n", [Pid]),
+	run(Ctx, N-1, M).
+
+wait(0) ->
+	ok;
+wait(N) ->
+	receive
+		{finished, Pid} -> ok
+	end,
+	io:format("Finished: ~p~n", [Pid]),
+	wait(N-1).
+
+do_js(Parent, _, 0) ->
+	Parent ! {finished, self()};
+do_js(Parent, Ctx, M) ->
+	io:format("Running: ~p~n", [M]),
+	Test = random_test(),
+	{ok, [Resp]} = emonk:call(Ctx, <<"f">>, [Test]),
+	Sorted = sort(Resp),
+	true = Test == Sorted,
+	do_js(Parent, Ctx, M-1).
+
+js() -> 
+	<<"var f = function(x) {return [x];};">>.
+
+random_test() ->
+	Tests = [
+		null,
+		true,
+		false,
+		1,
+		-1,
+		3.1416,
+		-3.1416,
+		12.0e10,
+		1.234E+10,
+		-1.234E-10,
+		10.0,
+		123.456,
+		10.0,
+		<<"foo">>,
+		<<"foo", 5, "bar">>,
+		<<"">>,
+		<<"\n\n\n">>,
+		<<"\" \b\f\r\n\t\"">>,
+		{[]},
+		{[{<<"foo">>, <<"bar">>}]},
+		{[{<<"foo">>, <<"bar">>}, {<<"baz">>, 123}]},
+		[],
+		[[]],
+		[1, <<"foo">>],
+		{[{<<"foo">>, [123]}]},
+		{[{<<"foo">>, [1, 2, 3]}]},
+		{[{<<"foo">>, {[{<<"bar">>, true}]}}]},
+		{[
+			{<<"foo">>, []},
+			{<<"bar">>, {[{<<"baz">>, true}]}}, {<<"alice">>, <<"bob">>}
+		]},
+		[-123, <<"foo">>, {[{<<"bar">>, []}]}, null]
+	],
+	{_, [Test | _]} = lists:split(random:uniform(length(Tests)) - 1, Tests),
+	sort(Test).
+
+sort({Props}) ->
+	objsort(Props, []);
+sort(List) when is_list(List) ->
+	lstsort(List, []);
+sort(Other) ->
+	Other.
+
+objsort([], Acc) ->
+	{lists:sort(Acc)};
+objsort([{K,V} | Rest], Acc) ->
+	objsort(Rest, [{K, sort(V)} | Acc]).
+
+lstsort([], Acc) ->
+	lists:reverse(Acc);
+lstsort([Val | Rest], Acc) ->
+	lstsort(Rest, [sort(Val) | Acc]).

--- a/samples/JavaScript/axios.es
+++ b/samples/JavaScript/axios.es
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export default {
+	async getIndex(prefix) {
+		const {data} = await axios.get((prefix || "") + "/index.json");
+		return data;
+	},
+	
+	async getContent(path, prefix) {
+		const {data} = await axios.get((prefix || "") + "/" + path + ".json");
+		return data;
+	}
+}

--- a/samples/JavaScript/index.es
+++ b/samples/JavaScript/index.es
@@ -1,0 +1,35 @@
+import config from "../webpack.config";
+import webpackDevMiddleware from "webpack-dev-middleware";
+import webpackHot from "webpack-hot-middleware";
+import webpack from "webpack";
+import express from "express";
+
+app.use(webpackDevMiddleware(compiler, {
+	noInfo: false,
+	quiet: false,
+	publicPath: config.output.publicPath,
+	hot: true,
+	historyApiFallback: true
+}));
+	
+app.get("/(:root).json", (req, resp) => {
+	resp.send(indexer.index(req.params.root));
+});
+
+export default function(){
+	const server = http.createServer(app);
+	
+	server.listen(3000);
+	
+	const wss = new WebSocketServer({server});
+	
+	let id = 1;
+	wss.on("connection", (ws) => {
+		console.log("Hello", " world");
+		let wsId = id++;
+		sessions[wsId] = ws;
+		ws.on("close", () => {
+			delete sessions[wsId]
+		});
+	});
+};

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -83,6 +83,13 @@ class TestHeuristcs < Minitest::Test
       "ECLiPSe" => all_fixtures("ECLiPSe", "*.ecl")
     })
   end
+  
+  def test_es_by_heuristics
+    assert_heuristics({
+      "Erlang" => all_fixtures("Erlang", "*.es"),
+      "JavaScript" => all_fixtures("JavaScript", "*.es")
+    })
+  end
 
   def test_f_by_heuristics
     assert_heuristics({


### PR DESCRIPTION
The usage of `.es` as a JavaScript file extension has grown in recent times, undoubtedly due to the influx of transpilers. However, GitHub currently misclassifies these files as Erlang scripts; this PR remedies that.

The heuristic
-------------
I don't know a single word of Erlang, but it appears that `.es` files ("Erlang scripts") are an interpreted form of the language which requires an author to define a routine named `main` in the source. From the [official documentation](http://erlang.org/doc/man/escript.html):

> An Erlang script file must always contain the function **main/1**. When the script is run, the `main/1` function will be called with a list of strings representing the arguments given to the script (not changed or interpreted in any way).

I deduced that Erlang scripts could be identified by `main([]) ->`, which is also illegal JavaScript.

I extended the heuristic to check for lines beginning with `%%`. While Erlang uses `%` to initiate a comment, the doubled form is also abundant. It's also the required form of passing arguments to the emulator. To quote the docs I linked to above:

> Such an argument line must start with `%%!` and the rest of the line will interpreted as arguments to the emulator.

While it's unlikely a JavaScript file would have a modulus operator at the start of a line, it isn't invalid syntax. For instance, this is legal JavaScript (albeit really weird):
```js
let a = 2
% 1;
```

Results
----------
Not surprisingly, most search results for `.es` yielded files [localised](https://github.com/Alhadis/Linguist-Heuristics/tree/es/fixtures/Unrelated/Espa%C3%B1ol) in Spanish (esto es un buen lingüista, jajaja). All but two of the ~2,777 files collected from [search results](https://github.com/search?q=extension%3Aes+NOT+nothack&type=Code) were [correctly identified](https://github.com/Alhadis/Linguist-Heuristics/blob/es/results.txt) as either ECMAScript or Erlang:

**[App.2.es:](https://raw.githubusercontent.com/embedthis/ejscript/f85405f5c25a3335a9bf4f4a249e5f3eaf225081/samples/web/mvc-blog/blog/src/App.es)**
```js
module App {
}
```

**[locale.js.es:](https://github.com/delsovalle/prometeus/blob/d79577ff8aee2b14053e3be9f18497363fe37d30/synoman/phpsrc/web/js/locale.js.es)**
```
_={"a":"No se encuentra la página","b":"Lo sentimos, no se encuentra la página que está buscando.","c":"Anterior"};
```

I don't think those two edge cases are really worth the trouble of bloating the heuristic for. For a start, the first one isn't even real JavaScript (but a mutated superset called [Embedthis Ejscript](https://github.com/embedthis/ejscript/)). As for the second, well, I'd be lying if I said I see something like that every day.