### PR TITLE
Add grammar for CLIPS back

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -719,3 +719,6 @@
 [submodule "vendor/grammars/TLA"]
 	path = vendor/grammars/TLA
 	url = https://github.com/agentultra/TLAGrammar
+[submodule "vendor/grammars/sublime-clips"]
+	path = vendor/grammars/sublime-clips
+	url = https://github.com/psicomante/CLIPS-sublime

--- a/grammars.yml
+++ b/grammars.yml
@@ -524,6 +524,8 @@ vendor/grammars/sublime-bsv:
 - source.bsv
 vendor/grammars/sublime-cirru:
 - source.cirru
+vendor/grammars/sublime-clips/:
+- source.clips
 vendor/grammars/sublime-glsl:
 - source.essl
 - source.glsl

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -457,7 +457,7 @@ CLIPS:
   type: programming
   extensions:
   - .clp
-  tm_scope: none
+  tm_scope: source.clips
   ace_mode: text
 
 CMake:

--- a/vendor/licenses/grammar/sublime-clips.txt
+++ b/vendor/licenses/grammar/sublime-clips.txt
@@ -1,0 +1,13 @@
+---
+type: grammar
+name: sublime-clips
+license: mit
+---
+The MIT License (MIT)
+Copyright (c) 2016 Roberto "Psicomante" Pesando - https://github.com/psicomante/CLIPS-sublime
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This pull request adds back the grammar for CLIPS since it's now under MIT license.
The grammar was removed in #2884.

/cc psicomante/CLIPS-sublime#2