### PR TITLE
Heuristic for .inc PHP files

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -187,6 +187,12 @@ module Linguist
       end
     end
 
+    disambiguate ".inc" do |data|
+      if /^<\?(?:php)?/.match(data)
+        Language["PHP"]
+      end
+    end
+
     disambiguate ".l" do |data|
       if /\(def(un|macro)\s/.match(data)
         Language["Common Lisp"]

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -122,6 +122,12 @@ class TestHeuristcs < Minitest::Test
     })
   end
 
+  def test_inc_by_heuristics
+    assert_heuristics({
+      "PHP" => all_fixtures("PHP", "*.inc")
+    })
+  end
+
   def test_ls_by_heuristics
     assert_heuristics({
       "LiveScript" => all_fixtures("LiveScript", "*.ls"),


### PR DESCRIPTION
This pull request adds a heuristic rule for `.inc` PHP files, as discussed in #2972.

Files | PHP | C++ | SourcePawn
---|---|---|---
[2,879 files previously detected as C++](https://github.com/search?l=cpp&q=extension%3Ainc+NOT+dkfjdkjkg&ref=searchresults&type=Code&utf8=%E2%9C%93) | 92.22% | 7.78% | 0% | 0%
[2,891 files previously detected as SourcePawn](https://github.com/search?l=sourcepawn&q=extension%3Ainc+NOT+dkfjdkjkg&ref=searchresults&type=Code&utf8=%E2%9C%93) | 86.13% | 0.01% | 13.86%