### PR TITLE
Add .php_cs to PHP files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2582,6 +2582,7 @@ PHP:
   - .php5
   - .phps
   - .phpt
+  - .php_cs
   filenames:
   - Phakefile
   interpreters:


### PR DESCRIPTION
`.php_cs` is the default configuration for [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) which is a PHP file.

Example of a file where the PHP code should be highlighted on GitHub, but it isn't: https://github.com/composer/composer/blob/3b0a1c6f702d81600e1ac2c8fa7cbaf816e88d12/.php_cs