### PR TITLE
Remove Lean ACE grammar.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1952,7 +1952,7 @@ Lean:
   extensions:
   - .lean
   - .hlean
-  ace_mode: lean
+  ace_mode: text
 
 Less:
   type: markup


### PR DESCRIPTION
 Because it was deleted in upstream.  Changed to `text`.  