### PR TITLE
Add npm-shrinkwrap.json to generated files

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -56,6 +56,7 @@ module Linguist
       generated_net_specflow_feature_file? ||
       composer_lock? ||
       node_modules? ||
+      npm_shrinkwrap? ||
       godeps? ||
       generated_by_zephir? ||
       minified_files? ||
@@ -109,11 +110,11 @@ module Linguist
     #
     # We assume that if one of the last 2 lines starts with a source map
     # reference, then the current file was generated from other files.
-    # 
+    #
     # We use the last 2 lines because the last line might be empty.
-    # 
+    #
     # We only handle JavaScript, no CSS support yet.
-    # 
+    #
     # Returns true or false.
     def has_source_map?
       return false unless extname.downcase == '.js'
@@ -303,6 +304,13 @@ module Linguist
       !!name.match(/node_modules\//)
     end
 
+    # Internal: Is the blob a generated npm shrinkwrap file.
+    #
+    # Returns true or false.
+    def npm_shrinkwrap?
+      !!name.match(/npm-shrinkwrap\.json/)
+    end
+
     # Internal: Is the blob part of Godeps/,
     # which are not meant for humans in pull requests.
     #
@@ -355,14 +363,14 @@ module Linguist
     # on the first line.
     #
     # GFortran module files contain:
-    # GFORTRAN module version 'x' created from 
+    # GFORTRAN module version 'x' created from
     # on the first line.
     #
     # Return true of false
     def generated_module?
       return false unless extname == '.mod'
       return false unless lines.count > 1
-      return lines[0].include?("PCBNEW-LibModule-V") || 
+      return lines[0].include?("PCBNEW-LibModule-V") ||
               lines[0].include?("GFORTRAN module version '")
     end
 

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -36,7 +36,7 @@ class TestGenerated < Minitest::Test
     generated_loading_data(File.join(samples_path, name))
   end
 
-  def test_check_generated    
+  def test_check_generated
     # Xcode project files
     generated_sample_without_loading_data("Binary/MainMenu.nib")
     generated_sample_without_loading_data("Dummy/foo.xcworkspacedata")
@@ -50,6 +50,9 @@ class TestGenerated < Minitest::Test
 
     # Node modules
     generated_sample_without_loading_data("Dummy/node_modules/foo.js")
+
+    # npm shrinkwrap file
+    generated_sample_without_loading_data("Dummy/npm-shrinkwrap.json")
 
     # Godep saved dependencies
     generated_sample_without_loading_data("Godeps/Godeps.json")


### PR DESCRIPTION
This file is generated by the `npm shrinkwrap` command. It's large, generated, and has a noisy diff. One example of a similar file - php composer lock files, is already ignored as generated.

Resolves https://github.com/github/linguist/issues/3045.