### PR TITLE
Add "mkfile" as a recognised Makefile name

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2068,6 +2068,7 @@ Makefile:
   - .mak
   - .d
   - .mk
+  - .mkfile
   filenames:
   - GNUmakefile
   - Kbuild
@@ -2076,6 +2077,7 @@ Makefile:
   - Makefile.in
   - Makefile.inc
   - makefile
+  - mkfile
   interpreters:
   - make
   ace_mode: makefile

--- a/samples/Makefile/filenames/mkfile
+++ b/samples/Makefile/filenames/mkfile
@@ -1,0 +1,25 @@
+TYPE=gemstones
+GEM=amethyst bloodstone citrine emerald garnet jade lapis-lazuli moonstone opal perl ruby sapphire topaz unakite variscite wernerite xanthite yttrotitanite zincostaurolite
+
+all:G:
+	cd /sys/log
+	gem=`{date|sed 's/(^[^ ]*) .*/\1/'}
+	for(i in $GEM){
+		if(test -e $i){
+			mv $i $i.$gem
+		}
+		rm -f $i
+		> $i
+		cp $i $0
+	}
+	for(i in $GEMS){
+		if(test -e $i){
+			cp $i $i.$gem
+		}
+		rm -f $i
+	}
+
+polish:GS:
+	for(i in $GEMS){
+		usr/bin/polish /tmp/gemstone/$i /tmp/gemstone/$i &
+	}

--- a/samples/Makefile/filenames/mkfile
+++ b/samples/Makefile/filenames/mkfile
@@ -1,25 +1,9 @@
-TYPE=gemstones
-GEM=amethyst bloodstone citrine emerald garnet jade lapis-lazuli moonstone opal perl ruby sapphire topaz unakite variscite wernerite xanthite yttrotitanite zincostaurolite
+GREETINGS=hello gday bonjour hola ola kaixo tag hoi konnichiwa nihao dobredan namaste salaam
 
-all:G:
-	cd /sys/log
-	gem=`{date|sed 's/(^[^ ]*) .*/\1/'}
-	for(i in $GEM){
-		if(test -e $i){
-			mv $i $i.$gem
-		}
-		rm -f $i
-		> $i
-		cp $i $0
-	}
-	for(i in $GEMS){
-		if(test -e $i){
-			cp $i $i.$gem
-		}
-		rm -f $i
-	}
+all:V:
+	mk greet.^($GREETINGS)
+	for(i in $GREETINGS)
+		mk $i
 
-polish:GS:
-	for(i in $GEMS){
-		usr/bin/polish /tmp/gemstone/$i /tmp/gemstone/$i &
-	}
+greet.%: text-folder
+	/n/$printer $stem >[2=1]


### PR DESCRIPTION
Some older Unix-like systems used the name `mkfile` for their system's Makefiles - most notably [Plan 9](https://github.com/codesrxxx/plan9_source/blob/master/sys/src/mkfile). A search result for `mkfile` yields a whooping [+32k results](https://github.com/search?utf8=%E2%9C%93&q=filename%3Amkfile&type=Code&ref=searchresults), many of which are probably copies of distributed source code.

There're also about [~116 matches](https://github.com/search?q=extension%3Amkfile+NOT+nothack&type=Code) for `mkfile` in GitHub's file extension search, so it probably warrants inclusion as a file extension addition too.

People seemed rather laid-back about file extensions in those days...