### PR TITLE
Add heuristic for Perl6 and Turing

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -391,6 +391,14 @@ module Linguist
       end
     end
     
+    disambiguate ".t" do |data|
+      if /^\s*%|^\s*var\s+\w+\s*:\s*\w+/.match(data)
+        Language["Turing"]
+      elsif /^\s*use\s+v6\s*;/.match(data)
+        Language["Perl6"]
+      end
+    end
+    
     disambiguate ".toc" do |data|
       if /^## |@no-lib-strip@/.match(data)
         Language["World of Warcraft Addon Data"]


### PR DESCRIPTION
After running Linguist a few times on Turing repositories in the wild (such as [this one](https://github.com/jbrick/highschool_turing)), I feel it could still benefit from an additional heuristic, even if #3040 greatly improved Linguist's classification of Turing from Perl6.

Turing and Perl6 both use different styles of line-comments (`%` versus `#`, respectively), so the heuristic was easy to add. [Surprisingly](http://i.imgur.com/9Fxm1eT.png), I managed to get Perl6 running to test if `%` was invalid syntax at the start of a line. A glaring error message confirmed that it was indeed invalid syntax:

<img src="https://cloud.githubusercontent.com/assets/2346707/15985281/91dd4d6e-302b-11e6-9728-98d3999a3d09.png" width="432" alt="Figure 1" />

Turing's heuristic also checks for `var {name} : {type}`-like patterns, where `{name}` and `{type}` are sequences of word-characters (`\w`). These lines are unlikely to manifest in Perl 6, which retains Perl 5's method of initialising variables ([`my $a = accum 5;`](https://github.com/perl6/perl6-examples/blob/master/categories/best-of-rosettacode/accumulator-factory.pl#L84)).