### PR TITLE
allow `.pug` to be threated as jade

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1705,6 +1705,7 @@ Jade:
   type: markup
   extensions:
   - .jade
+  - .pug
   tm_scope: text.jade
   ace_mode: jade
 

--- a/samples/Jade/hello.pug
+++ b/samples/Jade/hello.pug
@@ -1,0 +1,9 @@
+doctype html
+html
+  head
+    meta(charset='utf-8')
+    link(rel='stylesheet', type='text/css', href='main.css')
+    title Hello Pug
+  body
+    #text
+      include page


### PR DESCRIPTION
Hi,

There is such a thing as Jade template engine that has been recently renamed to Pug due to copyright reasons: https://github.com/pugjs/pug/issues/2184

GitHub perfectly supports syntax highlighting of `.jade` files, but due to this rename the new recommended extension is `.pug`. This patch is a quick fix to support both `.jade` and `.pug`.