### PR TITLE
Add support for BSDmakefile, .arcconfig, and .JSON-tmLanguage files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1622,6 +1622,7 @@ JSON:
   searchable: false
   extensions:
   - .json
+  - .JSON-tmLanguage
   - .geojson
   - .lock
   - .topojson

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1626,6 +1626,7 @@ JSON:
   - .lock
   - .topojson
   filenames:
+  - .arcconfig
   - .jshintrc
   - composer.lock
   - mcmod.info

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2084,6 +2084,7 @@ Makefile:
   - .mk
   - .mkfile
   filenames:
+  - BSDmakefile
   - GNUmakefile
   - Kbuild
   - Makefile

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1622,8 +1622,8 @@ JSON:
   searchable: false
   extensions:
   - .json
-  - .JSON-tmLanguage
   - .geojson
+  - .JSON-tmLanguage
   - .lock
   - .topojson
   filenames:

--- a/samples/JSON/Git Commit.JSON-tmLanguage
+++ b/samples/JSON/Git Commit.JSON-tmLanguage
@@ -1,0 +1,123 @@
+{
+	"name": "Git Commit Message",
+	"scopeName": "text.git-commit",
+	"fileTypes": [
+		"COMMIT_EDITMSG"
+	],
+	"patterns": [
+		{
+			"name": "comment.line.number-sign.git-commit-message",
+			"begin": "^#",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.comment.git-commit-message"
+				}
+			},
+			"end": "$",
+			"patterns": [
+				{
+					"name": "comment.line.on-branch.git-commit-message",
+					"match": "(?:On branch )([^ ]+)",
+					"captures": {
+						"1": {
+							"name": "support.function.branch.git-commit-message"
+						}
+					}
+				},
+				{
+					"name": "comment.line.on-branch.git-commit-message",
+					"match": "Your branch .* '([^ ']+)'",
+					"captures": {
+						"1": {
+							"name": "support.function.branch.git-commit-message"
+						}
+					}
+				},
+				{
+					"name": "comment.line.untracked.git-commit-message",
+					"begin": " Untracked files:",
+					"beginCaptures": {
+						"0": {
+							"name": "entity.definition.untracked.git-commit-message"
+						}
+					},
+					"end": "^#$",
+					"patterns": [
+						{
+							"name": "comment.line.untracked-file.git-commit-message",
+							"match": "\t(.*)$",
+							"captures": {
+								"1": {
+									"name": "support.function.file-status.git-commit-message"
+								},
+								"2": {
+									"name": "constant.character.branch.git-commit-message"
+								}
+							}
+						}
+					]
+				},
+				{
+					"name": "comment.line.discarded.git-commit-message",
+					"begin": " Change(?:s not staged for commit|d but not updated):",
+					"beginCaptures": {
+						"0": {
+							"name": "entity.definition.discarded.git-commit-message"
+						}
+					},
+					"end": "^#$",
+					"patterns": [
+						{
+							"name": "comment.line.discarded.git-commit-message",
+							"match": "\t([^:]+):(.*)$",
+							"captures": {
+								"1": {
+									"name": "support.function.file-status.git-commit-message"
+								},
+								"2": {
+									"name": "constant.character.branch.git-commit-message"
+								}
+							}
+						}
+					]
+				},
+				{
+					"name": "comment.line.selected.git-commit-message",
+					"begin": " Changes to be committed:",
+					"beginCaptures": {
+						"0": {
+							"name": "entity.definition.selected.git-commit-message"
+						}
+					},
+					"end": "^#$",
+					"patterns": [
+						{
+							"name": "comment.line.selected.git-commit-message",
+							"match": "\t([^:]+):(.*)$",
+							"captures": {
+								"1": {
+									"name": "support.function.file-status.git-commit-message"
+								},
+								"2": {
+									"name": "constant.character.branch.git-commit-message"
+								}
+							}
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "meta.diff.git-commit",
+			"comment": "diff at the end of the commit message when using commit -v, or viewing a log. End pattern is just something to be never matched so that the meta continues untill the end of the file.",
+			"begin": "diff\\ \\-\\-git",
+			"end": "(?=xxxxxx)123457",
+			"patterns": [
+				{
+					"include": "source.diff"
+				}
+			]
+		}
+	],
+	"uuid": "de3fb2fc-e564-4a31-9813-5ee26967c5c8"
+}

--- a/samples/JSON/filenames/.arcconfig
+++ b/samples/JSON/filenames/.arcconfig
@@ -1,0 +1,8 @@
+{
+	"project_id": "example",
+	"conduit_uri": "https://ex.am.pl/",
+	"copyright_holder": "Apache Software Foundation",
+	"arcanist_configuration": "ArcJIRAConfiguration",
+	"phabricator.uri": "https://phabricator.example.com/",
+	"load": ["libs/src"]
+}

--- a/samples/Makefile/filenames/BSDmakefile
+++ b/samples/Makefile/filenames/BSDmakefile
@@ -1,0 +1,11 @@
+# pmake might add -J (private)
+FLAGS=${.MAKEFLAGS:C/\-J ([0-9]+,?)+//W}
+
+all: .DEFAULT
+.DEFAULT:
+	@which gmake > /dev/null 2>&1 ||\
+		(echo "GMake is required for node.js to build.\
+			Install and try again" && exit 1)
+	@gmake ${.FLAGS} ${.TARGETS}
+
+.PHONY: test


### PR DESCRIPTION
This PR is addressing two different languages, so forgive me if this should've been handled in two different pull requests.

 Filename/type | URL | Added as…  | Usage     | Origin of sample
---------------|-----|------------|-----------|-----------------
`.arcconfig`   | [:link:](https://secure.phabricator.com/book/phabricator/article/arcanist_new_project/)   | JSON | [+3,455 results](https://github.com/search?utf8=%E2%9C%93&q=filename%3A.arcconfig+NOT+nothack&type=Code&ref=searchresults) | Hand-written [with reference](https://github.com/yunxing/Hive_optimization/blob/master/.arcconfig)
`.JSON‑tmLanguage` | [:link:](https://forum.sublimetext.com/t/creating-a-new-syntax-definition-stock/5204) | JSON | [+3,120 results](https://github.com/search?q=extension%3A.JSON-tmLanguage+NOT+nothack&type=Code) | [`sublime-text-git`](https://github.com/kemayo/sublime-text-git/blob/master/syntax/Git%20Commit%20Message.JSON-tmLanguage) ([MIT‑licensed](https://github.com/kemayo/sublime-text-git/blob/master/LICENSE))
`BSDmakefile` | n/a | Makefile   | [+2,350 results](https://github.com/search?p=1&q=filename%3ABSDmakefile+NOT+nothack&ref=searchresults&type=Code&utf8=%E2%9C%93) | [NodeJS source](https://github.com/nodejs/node/blob/master/BSDmakefile)

Anything I've missed, please let me know.