### PR TITLE
Add "gpyi" files to JSON category

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1768,6 +1768,7 @@ JSON:
   - .geojson
   - .JSON-tmLanguage
   - .topojson
+  - .gypi
   filenames:
   - .arcconfig
   - .jshintrc


### PR DESCRIPTION
Add gpyi to highlight C++ scripts in Node.js. They are formatted as glorified JSON.