### PR TITLE
Distinguish SASS and CSS

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3403,7 +3403,6 @@ SaltStack:
 Sass:
   type: markup
   tm_scope: source.sass
-  group: CSS
   extensions:
   - .sass
   ace_mode: sass


### PR DESCRIPTION
This pull request makes SASS a language of its own, distinct from CSS.
This change was requested several times in #2933, #3084, #2585 and #2650.
