### PR TITLE
add .template as an extension for JSON files (for AWS CloudFormation)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1624,6 +1624,7 @@ JSON:
   - .json
   - .geojson
   - .lock
+  - .template
   - .topojson
   filenames:
   - .jshintrc

--- a/samples/JSON/cfnbase.template
+++ b/samples/JSON/cfnbase.template
@@ -1,0 +1,6 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "CloudFormation template file.",
+  "Resources" : {
+  }
+}


### PR DESCRIPTION
AWS CloudFormation uses JSON files ending in .template.

Here's a search: https://github.com/search?utf8=%E2%9C%93&q=extension%3Atemplate+AWSTemplateFormatVersion&type=Code&ref=searchresults