### PR TITLE
Add "README.1ST" to recognised text-file names

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3669,6 +3669,7 @@ Text:
   - INSTALL
   - LICENSE
   - NEWS
+  - README.1ST
   - README.me
   - click.me
   - delete.me

--- a/samples/Text/filenames/readme.1st
+++ b/samples/Text/filenames/readme.1st
@@ -1,0 +1,42 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt
+volutpat metus, non accumsan tortor convallis id. Headline un oreiller.
+Il est recommandé que la boîte en carton. Micro-ondes et sollicitudin bien.
+
+---------------------------------------------
+Pellentesque sodales lectus ac lorem tempus, non placerat blandit de nisi.
+Phasellus Cursus, eros, et parfois, il est arcu diam mollis felis, ac tempor
+nisl elit quis felis. Morbi nca nisi vel ligula interdum pas l'auteur de, ni
+peur. Mécène voix améliorée. Besoin de tirer gratuitement. Suspendisse
+fermentum convallis metus non blandit. Ac turpis quis de molestie de Mécène.
+Gluten. Donec urna leo, aliquet quis urna et, congue est plein. Pellentesque
+ut pretium erat, rutrum neque tincidunt. Donec hendrerit massa sed sapien
+dapibus ultrices.
+
+==============================================
+Et le porche des Mécène, le prix de la société n'a pas, lacinia justo.
+Pellentesque habitant morbi tristique senectus et Netus et Malesuada fames
+egestas ac turpis. Ut leo mi, feugiat sagittis un ac id Mauris, posuere
+lobortis neque. Non, il n'y avait pas de varius tincidunt pretium.
+
+En effet, nca pur hendrerit pellentesque sapien enim sagittis ipsum, aliquam
+tempor est récolté dans le jeu. Ut sempre egestas ultrices lorem à risus.
+Même arcu dolor, ipsum, ma vie, il a été dit fringilla odio.
+
+
+	- Lorem ipsum eu commodo imperdiet sem
+	- ligula arcu placerat turpis, une
+	- importante lorem nisi eget urna.
+
+Curabitur aliquam accumsan nulla blandit mollis. Celtics à la succession!
+Id ou pas d'alcool. A iaculis Duis consectetur vitae enim. Et magnis dis
+parturiente montes Cras iaculis justo eu libero. Thermal non sapien quis
+nisi Pellentesque placerat. Praesent fringilla diam nisl, nca dignissim
+sem lobortis feugiat. Vivre beaucoup de pauvreté.
+
+Morbi non justo eleifend!
+
+Lacinia lacus fringilla, il fut un temps. Sed dans nunc à une chanson des
+Beatles ou pour décorer. Aeneas de basket-ball de diamètre. Fusce felis à
+partir, pas de pellentesque eget, le stress thermique pulvinar. Etiam
+porta odio sed nibh accumsan tristique. Mécène tincidunt quis justo eget
+porttitor. Jusqu'à ce que l'élément de temps ciblé.


### PR DESCRIPTION
Fairly trivial addition: [there're many readme files](https://github.com/search?q=filename%3AREADME.1st+NOT+nothack&type=Code) using `.1st` as a file extension (to the surprise of nobody). Adding `.1st` as an extension was tempting, but I did find [some](https://github.com/gatesvp/UltimatePsionics/blob/ca037de77cbf16a31f17c6908c734033de10a054/PFRPG_Psionics_Unleashed_Tags.1st) [files](https://github.com/jgshort/jgshort.github.io/blob/be374cfbfad173762d08a73d6d393e3755ccde76/downloads/code/wordptr/fnptrs/test.1st) that obviously weren't pure text, so I've added it as a filename instead.

The contents of the sample are randomly-generated excerpts of [Lorem Ipsum](http://lipsum.com/feed/html) translated into French for the amusement of @pchaigno.