### PR TITLE
Classify PostScript as a programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2930,7 +2930,7 @@ Pony:
   ace_mode: text
 
 PostScript:
-  type: markup
+  type: programming
   color: "#da291c"
   extensions:
   - .ps


### PR DESCRIPTION
No idea how I missed this the other night in [my other PS-related PR](https://github.com/github/linguist/pull/3141), but I can tell you now, PostScript is definitely not markup. It's a full-blown Turing-complete programming language which just happens to be used primarily for graphical purposes. Wikipedia's entry on [DSLs](https://en.wikipedia.org/wiki/Domain-specific_language) even uses PostScript to describe why the term "Domain-specific language" can be nebulous:

> For example, Perl was originally developed as a text-processing and glue language, for the same domain as AWK and shell scripts, but was mostly used as a general-purpose programming language later on. **By contrast, PostScript is a Turing complete language, and in principle can be used for any task, but in practice is narrowly used as a page description language.**

I don't know if there's any difference between `markup` and `programming` as far as Linguist's classifications are concerned, but I felt impelled to correct this nonetheless. [Here's an example of a program](https://github.com/bwipp/postscriptbarcode) written in PostScript that's written like, uh, a program.