### PR TITLE
Add .app.src as Erlang extension.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -948,6 +948,7 @@ Erlang:
   color: "#B83998"
   extensions:
   - .erl
+  - .app.src
   - .es
   - .escript
   - .hrl

--- a/samples/Erlang/sample.app.src
+++ b/samples/Erlang/sample.app.src
@@ -1,0 +1,8 @@
+{application, sample,
+ [{description, "sample app"},
+  {vsn, "1.0.0"},
+  {registered, []},
+  {mod, {sample_app, []}},
+  {applications, [kernel, stdlib]},
+  {env, []},
+  {modules, []}]}.


### PR DESCRIPTION
*.app.src is a convention that modern build tools use as input to describe an Erlang application.

In-the-wild search doesn't pull up any results, I think due to the period in the extension, but it should be popular among Erlang projects.