### PR TITLE
Bring back GAS highlighting

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1128,7 +1128,7 @@ GAS:
   extensions:
   - .s
   - .ms
-  tm_scope: none
+  tm_scope: source.assembly
   ace_mode: assembly_x86
 
 GDScript:


### PR DESCRIPTION
`GAS` code currently isn't syntax-highlighted but it should be. This PR fixes that.