### PR TITLE
Interpreters for Scheme

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3421,6 +3421,9 @@ Scheme:
   - guile
   - bigloo
   - chicken
+  - csi
+  - gosh
+  - r6rs
   ace_mode: scheme
 
 Scilab:


### PR DESCRIPTION
This pull request adds three new interpreters for Scheme:
- [`cis`](https://github.com/search?utf8=%E2%9C%93&q=usr+bin+env+csi+extension%3Ascm&type=Code&ref=searchresults)
- [`gosh`](https://github.com/search?utf8=%E2%9C%93&q=usr+bin+env+gosh+extension%3Ascm&type=Code&ref=searchresults)
- [`r6rs`](https://github.com/search?utf8=%E2%9C%93&q=r6rs+extension%3Ascm&type=Code&ref=searchresults)

Not sure if there's a requirement of in-the-wild adoption for interpreters (in which case, `cis` might be just).