### PR TITLE
Add support for the COLLADA file format

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -479,6 +479,13 @@ COBOL:
   - .cpy
   ace_mode: cobol
 
+COLLADA:
+  type: data
+  extensions:
+  - .dae
+  tm_scope: text.xml
+  ace_mode: xml
+
 CSS:
   type: markup
   tm_scope: source.css


### PR DESCRIPTION
[COLLADA](https://en.wikipedia.org/wiki/COLLADA) is a [standardised](http://www.iso.org/iso/catalogue_detail.htm?csnumber=59902) 3D format that uses an XML-based schema for exchanging 3D assets between software packages. They're essentially just an XML file the same way an SVG is, and use the `.dae` (Digital Asset Exchange) file extension.

[Searching for `.dae` files](https://github.com/search?q=extension%3Adae+NOT+nothack&type=Code) yields around 163,200 results, so the format certainly has relevance on GitHub. Heck, [the project itself](https://github.com/khronosGroup/OpenCOLLADA) is hosted here.

I've omitted samples simply because I've moved house, and all my 3D software is on my desktop computer that's not been set back up yet. And, erm, as a 3D artist, it'd be a faux pas to use anybody else's work to demonstrate an example... just saying. Sure you understand.