### PR TITLE
List ".opts" as a configuration file format

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1638,6 +1638,7 @@ INI:
   extensions:
   - .ini
   - .cfg
+  - .opts
   - .prefs
   - .pro
   - .properties

--- a/samples/INI/mocha.opts
+++ b/samples/INI/mocha.opts
@@ -1,0 +1,5 @@
+--check-leaks
+--reporter spec
+--require should
+--ui exports
+--grep /^API:/

--- a/samples/INI/spec.opts
+++ b/samples/INI/spec.opts
@@ -1,0 +1,6 @@
+--colour
+--loadby random
+--format profile
+--backtrace
+--exclude "spec/*,gems/*"
+--rails


### PR DESCRIPTION
Years of [`cat` abuse](https://en.wikipedia.org/wiki/Cat_%28Unix%29#Useless_use_of_cat) appear to have silently nurtured an implicit format for storing command-line options [in plain-text](https://github.com/datamapper/dm-aggregates/blob/68a6f29ab3c663a58eec2b5943e2ce538a9a4a2f/spec/spec.opts). I can't say I'm tripping over these things every day on GitHub, but [~510,095 results](https://github.com/search?p=17&q=extension%3Aopts+NOT+nothack&type=Code) with virtually identical syntax convinces me they're worth acknowledging as configuration files.

I've lumped them under the INI umbrella, which seems to be the closest fit. Recall there's no concrete definition of an "INI file" anyway, Windows `.ini` files notwithstanding.

This has been yet another absurdly trivial addition to GitHub Linguist, courtesy of yours truly.

To the [154 groaning watchers](https://github.com/github/linguist/watchers): you're welcome.
