### PR TITLE
Support for Python console

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3384,6 +3384,15 @@ Python:
   aliases:
   - rusthon
   language_id: 303
+Python console:
+  type: programming
+  group: Python
+  searchable: false
+  aliases:
+  - pycon
+  tm_scope: text.python.console
+  ace_mode: text
+  language_id: 428
 Python traceback:
   type: data
   group: Python


### PR DESCRIPTION
This pull request adds Python console highlighting, as discussed in #1939.

The goal is to enable Python console highlighting in Markdown documents and comments with the `pycon` identifier. Thus, the entry in `languages.yml` doesn't define extensions or filenames.

[Here is an example of the result in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fatom%2Flanguage-python%2Fblob%2Fmaster%2Fgrammars%2Fpython-console.cson&grammar_text=&code_source=from-text&code_url=&code=%3E%3E%3E++try%3A%0D%0A...+++++from+io+import+StringIO%0D%0A...+except+ImportError%3A%0D%0A...+++++from+StringIO+import+StringIO).
