### PR TITLE
Add language colour for Roff

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2875,7 +2875,6 @@ Pony:
 
 PostScript:
   type: markup
-  color: "#da291c"
   extensions:
   - .ps
   - .eps

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1342,6 +1342,7 @@ Graphviz (DOT):
 
 Groff:
   type: markup
+  color: "#ecdebe"
   extensions:
   - .man
   - '.1'

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2875,6 +2875,7 @@ Pony:
 
 PostScript:
   type: markup
+  color: "#da291c"
   extensions:
   - .ps
   - .eps


### PR DESCRIPTION
This PR adds a colour for Roff (incorrectly named "Groff" on GitHub):

<img src="https://cloud.githubusercontent.com/assets/2346707/16231640/7366bec4-380a-11e6-8577-f4ed8242cced.png" width="128" alt="Figure 1" />

I chose a colour to match the look of aged paper, which symbolises both the language's longevity and its importance in authoring documentation/manuals. No canonical implementation of Roff exists which has any branding with distinguishable colours... so I fell back on natural sources as my inspiration.

----

This PR also attempted to add a colour for the PostScript language, which was the same [PANTONE red](https://www.pantone.com/color-finder/485-C) used in Adobe's official branding. [Example](https://www.adobe.com/products/postscript/pdfs/ps3datasheet.pdf):

<img width="612" alt="Figure 2" src="https://cloud.githubusercontent.com/assets/2346707/16231929/c4a51384-380b-11e6-9f4c-56b10d7e0e45.png">

However, the colour-proximity test was blocking every attempt at picking a close enough colour... and even shades that were noticeably different were being rejected. Here's a comparison of the conflicting colours, with the attempted PostScript shades on the right:

<img src="https://cloud.githubusercontent.com/assets/2346707/16232006/19e82d86-380c-11e6-82f5-7b81cb134177.png" width="500" alt="Figure 3" />

This might be attributed to my colour-blindness, but I fail to see how the bottom-right colour could possibly be confused with any of the other shades depicted here.