### PR TITLE
Remove Terra from Lua group

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3600,7 +3600,6 @@ Terra:
   - .t
   color: "#00004c"
   ace_mode: lua
-  group: Lua
   interpreters:
   - lua
 


### PR DESCRIPTION
This pull request removes Terra from the Lua group, as discussed in #2975. Although closely related, Terra and Lua are two separate languages.