### PR TITLE
Add --json option to bin/linguist

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -5,6 +5,7 @@
 #
 require 'linguist'
 require 'rugged'
+require 'json'
 
 path = ARGV[0] || Dir.pwd
 
@@ -16,14 +17,17 @@ end
 
 ARGV.shift
 breakdown = true if ARGV[0] == "--breakdown"
+json_breakdown = true if ARGV[0] == "--json"
 
 if File.directory?(path)
   rugged = Rugged::Repository.new(path)
   repo = Linguist::Repository.new(rugged, rugged.head.target_id)
-  repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
-    percentage = ((size / repo.size.to_f) * 100)
-    percentage = sprintf '%.2f' % percentage
-    puts "%-7s %s" % ["#{percentage}%", language]
+  if !json_breakdown
+    repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
+      percentage = ((size / repo.size.to_f) * 100)
+      percentage = sprintf '%.2f' % percentage
+      puts "%-7s %s" % ["#{percentage}%", language]
+    end
   end
   if breakdown
     puts
@@ -35,6 +39,8 @@ if File.directory?(path)
       end
       puts
     end
+  elsif json_breakdown
+    puts JSON.dump(repo.breakdown_by_file)
   end
 elsif File.file?(path)
   blob = Linguist::FileBlob.new(path, Dir.pwd)


### PR DESCRIPTION
git-linguist requires the current directory to be a git repo, so it is not an option in my case. Thus adding machine-readable output to bin/linguist
