### PR TITLE
Add syntax highlighting for Turing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -740,3 +740,6 @@
 [submodule "vendor/grammars/atom-language-clean"]
 	path = vendor/grammars/atom-language-clean
 	url = https://github.com/timjs/atom-language-clean.git
+[submodule "vendor/grammars/language-turing"]
+	path = vendor/grammars/language-turing
+	url = https://github.com/Alhadis/language-turing

--- a/grammars.yml
+++ b/grammars.yml
@@ -386,6 +386,8 @@ vendor/grammars/language-supercollider:
 - source.supercollider
 vendor/grammars/language-toc-wow:
 - source.toc
+vendor/grammars/language-turing:
+- source.turing
 vendor/grammars/language-wavefront:
 - source.wavefront.mtl
 - source.wavefront.obj

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3738,7 +3738,7 @@ Thrift:
 
 Turing:
   type: programming
-  color: "#45f715"
+  color: "#cf142b"
   extensions:
   - .t
   - .tu

--- a/vendor/licenses/grammar/language-turing.txt
+++ b/vendor/licenses/grammar/language-turing.txt
@@ -1,0 +1,18 @@
+---
+type: grammar
+name: language-turing
+license: isc
+---
+Copyright (c) 2016, John Gardner
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
[Turing](https://en.wikipedia.org/wiki/Turing_%28programming_language%29) doesn't have a grammar, [so I wrote one](https://github.com/Alhadis/language-turing).

I've also changed the language's colour from a bright, garish green to a more suitable red:

<img src="https://cloud.githubusercontent.com/assets/2346707/16048751/9a390c72-3298-11e6-9c9a-21a5b0aaa147.png" alt="Figure 1" width="320" /> <img src="https://cloud.githubusercontent.com/assets/2346707/16048765/a7fff564-3298-11e6-8a92-a779c73454df.png" alt="Figure 2" width="320" />

**Rationale:** Red is the colour used in [Turing's logo](https://en.wikipedia.org/wiki/File:Turing_logo.gif), and it also reflects the language's Canadian heritage. The shade of red I picked is the same one used by the [flag of Ontario](https://upload.wikimedia.org/wikipedia/commons/8/88/Flag_of_Ontario.svg), the state where the Turing language was conceived (and continues to be taught).

<img src="https://cloud.githubusercontent.com/assets/2346707/16048966/5b3e66ce-3299-11e6-9356-4f4fe4403dd6.png" alt="Do I get a Turing award for this?" />
