### PR TITLE
Grammar for AutoIt from Sublime Text package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -710,3 +710,6 @@
 [submodule "vendor/grammars/language-graphql"]
 	path = vendor/grammars/language-graphql
 	url = https://github.com/rmosolgo/language-graphql
+[submodule "vendor/grammars/sublime-autoit"]
+	path = vendor/grammars/sublime-autoit
+	url = https://github.com/AutoIt/SublimeAutoItScript

--- a/grammars.yml
+++ b/grammars.yml
@@ -512,6 +512,8 @@ vendor/grammars/sublime-MuPAD:
 - source.mupad
 vendor/grammars/sublime-aspectj/:
 - source.aspectj
+vendor/grammars/sublime-autoit/:
+- source.autoit
 vendor/grammars/sublime-befunge:
 - source.befunge
 vendor/grammars/sublime-bsv:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -260,7 +260,7 @@ AutoIt:
   - AutoItScript
   extensions:
   - .au3
-  tm_scope: none
+  tm_scope: source.autoit
   ace_mode: autohotkey
 
 Awk:

--- a/vendor/licenses/grammar/sublime-autoit.txt
+++ b/vendor/licenses/grammar/sublime-autoit.txt
@@ -1,0 +1,12 @@
+---
+type: grammar
+name: sublime-autoit
+license: mit
+---
+Copyright (c) 2016 AutoIt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This pull request adds a grammar for AutoIt ([demonstration on Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2FAutoIt%2FSublimeAutoItScript%2Fblob%2Fmaster%2FAutoIt.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2FTheDcoder%2FIRC-Bot-Base-for-AutoIt%2Fblob%2Fmaster%2FBot.au3&code=)).

/cc @TheDCoder