### PR TITLE
Improve .ts heuristic rule

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -414,7 +414,7 @@ module Linguist
     end
 
     disambiguate ".ts" do |data|
-      if data.include?("<TS ")
+      if data.include?("</TS>")
         Language["XML"]
       else
         Language["TypeScript"]

--- a/samples/XML/translation_en3.ts
+++ b/samples/XML/translation_en3.ts
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE TS>
+<TS>
+<context>
+    <name>Test</name>
+    <message>
+        <source>Message 1</source>
+        <translation>Message 1 (en)</translation>
+    </message>
+    <message>
+        <source>Message 2</source>
+        <translation>Message 2 (en)</translation>
+    </message>
+    <message>
+        <source>Message 3</source>
+        <translation>Message 3 (en)</translation>
+    </message>
+    <message>
+        <source>Message 4</source>
+        <translation>Message 4 (en)</translation>
+    </message>
+    <message>
+        <source>Küchen Möbel</source>
+        <translation>Cooking furniture (en)</translation>
+    </message>
+    <message>
+        <source>Cooking furniture</source>
+        <translation>Küchen Möbel (en)</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
This pull request improves the `.ts` heuristic rule. It's generally better to use the closing TS tag as it cannot contain parameters. I added a sample file to test this change as well.

Fixes #3097.