### PR TITLE
Add support for LotusScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4007,6 +4007,7 @@ Visual Basic:
   - .cls
   - .frm
   - .frx
+  - .lss
   - .vba
   - .vbhtml
   - .vbs


### PR DESCRIPTION
I propose simple solution to highlight syntax in LotusScript lss files. It can be treated as Visual Basic.
