### PR TITLE
Add ISC to license whitelist

### DIFF
--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -15,6 +15,7 @@ class TestGrammars < Minitest::Test
     apache-2.0
     bsd-2-clause
     bsd-3-clause
+    isc
     mit
     mpl-2.0
     public

--- a/vendor/licenses/config.yml
+++ b/vendor/licenses/config.yml
@@ -4,6 +4,7 @@ whitelist:
   - bsd-3-clause
   - permissive
   - mit
+  - isc
   - mpl-2.0
   - unlicense
   - wtfpl


### PR DESCRIPTION
I asked about the license's inclusion in a [line note](https://github.com/github/linguist/commit/16a6d680c423b177787f58980d5241f3d6e83129#commitcomment-16910733), but it's probably more relevant to bring it up in the form of a pull request.

The [ISC license](https://en.wikipedia.org/wiki/ISC_license) is a permissive, OSI-approved free software license that's functionally identical to the MIT/Expat license. The only "difference" is the ISC license excludes legal clauses that're already covered by the [Berne Convention](https://en.wikipedia.org/wiki/Berne_Convention).

The ISC license is [recommended by OpenBSD](http://www.openbsd.org/policy.html), and is also the default license type of newly-created NPM modules. The terseness and straightforwardness of the clauses make it (in my opinion, anyway) a preferable alternative to the decidedly long-winded MIT license.

---------------------------
**TL;DR:** [Same](http://choosealicense.com/licenses/isc/) [shit](http://choosealicense.com/licenses/mit/), different TLA.

Basically, I was surprised when Linguist's tests rejected the addition of a grammar addition, stating that ISC wasn't on the license whitelist.