### PR TITLE
Exclude "dist" directory from language statistics

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -15,6 +15,9 @@
 # Dependencies
 - ^[Dd]ependencies/
 
+# Distributions
+- (^|/)dist/
+
 # C deps
 #  https://github.com/joyent/node
 - ^deps/


### PR DESCRIPTION
It is listed in a lot of .gitignore files, if this is any indicator that it should not be checked: https://github.com/search?utf8=%E2%9C%93&q=dist+filename%3Agitignore&type=Code&ref=searchresults