### PR TITLE
Fix protocol of Nix submodule's URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -700,4 +700,4 @@
 	url = https://github.com/zmthy/grace-tmbundle
 [submodule "vendor/grammars/nix"]
 	path = vendor/grammars/nix
-	url = git@github.com:wmertens/sublime-nix.git
+	url = https://github.com/wmertens/sublime-nix


### PR DESCRIPTION
While working on #2920, I noticed the [tests were failing](http://pastebin.com/VcwcrgVF) because one of the submodules didn't have a URL that used the HTTPS protocol. I checked the repository's recent commit history, and noticed [this was the culprit](https://github.com/github/linguist/commit/bd0f4f6f78).
