### PR TITLE
Added .pug extension to Jade

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1705,6 +1705,7 @@ Jade:
   type: markup
   extensions:
   - .jade
+  - .pug
   tm_scope: text.jade
   ace_mode: jade
 


### PR DESCRIPTION
**Jade** was recently renamed to **Pug**, including the file extension which is now `.pug`
As documented on their [repo](https://github.com/pugjs/pug).