### PR TITLE
Added Django env folder to Vendors

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -183,7 +183,8 @@
 # Knockout
 - (^|/)knockout-(\d+\.){3}(debug\.)?js$
 
-## Python ##
+# Python and Django
+- ^env/
 
 # Sphinx
 - (^|/)docs?/_?(build|themes?|templates?|static)/

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -183,14 +183,14 @@
 # Knockout
 - (^|/)knockout-(\d+\.){3}(debug\.)?js$
 
-# Python and Django
-- ^env/
+## Python ##
 
 # Sphinx
 - (^|/)docs?/_?(build|themes?|templates?|static)/
 
 # django
 - (^|/)admin_media/
+- (^|/)env/
 
 # Fabric
 - ^fabfile\.py$


### PR DESCRIPTION
The Python local environment folder stores all the dependencies of the project like django, pillow and other libraries in Reqirements.txt. Since those are 3rd party apps and libraries, they should be excluded from the language statistics. So the python **env folder** has been added to vendors.yml.