### PR TITLE
Add .BUILD extension to Python languages

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2879,6 +2879,7 @@ Python:
   ace_mode: python
   color: "#3572A5"
   extensions:
+  - .BUILD
   - .py
   - .bzl
   - .cgi


### PR DESCRIPTION
You'll notice that files named `BUILD` are already supported, which is for [Bazel](https://github.com/bazelbuild/bazel). But there are also situations where BUILD files might be named something like [closure_library.BUILD](https://github.com/bazelbuild/rules_closure/blob/master/closure/library/closure_library.BUILD). We'd like to have those syntax highlighted too.

CC: @Dominator008 