### PR TITLE
Add support for the Jazz programming language.

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -357,6 +357,8 @@ vendor/grammars/language-javascript:
 - source.js
 - source.js.regexp
 - source.js.regexp.replacement
+vendor/grammars/language-jazz:
+- source.jazz
 vendor/grammars/language-jsoniq/:
 - source.jq
 - source.xq

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1411,7 +1411,7 @@ HTML+Django:
   - html+jinja
   - htmldjango
   ace_mode: django
-  
+
 HTML+ECR:
   type: markup
   tm_scope: text.html.ecr
@@ -1785,6 +1785,14 @@ Julia:
   - .jl
   color: "#a270ba"
   ace_mode: julia
+
+Jazz:
+  type: programming
+  tm_scope: source.jazz
+  extensions:
+  - .jazz
+  color: "#36b3b5"
+  ace_mode: jazz
 
 Jupyter Notebook:
   type: markup

--- a/samples/Jazz/assert.jazz
+++ b/samples/Jazz/assert.jazz
@@ -1,0 +1,39 @@
+;; Author(s) - Finn Rayment
+;; Version - 1.0
+;; Description - Assertions allow for objects to be compared in a forceful
+;;               manner when it should be assured that the object is equal to
+;;               another.
+static module assert() (
+
+    ;; Import list module.
+    use list
+
+    ;; Throws an assertion error and forces the program to quit.
+    priv func fail(base, compare) (
+        err "Assertion failed comparing " + base " to " + compare + "."
+        exit 1
+    )
+
+    ;; Asserts a single object by comparing it to another.
+    func assert(base, compare) (
+        if (base == compare) (
+            return true
+        )
+        fail(base, compare)
+    )
+
+    ;; Asserts an array to a single object by iterating through all the items
+    ;; and comparing each of them.
+    func assertArray(array, compare) (
+        cast array -> list(?)
+        for ((i = 0) < array.size()) (
+            obj = array.get(i)
+            if (obj != compare) (
+                fail(obj, compare)
+            )
+            i += 1
+        )
+        return true
+    )
+
+)

--- a/samples/Jazz/fibonacci.jazz
+++ b/samples/Jazz/fibonacci.jazz
@@ -1,0 +1,18 @@
+module fibonacci() (
+
+    func run(times) (
+        a = 1
+        b = 1
+        for ((i = 0) < times) (
+            if (a > b) (
+                b += a
+                print b
+            ) else (
+                a += b
+                print a
+            )
+            i += 1
+        )
+    )
+
+)

--- a/samples/Jazz/list.jazz
+++ b/samples/Jazz/list.jazz
@@ -1,0 +1,60 @@
+;; Author(s) - Finn Rayment
+;; Version - 1.0
+;; Description - Lists wrap primitive arrays into basic data structures which
+;;               allow for simplified array manipulation. Lists are dynamic
+;;               and contain no 'constraints' as to how big they can be.
+module list(t) (
+
+    ;; Array. Contains a list of values.
+    priv array = t[]
+	;; Size of the list.
+	priv size = 0
+
+	;; Returns the value located at 'index' from 'array'.
+	func get(index) (
+		cast index -> int
+        if (index > size) (return)
+		return array[index]
+	)
+
+	;; Adds a value to the list at the bottom. (Index-wise)
+	func add(type) (
+		cast type -> t
+		array += t
+        size += 1
+	)
+
+    ;; Checks weather or not the specified value currently exists in the list.
+    func contains(value) (
+        cast value -> t
+        for ((i = 0) < size) (
+            if (array[i] == value) (
+                return true
+            )
+            i += 1
+        )
+        return false
+    )
+
+	;; Removes the value located at the specified index from the array.
+    ;; If it doesn't exist, it will not be removed, instead ignored.
+	func remove(index) (
+		cast index -> int
+		newarray = t[]
+		removed = false
+		for ((i = 0) < size) (
+			if (i != index) (
+    			newarray += array[i]
+			)
+			i += 1
+		)
+		array = newarray
+		if (index < size) (size -= 1)
+	)
+
+	;; Returns the size of the 'array' list.
+	func size() (
+		return size
+	)
+
+)

--- a/samples/Jazz/map.jazz
+++ b/samples/Jazz/map.jazz
@@ -1,0 +1,87 @@
+;; Author(s) - Finn Rayment
+;; Version - 1.0
+;; Description - Maps are an 'associative array' data structure which plot
+;;               entries containing 'keys' which correspond to a 'value'.
+;;               Each map only has one instance of a 'key', while they house
+;;               unlimited instances of 'values'.
+module map(k, v) (
+
+	;; Structure providing entries for the map.
+	;; Contains basic 'key' and 'value' objects.
+	priv struct map_entry(k, v) (
+		key = k
+		value = v
+	)
+
+	;; Map table. Contains 'keys' corresponding to 'values'.
+	priv entries = map_entry(k, v)[]
+	;; Size of 'entries' array.
+	priv size = 0
+
+	;; Returns a value from 'entries' if it contains 'key'. Otherwise, it will
+	;; return 'nil'.
+	func get(key) (
+		cast key -> k
+		for ((i = 0) < size) (
+			if (entries[i].key == key) (
+				return entries[i].value
+			)
+			i += 1
+		)
+	)
+
+	;; Maps a value to the specified key in the table. If the key doesn't
+	;; already exist, it will be created.
+	func put(key, value) (
+		cast key -> k
+		cast value -> v
+		insert = true
+		for ((i = 0) < size) (
+			if (entries[i].key == key) (
+				entries[i].value = value
+				insert = false
+			)
+		 	i += 1
+		)
+		if (insert) (
+			entries += map_entry(key, value)
+			size += 1
+		)
+	)
+
+	;; Checks weather or not the specified key currently exists in the map.
+	func contains(key) (
+		for ((i = 0) < size) (
+			if (entries[i].key == key) (
+				return true
+			)
+			i += 1
+		)
+		return false
+	)
+
+	;; Removes a mapping from the table. If it doesn't exist, it will not be
+	;; removed, instead ignored.
+	func remove(key) (
+		cast key -> k
+		newentries = map_entry(k, v)[]
+		removed = false
+		for ((i = 0) < size) (
+			if (entries[i].key != key) (
+				newentries += entries[i]
+			) else (
+				removed = true
+			)
+			i += 1
+		)
+		entries = newentries
+		if (removed) (size -= 1)
+	)
+
+	;; Returns the size of the 'entries' map.
+	;; This is measured in 'keys', not 'values'.
+	func size() (
+		return size
+	)
+
+)

--- a/samples/Jazz/template.jazz
+++ b/samples/Jazz/template.jazz
@@ -1,0 +1,33 @@
+;; Author(s) - names
+;; Version - version
+;; Description - description
+module moduleName(typeParameters) (
+
+    ;; Primitives.
+	priv integer = 0
+    priv decimal = 3.141592654
+    priv string = "foo"
+    priv character = 'c'
+    priv boolean = false
+
+    ;; Generic structure.
+    priv struct person(p_name, p_age, p_gender) (
+        name = p_name
+        age = p_age
+        gender = p_gender
+    )
+
+	;; Generic function that returns `nil`.
+	func functionNil(args) (
+		cast args -> int
+        args += 1
+	)
+
+    ;; Genreic function that returns a number.
+    func functionReturn(args) (
+        cast args -> int
+        args += 1
+        return args
+    )
+
+)

--- a/vendor/grammars/language-jazz/.gitignore
+++ b/vendor/grammars/language-jazz/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+npm-debug.log
+node_modules

--- a/vendor/grammars/language-jazz/.travis.yml
+++ b/vendor/grammars/language-jazz/.travis.yml
@@ -1,0 +1,35 @@
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+git:
+  depth: 10
+
+sudo: false
+
+os:
+  - linux
+  - osx
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot
+
+branches:
+  only:
+    - master

--- a/vendor/grammars/language-jazz/LICENSE.md
+++ b/vendor/grammars/language-jazz/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Finn Rayment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/grammars/language-jazz/README.md
+++ b/vendor/grammars/language-jazz/README.md
@@ -1,0 +1,6 @@
+# Jazz language support in Atom [![Build Status](https://travis-ci.org/frayment/language-jazz.svg?branch=master)](https://travis-ci.org/frayment/language-jazz)
+
+Adds syntax highlighting and snippets to Jazz files in Atom.
+
+Contributions are greatly appreciated. Please fork this repository and open a
+pull request to add snippets, make grammar tweaks, etc.

--- a/vendor/grammars/language-jazz/grammars/jazz.cson
+++ b/vendor/grammars/language-jazz/grammars/jazz.cson
@@ -1,0 +1,115 @@
+'scopeName': 'source.jazz'
+'name': 'Jazz'
+'fileTypes': [
+    'jazz'
+]
+'patterns': [
+	# Comments.
+	{
+		'match': '(;;(?:.*[^\n])?)'
+		'name': 'comment.line.jazz'
+	}
+    # Integers and decimals.
+	{
+	    'match': '\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))\\b'
+	    'name': 'constant.numeric.jazz'
+	}
+    # Strings.
+	{
+		'begin': '"'
+		'beginCaptures':
+			'0':
+				'name': 'punctuation.definition.string.begin.jazz'
+		'end': '"'
+		'endCaptures':
+			'0':
+				'name': 'punctuation.definition.string.end.jazz'
+		'name': 'string.quoted.double.jazz'
+		'patterns': [
+			{
+				'match': '\\\\.'
+				'name': 'constant.character.escape.jazz'
+			}
+		]
+	}
+    # Characters.
+	{
+		'begin': '\''
+		'beginCaptures':
+			'0':
+				'name': 'punctuation.definition.string.begin.jazz'
+		'end': '\''
+		'endCaptures':
+			'0':
+				'name': 'punctuation.definition.string.end.jazz'
+		'name': 'string.quoted.single.jazz'
+		'patterns': [
+			{
+				'match': '\\\\.'
+				'name': 'constant.character.escape.jazz'
+			}
+		]
+	}
+    # Module declaration.
+	{
+		'match': '(module)(?: \\b([_a-zA-Z][_a-zA-Z0-9]*)\\b(\\((?:(?:[^;\\n]*\\))|(.*)(;;.*[\\)]?))))?'
+		'captures':
+			'1':
+				'name': 'storage.type.jazz'
+			'2':
+				'name': 'entity.name.class.jazz'
+			'3':
+				'name': 'variable.other.jazz'
+			'5':
+				'name': 'comment.line.jazz'
+		'name': 'meta.function.jazz'
+	}
+    # Function/structure declaration.
+	{
+		'match': '(func|struct)(?: \\b([_a-zA-Z][_a-zA-Z0-9]*)\\b(\\((?:(?:[^;\\n]*\\))|(.*)(;;.*[\\)]?))))?'
+		'captures':
+			'1':
+				'name': 'storage.type.jazz'
+			'2':
+				'name': 'entity.name.function.jazz'
+			'3':
+				'name': 'variable.parameter.jazz'
+			'5':
+				'name': 'comment.line.jazz'
+		'name': 'meta.function.jazz'
+	}
+    # Primitives.
+    {
+        'match': '\\b(int|float|char|bool)\\b'
+        'name': 'support.type.jazz'
+    }
+    # Keywords.
+	{
+		'match': '\\b(?:(priv|pub|final|static|native)|(cast|keyword|use)|(for|if|else|return|try|catch|print|err|exit)|(true|false|nil))\\b'
+		'captures':
+			'1':
+				'name': 'storage.modifier.jazz'
+			'2':
+				'name': 'support.type.jazz'
+			'3':
+				'name': 'keyword.control.jazz'
+			'4':
+				'name': 'constant.lanuage.jazz'
+		'name': 'meta.function.jazz'
+	}
+    # Objects.
+    {
+        'match': '\\b([_a-zA-Z][_a-zA-Z0-9]*(?:(?:\\[.*\\])|(?:\\(.*\\))?))\\.([_a-zA-Z][_a-zA-Z0-9]*)\\b'
+        'captures':
+            '1':
+                'name': 'variable.defined.jazz'
+            '2':
+                'name': 'entity.name.function.jazz'
+        'name': 'meta.nestedobject.jazz'
+    }
+    # Special operators.
+    {
+        'match': '->'
+        'name': 'constant.language.jazz'
+    }
+]

--- a/vendor/grammars/language-jazz/language-jazz.cson
+++ b/vendor/grammars/language-jazz/language-jazz.cson
@@ -1,0 +1,40 @@
+'.source.jazz':
+    # Blocks.
+    'module name(generics) ( … )':
+        'prefix': 'module'
+        'body': 'module ${1:name}(${2:generics}) (\n\t$3\n)'
+        'description': 'Generic module block.'
+    'struct name(args) ( … )':
+        'prefix': 'struct'
+        'body': 'struct ${1:name}(${2:args}) (\n\t$3\n)'
+        'description': 'Generic struct block.'
+    'func name(args) ( … )':
+        'prefix': 'func'
+        'body': 'func ${1:name}(${2:args}) (\n\t$3\n)'
+        'description': 'Generic function block.'
+    'for ((definition) condition) ( … )':
+        'prefix': 'for'
+        'body': 'for ((${1:definition}) ${2:condition}) (\n\t$3\n)'
+        'description': 'Generic for-loop.'
+    # Utilities.
+    'cast object -> object':
+        'prefix': 'cast'
+        'body': 'cast ${1:object} -> ${2:object}'
+        'description': 'Cast object to another type.'
+    'keyword name -> object':
+        'prefix': 'key'
+        'body': 'keyword ${1:name} -> ${2:object}'
+        'description': 'Create keyword from another object.'
+    'return object':
+        'prefix': 'return'
+        'body': 'return ${1:object}'
+        'description': 'Return an object from a function.'
+    'variable = value':
+        'prefix': 'var'
+        'body': '${1:variable} = ${2:value}'
+        'description': 'Generic variable definition.'
+    # Other.
+    'func main(args) ( … )':
+        'prefix': 'main'
+        'body': 'func main(args) (\n\t$1\n)'
+        'description': 'Main function for runtime.'

--- a/vendor/grammars/language-jazz/package.json
+++ b/vendor/grammars/language-jazz/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "language-jazz",
+  "version": "0.1.2",
+  "description": "Jazz language support for Atom.",
+  "engines": {
+    "atom": "*"
+  },
+  "dependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/frayment/language-jazz.git"
+  },
+  "bugs": {
+    "url": "https://github.com/frayment/language-jazz/issues"
+  },
+  "license": "MIT"
+}

--- a/vendor/grammars/language-jazz/snippets/language-jazz.cson
+++ b/vendor/grammars/language-jazz/snippets/language-jazz.cson
@@ -1,0 +1,40 @@
+'.source.jazz':
+    # Blocks.
+    'module name(generics) ( … )':
+        'prefix': 'module'
+        'body': 'module ${1:name}(${2:generics}) (\n\t$3\n)'
+        'description': 'Generic module block.'
+    'struct name(args) ( … )':
+        'prefix': 'struct'
+        'body': 'struct ${1:name}(${2:args}) (\n\t$3\n)'
+        'description': 'Generic struct block.'
+    'func name(args) ( … )':
+        'prefix': 'func'
+        'body': 'func ${1:name}(${2:args}) (\n\t$3\n)'
+        'description': 'Generic function block.'
+    'for ((definition) condition) ( … )':
+        'prefix': 'for'
+        'body': 'for ((${1:definition}) ${2:condition}) (\n\t$3\n)'
+        'description': 'Generic for-loop.'
+    # Utilities.
+    'cast object -> object':
+        'prefix': 'cast'
+        'body': 'cast ${1:object} -> ${2:object}'
+        'description': 'Cast object to another type.'
+    'keyword name -> object':
+        'prefix': 'key'
+        'body': 'keyword ${1:name} -> ${2:object}'
+        'description': 'Create keyword from another object.'
+    'return object':
+        'prefix': 'return'
+        'body': 'return ${1:object}'
+        'description': 'Return an object from a function.'
+    'variable = value':
+        'prefix': 'var'
+        'body': '${1:variable} = ${2:value}'
+        'description': 'Generic variable definition.'
+    # Other.
+    'func main(args) ( … )':
+        'prefix': 'main'
+        'body': 'func main(args) (\n\t$1\n)'
+        'description': 'Main function for runtime.'

--- a/vendor/grammars/language-jazz/spec/jazz-spec.coffee
+++ b/vendor/grammars/language-jazz/spec/jazz-spec.coffee
@@ -1,0 +1,51 @@
+describe "Jazz grammar", ->
+    grammar = null
+
+    beforeEach ->
+        waitsForPromise ->
+            atom.packages.activatePackage("language-jazz")
+
+        runs ->
+            grammar = atom.grammars.grammarForScopeName("source.jazz")
+
+    it "parses the grammar", ->
+        expect(grammar).toBeDefined()
+        expect(grammar.scopeName).toBe "source.jazz"
+
+    it "tokenises keywords", ->
+        tokens = grammar.tokenizeLines('func')
+
+        expect(tokens[0][0].value).toBe 'func'
+        expect(tokens[0][0].scopes).toEqual ['source.jazz', 'meta.function.jazz', 'storage.type.jazz']
+
+    it "tokenises comments inside function parameters", ->
+        tokens = grammar.tokenizeLines('func test(arg1, ;; arg2)')
+
+        expect(tokens[0][0].value).toBe 'func'
+        expect(tokens[0][4].scopes).toEqual ['source.jazz', 'meta.function.jazz', 'variable.parameter.jazz', 'comment.line.jazz']
+
+    it "tokenizes multi-line strings", ->
+        tokens = grammar.tokenizeLines('"Hello,\nWorld!"')
+
+        # Line 0
+        expect(tokens[0][0].value).toBe '"'
+        expect(tokens[0][0].scopes).toEqual ['source.jazz', 'string.quoted.double.jazz', 'punctuation.definition.string.begin.jazz']
+
+        expect(tokens[0][1].value).toBe 'Hello,'
+        expect(tokens[0][1].scopes).toEqual ['source.jazz', 'string.quoted.double.jazz']
+
+        expect(tokens[0][3]).not.toBeDefined()
+
+        # Line 1
+        expect(tokens[1][0].value).toBe 'World!'
+        expect(tokens[1][0].scopes).toEqual ['source.jazz', 'string.quoted.double.jazz']
+
+        expect(tokens[1][1].value).toBe '"'
+        expect(tokens[1][1].scopes).toEqual ['source.jazz', 'string.quoted.double.jazz', 'punctuation.definition.string.end.jazz']
+
+        expect(tokens[1][2]).not.toBeDefined()
+
+    it "tokenizes nested object definitions", ->
+        tokens = grammar.tokenizeLines('test.foo')
+
+        expect(tokens[0][1].scopes).toEqual ['source.jazz', 'meta.nestedobject.jazz']


### PR DESCRIPTION
Updated grammars.yml with language support.
Updated languages.yml with language support.
Added language samples to `samples/Jazz`.
Added current version of repository `language-jazz` as a grammar.

"Out-in-the-wild" example (Still being worked on): [`jazz`](https://github.com/frayment/jazz)