### PR TITLE
Add .appxmanifest to the list of xml files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3924,6 +3924,7 @@ XML:
   extensions:
   - .xml
   - .ant
+  - .appxmanifest
   - .axml
   - .builds
   - .ccxml


### PR DESCRIPTION
Typical Windows Store apps will have a XML-based `.appxmanifest` file for configuring some properties of the app; this PR adds that to the list of XML files in `languages.yml`.

cc @arfon @pchaigno 
