### PR TITLE
Make XML a markup language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4032,7 +4032,7 @@ XC:
   ace_mode: c_cpp
 
 XML:
-  type: data
+  type: markup
   ace_mode: xml
   aliases:
   - rss


### PR DESCRIPTION
XML is, by definition, a markup language, so it should be considered one, in my opinion, by GitHub's linguist. The first sentence of the [Wikipedia page for XML](https://en.wikipedia.org/wiki/XML) is this:

>Extensible Markup Language (XML) is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable.