### PR TITLE
Recognize python typing stub files (*.pyi) as Python

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3014,6 +3014,7 @@ Python:
   - .tac
   - .wsgi
   - .xpy
+  - .pyi
   filenames:
   - BUCK
   - BUILD


### PR DESCRIPTION
See also PEP 484 for details:
https://www.python.org/dev/peps/pep-0484/#stub-files
