### PR TITLE
Add interpreters for APL and J

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -75,6 +75,10 @@ APL:
   extensions:
   - .apl
   - .dyalog
+  interpreters:
+  - apl
+  - aplx
+  - dyalog
   tm_scope: source.apl
   ace_mode: text
 

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1670,6 +1670,8 @@ J:
   color: "#9EEDFF"
   extensions:
   - .ijs
+  interpreters:
+  - jconsole
   tm_scope: source.j
   ace_mode: text
 

--- a/samples/APL/hashbang
+++ b/samples/APL/hashbang
@@ -1,0 +1,7 @@
+#!/usr/local/bin/apl --script
+NEWLINE ← ⎕UCS 10
+HEADERS ← 'Content-Type: text/plain', NEWLINE
+HEADERS
+⍝ ⎕←HEADERS
+⍝ ⍕⎕TS
+)OFF

--- a/samples/J/hashbang
+++ b/samples/J/hashbang
@@ -1,0 +1,3 @@
+#!/bin/jconsole
+echo 'Hello, GitHub!'
+exit ''


### PR DESCRIPTION
Currently, Linguist doesn't recognise APL or J scripts without file extensions.

### APL
Imagine there's a file named `hashbang` written to run under GNU APL:
```shell
#!/usr/local/bin/apl --script
```
Output of `linguist hashbang`:
```
hashbang: 8 lines (7 sloc)
  type:      Text
  mime type: text/plain
  language:  
```

I'm unsure if [Dyalog](http://dyalog.com/) or [APLX](https://en.wikipedia.org/wiki/APLX) actually allow APL scripts to be run as executables from command-line, but since both programs are commercial and closed source, I'm too poor to fork out the dough to find out... vultures.

The fixture I added for the APL hashbang is a [webserver script](https://github.com/Alhadis/Snippets/commit/b686026f4993) I wrote while wired on energy drinks at some fucked up hour of the morning without sleep.

### J
The language's [Wikipedia page](https://en.wikipedia.org/wiki/J_%28programming_language%29#Examples) lists this as an example script for a Unix-like system:
```shell
#!/bin/jc
echo 'Hello, world!'
exit ''
```
I downloaded the [J installer](http://www.jsoftware.com/download/j804/install/) and found the name of the interpreter is actually `jconsole`. Which I'm guessing is what `jc` in Wikipedia's example erroneously refers to.