### PR TITLE
Language was officially renamed from 'Nimrod' to 'Nim'

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2504,7 +2504,7 @@ Nginx:
   ace_mode: text
   color: "#9469E9"
 
-Nimrod:
+Nim:
   type: programming
   color: "#37775b"
   extensions:


### PR DESCRIPTION
See http://nim-lang.org/