### PR TITLE
Make PostScript red again

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2931,6 +2931,7 @@ Pony:
 
 PostScript:
   type: markup
+  color: "#da291c"
   extensions:
   - .ps
   - .eps
@@ -3233,7 +3234,7 @@ Rebol:
 
 Red:
   type: programming
-  color: "#ee0000"
+  color: "#f50000"
   extensions:
   - .red
   - .reds
@@ -3478,7 +3479,7 @@ Sass:
 Scala:
   type: programming
   ace_mode: scala
-  color: "#DC322F"
+  color: "#c22d40"
   extensions:
   - .scala
   - .sbt


### PR DESCRIPTION
Second crack at what I tried doing a [couple months ago](https://github.com/github/linguist/pull/3069). This PR sets the colour of PostScript to [PANTONE 485 C](https://www.pantone.com/color-finder/485-C), as per the language's branding. And if there's ANY language whose colours deserve to retain their tonal integrity, it's the language that pretty much pioneered the whole world of desktop publishing.

The conflicting colours (Scala and, uhm, "Red") were pushed apart somewhat. Red was made redder, and Scala was given a desaturated darker shade of red. Scala's change is a bit more noticeable than Red's, but it was [too close to HTML's colour](https://github.com/guardian/membership-frontend) anyway.

I'd show you a "before-and-after", but my Internet connection decided to die as I was looking for a repository that'd show a Red/HTML comparison. I've had to copy+paste this PR message to my phone to post it using my data. Whoever said Australia is the "lucky country" clearly wasn't talking about our fucking Internet.