### PR TITLE
Adds support for Line of Code to the linguist executable:

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ project.languages      #=> { "Ruby" => 119387 }
 
 These stats are also printed out by the `linguist` executable. You can use the
 `--breakdown` flag, and the binary will also output the breakdown of files by language.
+If you use the `--loc` flag, it will print out the lines of code by language.
 
 You can try running `linguist` on the root directory in this repository itself:
 
@@ -118,6 +119,10 @@ bin/linguist
 github-linguist.gemspec
 lib/linguist.rb
 …
+
+$ bundle exec linguist --loc
+Ruby: 204865
+Shell: 910
 ```
 
 ## Contributing

--- a/bin/linguist
+++ b/bin/linguist
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # linguist — detect language type for a file, or, given a directory, determine language breakdown
-#     usage: linguist <path> [<--breakdown>]
+#     usage: linguist <path> [<--breakdown> <--loc>]
 #
 require 'linguist'
 require 'rugged'
@@ -13,55 +13,28 @@ if path == "--breakdown"
   path = Dir.pwd
   breakdown = true
 end
+loc = false
+if path == "--loc"
+  path = Dir.pwd
+  loc = true
+end
 
 ARGV.shift
 breakdown = true if ARGV[0] == "--breakdown"
+loc = true if ARGV[0] == "--loc"
 
 if File.directory?(path)
   rugged = Rugged::Repository.new(path)
   repo = Linguist::Repository.new(rugged, rugged.head.target_id)
-  repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
-    percentage = ((size / repo.size.to_f) * 100)
-    percentage = sprintf '%.2f' % percentage
-    puts "%-7s %s" % ["#{percentage}%", language]
-  end
   if breakdown
-    puts
-    file_breakdown = repo.breakdown_by_file
-    file_breakdown.each do |lang, files|
-      puts "#{lang}:"
-      files.each do |file|
-        puts file
-      end
-      puts
-    end
+    Linguist::Presenters::Breakdown.new(repo).present
+  end
+
+  if loc
+    Linguist::Presenters::Loc.new(repo).present
   end
 elsif File.file?(path)
-  blob = Linguist::FileBlob.new(path, Dir.pwd)
-  type = if blob.text?
-    'Text'
-  elsif blob.image?
-    'Image'
-  else
-    'Binary'
-  end
-
-  puts "#{blob.name}: #{blob.loc} lines (#{blob.sloc} sloc)"
-  puts "  type:      #{type}"
-  puts "  mime type: #{blob.mime_type}"
-  puts "  language:  #{blob.language}"
-
-  if blob.large?
-    puts "  blob is too large to be shown"
-  end
-
-  if blob.generated?
-    puts "  appears to be generated source code"
-  end
-
-  if blob.vendored?
-    puts "  appears to be a vendored file"
-  end
+  Linguist::Presenters::FileBlob.new(path).present
 else
-  abort "usage: linguist <path>"
+  abort "usage: linguist <path> [<--breakdown> <--loc>]"
 end

--- a/lib/linguist.rb
+++ b/lib/linguist.rb
@@ -6,6 +6,7 @@ require 'linguist/language'
 require 'linguist/repository'
 require 'linguist/samples'
 require 'linguist/shebang'
+require 'linguist/presenters'
 require 'linguist/version'
 
 class << Linguist

--- a/lib/linguist/presenters.rb
+++ b/lib/linguist/presenters.rb
@@ -1,0 +1,3 @@
+require 'linguist/presenters/loc_presenter'
+require 'linguist/presenters/breakdown_presenter'
+require 'linguist/presenters/file_blob'

--- a/lib/linguist/presenters/breakdown_presenter.rb
+++ b/lib/linguist/presenters/breakdown_presenter.rb
@@ -1,0 +1,24 @@
+module Linguist
+  # This class handles the output of each of the
+  # command options
+  module Presenters
+    class Breakdown
+      def initialize(repo, io = $stdout)
+        @repo = repo
+        @io = io
+      end
+
+      def present 
+        @io.puts
+        file_breakdown = @repo.breakdown_by_file
+        file_breakdown.each do |lang, files|
+          @io.puts "#{lang}:"
+          files.each do |file|
+            @io.puts file
+          end
+          @io.puts
+        end
+      end
+    end
+  end
+end

--- a/lib/linguist/presenters/file_blob.rb
+++ b/lib/linguist/presenters/file_blob.rb
@@ -1,0 +1,46 @@
+module Linguist
+  module Presenters
+    class FileBlob
+      def initialize(path, io = $stdout)
+        @path = path 
+        @io = io
+      end
+
+      def present
+        @io.puts "#{blob.name}: #{blob.loc} lines (#{blob.sloc} sloc)"
+        @io.puts "  type:      #{type}"
+        @io.puts "  mime type: #{blob.mime_type}"
+        @io.puts "  language:  #{blob.language}"
+
+        if blob.large?
+          @io.puts "  blob is too large to be shown"
+        end
+
+        if blob.generated?
+          @io.puts "  appears to be generated source code"
+        end
+
+        if blob.vendored?
+          @io.puts "  appears to be a vendored file"
+        end
+
+      end
+
+      private
+
+      def blob
+        @blob ||= Linguist::FileBlob.new(@path, Dir.pwd)
+      end
+
+      def type
+        @type ||= if blob.text?
+                 'Text'
+               elsif blob.image?
+                 'Image'
+               else
+                 'Binary'
+               end
+      end
+    end
+  end
+end

--- a/lib/linguist/presenters/loc_presenter.rb
+++ b/lib/linguist/presenters/loc_presenter.rb
@@ -1,0 +1,18 @@
+module Linguist
+  # This class handles the output of each of the
+  # command options
+  module Presenters
+    class Loc
+      def initialize(repo, io = $stdout)
+        @repo = repo
+        @io = io
+      end
+
+      def present
+        @repo.languages.each do |lang, lang_loc| 
+          @io.puts "#{lang}: #{lang_loc}"
+        end
+      end
+    end
+  end
+end

--- a/test/presenters/test_breakdown_presenter.rb
+++ b/test/presenters/test_breakdown_presenter.rb
@@ -1,0 +1,36 @@
+require_relative "../helper"
+
+module Presenters
+  class TestLoc < Minitest::Test
+    def rugged_repository
+      @rugged ||= Rugged::Repository.new(File.expand_path("../../../.git", __FILE__))
+    end
+
+    def master_oid
+      'd40b4a33deba710e2f494db357c654fbe5d4b419'
+    end
+
+    def linguist_repo(oid = master_oid)
+      Linguist::Repository.new(rugged_repository, oid)
+    end
+    
+    def subject 
+      @subject ||= Linguist::Presenters::Breakdown.new(linguist_repo, io)
+    end
+
+    def io
+      @io ||= StringIO.new 
+    end
+  
+    def test_includes_language
+      subject.present
+      assert_match(/Ruby:/, io.string)
+    end
+
+    def test_includes_files
+      subject.present
+      assert_match(/Gemfile/, io.string)
+      assert_match(/repository\.rb/, io.string)
+    end
+  end
+end

--- a/test/presenters/test_file_blob_presenter.rb
+++ b/test/presenters/test_file_blob_presenter.rb
@@ -1,0 +1,33 @@
+require_relative "../helper"
+
+module Presenters
+  class TestLoc < Minitest::Test
+
+    def file
+      'lib/linguist.rb'
+    end
+    
+    def subject 
+      @subject ||= Linguist::Presenters::FileBlob.new(file, io)
+    end
+
+    def io
+      @io ||= StringIO.new 
+    end
+  
+    def test_includes_language
+      subject.present
+      assert_match(/language:\s*Ruby/, io.string)
+    end
+
+    def test_includes_filename
+      subject.present
+      assert_match(/linguist\.rb/, io.string)
+    end
+
+    def test_includes_mime_type
+      subject.present
+      assert_match(/application\/x-ruby/, io.string)
+    end
+  end
+end

--- a/test/presenters/test_loc_presenter.rb
+++ b/test/presenters/test_loc_presenter.rb
@@ -1,0 +1,30 @@
+require_relative "../helper"
+
+module Presenters
+  class TestLoc < Minitest::Test
+    def rugged_repository
+      @rugged ||= Rugged::Repository.new(File.expand_path("../../../.git", __FILE__))
+    end
+
+    def master_oid
+      'd40b4a33deba710e2f494db357c654fbe5d4b419'
+    end
+
+    def linguist_repo(oid = master_oid)
+      Linguist::Repository.new(rugged_repository, oid)
+    end
+    
+    def subject 
+      @subject ||= Linguist::Presenters::Loc.new(linguist_repo, io)
+    end
+
+    def io
+      @io ||= StringIO.new 
+    end
+  
+    def test_includes_language
+      subject.present
+      assert_match(/Ruby:/, io.string)
+    end
+  end
+end


### PR DESCRIPTION
We wanted a quick way to get LOC/language for a repo, and linguist
had all the tools, but didn't offer it as a CLI flag. So, I added
it. :)

I did make an attempt at refactoring the linguist executable a bit,
added very simple presenters that can write to any IO object.

I hope you'll find this useful. Incidentally, it's mentioned as
a want in [Issue 3131](https://github.com/github/linguist/issues/3131)
