### PR TITLE
Adopt Elm language package to elm-community

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -448,7 +448,7 @@
 	url = https://github.com/scalate/Scalate.tmbundle
 [submodule "vendor/grammars/Elm.tmLanguage"]
 	path = vendor/grammars/Elm.tmLanguage
-	url = https://github.com/deadfoxygrandpa/Elm.tmLanguage
+	url = https://github.com/elm-community/Elm.tmLanguage
 [submodule "vendor/grammars/sublime-bsv"]
 	path = vendor/grammars/sublime-bsv
 	url = https://github.com/thotypous/sublime-bsv


### PR DESCRIPTION
On behalf of [elm-community](https://github.com/elm-community/Manifesto) I ask you to use elm-community's [clone](https://github.com/elm-community/Elm.tmLanguage) of [`Elm.tmLanguage`](https://github.com/deadfoxygrandpa/Elm.tmLanguage).

The original author Alex Neslusan @deadfoxygrandpa is unresponsive since 2016-04-10.

There is a [syntax change](https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.17.md#updating-syntax) in Elm language version 0.17 that needs to be reflected in the package's grammar rules. The existing grammar renders most of the new Elm 0.17 source code red for being illegal.

On 2016-04-06 the language creator @evancz [asked](https://github.com/deadfoxygrandpa/Elm.tmLanguage/issues/99) deadfoxygrandpa to update his package for the new syntax. Four days later deadfoxygrandpa promised to do it. Since then deadfoxygrandpa wasn't seen on GitHub or on Elm's mailing lists [elm-discuss](https://groups.google.com/forum/#!forum/elm-discuss) and [elm-dev](https://groups.google.com/forum/#!forum/elm-dev).

See this [PR](https://github.com/deadfoxygrandpa/Elm.tmLanguage/pull/101) for the pending update and corresponding discussion.