### PR TITLE
Detect .js files with source maps as generated

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -59,6 +59,7 @@ module Linguist
       godeps? ||
       generated_by_zephir? ||
       minified_files? ||
+      has_source_map? ||
       source_map? ||
       compiled_coffeescript? ||
       generated_parser? ||
@@ -102,6 +103,21 @@ module Linguist
       else
         false
       end
+    end
+
+    # Internal: Does the blob contain a source map reference?
+    #
+    # We assume that if one of the last 2 lines starts with a source map
+    # reference, then the current file was generated from other files.
+    # 
+    # We use the last 2 lines because the last line might be empty.
+    # 
+    # We only handle JavaScript, no CSS support yet.
+    # 
+    # Returns true or false.
+    def has_source_map?
+      return false unless extname.downcase == '.js'
+      lines.last(2).any? { |line| line.start_with?('//# sourceMappingURL') }
     end
 
     # Internal: Is the blob a generated source map?

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -63,6 +63,9 @@ class TestGenerated < Minitest::Test
     # Minified files
     generated_sample_loading_data("JavaScript/jquery-1.6.1.min.js")
 
+    # JS files with source map reference
+    generated_sample_loading_data("JavaScript/namespace.js")
+
     # Source Map
     generated_fixture_without_loading_data("Data/bootstrap.css.map")
     generated_fixture_loading_data("Data/sourcemap.v3.map")

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -17,6 +17,7 @@ class TestGenerated < Minitest::Test
     assert_raises(DataLoadedError, "Data wasn't loaded when calling generated? on #{blob}") do
       Generated.generated?(blob, lambda { raise DataLoadedError.new })
     end
+    assert Generated.generated?(blob, lambda { IO.read(blob) }), "#{blob} was not recognized as a generated file"
   end
 
   def generated_fixture_without_loading_data(name)


### PR DESCRIPTION
This covers compile-to-JavaScript languages other than CoffeeScript. E.g. it come up in one of our projects for files with JSX code that were compiled to "plain JavaScript" using babel. If the file has a source map reference, it's pretty much by definition generated from another file. :)

This also adds an additional check to the other `generated?` tests. Previously it was possible to comment out the `minified_files? ||` and the tests would still happily pass.