### PR TITLE
Fix a dumb typo

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -701,7 +701,7 @@ Cpp-ObjDump:
   - .cxx-objdump
   tm_scope: objdump.x86asm
   aliases:
-  - c++-objdumb
+  - c++-objdump
   ace_mode: assembly_x86
 
 Creole:


### PR DESCRIPTION
That's really [what it is](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L704).

<img src="https://cloud.githubusercontent.com/assets/2346707/15656161/be884e06-26e7-11e6-95f6-673708a3a576.png" width="257" alt="Figure 1" />

I actually bothered to do a Google search, just to see if there was some oddly-named variant or something. Judging from the lack of meaningful results, however, I'd say it's an honest misspelling...