### PR TITLE
Add syntax highlighting for the Clean language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -737,3 +737,6 @@
 [submodule "vendor/grammars/Elm"]
 	path = vendor/grammars/Elm
 	url = https://github.com/elm-community/Elm.tmLanguage
+[submodule "vendor/grammars/atom-language-clean"]
+	path = vendor/grammars/atom-language-clean
+	url = https://github.com/timjs/atom-language-clean.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -176,6 +176,8 @@ vendor/grammars/atom-fsharp/:
 - source.fsharp.fsi
 - source.fsharp.fsl
 - source.fsharp.fsx
+vendor/grammars/atom-language-clean:
+- source.clean
 vendor/grammars/atom-language-purescript/:
 - source.purescript
 vendor/grammars/atom-language-stan/:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -571,7 +571,7 @@ Clean:
   extensions:
   - .icl
   - .dcl
-  tm_scope: none
+  tm_scope: source.clean
   ace_mode: text
 
 Click:

--- a/vendor/licenses/grammar/atom-language-clean.txt
+++ b/vendor/licenses/grammar/atom-language-clean.txt
@@ -1,0 +1,25 @@
+---
+type: grammar
+name: atom-language-clean
+license: mit
+---
+Copyright (c) 2015 <Your name here>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
A [language package](https://github.com/timjs/atom-language-clean) for the [Clean programming language](http://clean.cs.ru.nl/) was published to Atom.io earlier tonight. The package is in the hands of one of the language's maintainers, which makes it an obvious choice, even if the site already had highlighting for Clean (which it doesn't).