### PR TITLE
Fix .ts heuristic rule

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -430,7 +430,7 @@ module Linguist
     end
 
     disambiguate ".ts" do |data|
-      if data.include?("</TS>")
+      if data.include?("<TS")
         Language["XML"]
       else
         Language["TypeScript"]


### PR DESCRIPTION
This pull request fixes #3170.

When analyzing repositories, we use LazyBlob, which has a [limit on the maximum number of lines analyzed in a file](https://github.com/github/linguist/blob/master/lib/linguist/lazy_blob.rb#L17). Thus, with large files, the last lines might not be used by Linguist (neither for the classifier, nor for the heuristic rules).
I recently modified the `.ts` heuristic to fix another issue (#3098). I changed it to use the closing TS tag (which is usually found at the end of the file) instead of the opening tag. Because of that, large `.ts` files do not match the heuristic anymore.
This pull request changes the `.ts` heuristic to use the opening TS tag again with a slight variation compared to the initial heuristic (no space after `<TS`).