### PR TITLE
Define TextMate grammar scope for Turing

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3742,7 +3742,7 @@ Turing:
   extensions:
   - .t
   - .tu
-  tm_scope: none
+  tm_scope: source.turing
   ace_mode: text
 
 Turtle:


### PR DESCRIPTION
I was clearly too busy cracking witty puns in #3052 to notice [I'd forgotten](https://github.com/github/linguist/pull/3052#issuecomment-226008610) to include the `tm_scope` attribute for Turing (thanks @pchaigno. I've had smoother moments).