### PR TITLE
Fix issue when no candidates for the Classifer strategy

### DIFF
--- a/lib/linguist/classifier.rb
+++ b/lib/linguist/classifier.rb
@@ -73,8 +73,8 @@ module Linguist
     #
     # Returns sorted Array of result pairs. Each pair contains the
     # String language name and a Float score.
-    def self.classify(db, tokens, languages = nil)
-      languages ||= db['languages'].keys
+    def self.classify(db, tokens, languages = [])
+      languages = db['languages'].keys if languages.empty?
       new(db).classify(tokens, languages)
     end
 

--- a/test/test_classifier.rb
+++ b/test/test_classifier.rb
@@ -55,6 +55,6 @@ class TestClassifier < Minitest::Test
   end
 
   def test_classify_empty_languages
-    assert_equal [], Classifier.classify(Samples.cache, fixture("Ruby/foo.rb"), [])
+    refute_equal [], Classifier.classify(Samples.cache, fixture("Ruby/foo.rb"), [])
   end
 end


### PR DESCRIPTION
There is [logic](https://github.com/github/linguist/blob/983ff20d3cee56a8d1625fcd6347372d765b8c57/lib/linguist/classifier.rb#L77) in the Classifier strategy to use all the languages in the training set if there are no language candidates at call time (a nil guard). However, this logic never fires, because `.call` passes [an empty array](https://github.com/github/linguist/blob/983ff20d3cee56a8d1625fcd6347372d765b8c57/lib/linguist/classifier.rb#L19) in this case (which doesn't trip the nil guard). This simple fix restores the intended behavior and allows the Classifier strategy to do its thing when there are no language candidates at call time.
