### PR TITLE
Grammar for REXX from Sublime Text package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -761,3 +761,6 @@ url = https://github.com/austinwagner/sublime-sourcepawn
 [submodule "vendor/grammars/atom-language-1c-bsl"]
 	path = vendor/grammars/atom-language-1c-bsl
 	url = https://github.com/xDrivenDevelopment/atom-language-1c-bsl.git
+[submodule "vendor/grammars/sublime-rexx"]
+	path = vendor/grammars/sublime-rexx
+	url = https://github.com/mblocker/rexx-sublime

--- a/grammars.yml
+++ b/grammars.yml
@@ -584,6 +584,8 @@ vendor/grammars/sublime-opal/:
 - source.opalsysdefs
 vendor/grammars/sublime-pony:
 - source.pony
+vendor/grammars/sublime-rexx/:
+- source.rexx
 vendor/grammars/sublime-robot-plugin:
 - text.robot
 vendor/grammars/sublime-rust:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3174,7 +3174,7 @@ REXX:
   - .rexx
   - .pprx
   - .rex
-  tm_scope: none
+  tm_scope: source.rexx
   ace_mode: text
 
 RHTML:

--- a/vendor/licenses/grammar/sublime-rexx.txt
+++ b/vendor/licenses/grammar/sublime-rexx.txt
@@ -1,0 +1,26 @@
+---
+type: grammar
+name: sublime-rexx
+license: mit
+---
+The MIT License (MIT)
+
+Copyright (c) 2016 Mike Blocker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
REXX support was added recently in #3124, but the grammar didn't have a permissive license at the time. It now has an MIT license, so we can use it.