### PR TITLE
Add Filebench WML

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -144,10 +144,22 @@ module Linguist
       end
     end
 
-    disambiguate ".for", ".f" do |data|
+    fortran_rx = /^([c*][^abd-z]|      (subroutine|program|end)\s|\s*!)/i
+
+    disambiguate ".f" do |data|
       if /^: /.match(data)
         Language["Forth"]
-      elsif /^([c*][^abd-z]|      (subroutine|program|end)\s|\s*!)/i.match(data)
+      elsif data.include?("flowop")
+        Language["Filebench WML"]
+      elsif fortran_rx.match(data)
+        Language["FORTRAN"]
+      end
+    end
+
+    disambiguate ".for" do |data|
+      if /^: /.match(data)
+        Language["Forth"]
+      elsif fortran_rx.match(data)
         Language["FORTRAN"]
       end
     end

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1135,6 +1135,13 @@ Fantom:
   tm_scope: none
   ace_mode: text
 
+Filebench WML:
+  type: programming
+  extensions:
+  - .f
+  tm_scope: none
+  ace_mode: text
+
 Filterscript:
   type: programming
   group: RenderScript

--- a/samples/Filebench WML/copyfiles.f
+++ b/samples/Filebench WML/copyfiles.f
@@ -1,0 +1,51 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+set $dir=/tmp
+set $nfiles=1000
+set $meandirwidth=20
+set $meanfilesize=16k
+set $iosize=1m
+set $nthreads=1
+
+set mode quit firstdone
+
+define fileset name=bigfileset,path=$dir,size=$meanfilesize,entries=$nfiles,dirwidth=$meandirwidth,prealloc=100,paralloc
+define fileset name=destfiles,path=$dir,size=$meanfilesize,entries=$nfiles,dirwidth=$meandirwidth
+
+define process name=filereader,instances=1
+{
+  thread name=filereaderthread,memsize=10m,instances=$nthreads
+  {
+    flowop openfile name=openfile1,filesetname=bigfileset,fd=1
+    flowop readwholefile name=readfile1,fd=1,iosize=$iosize
+    flowop createfile name=createfile2,filesetname=destfiles,fd=2
+    flowop writewholefile name=writefile2,fd=2,srcfd=1,iosize=$iosize
+    flowop closefile name=closefile1,fd=1
+    flowop closefile name=closefile2,fd=2
+  }
+}
+
+echo  "Copyfiles Version 3.0 personality successfully loaded"


### PR DESCRIPTION
Every now and then a [new repo pops up that's misclassified as Forth](https://github.com/search?q=language%3Aforth+fxmark).  After some research, I found out that these `.f` files are written in the [Filebench Workload Model Language](https://github.com/filebench/filebench/wiki/Workload-model-language).

There seem to be at least [1700 files](https://github.com/search?q=extension%3Af+flowop+OR+fileset).  (Recent changes in GitHub code search makes it harder to estimate number of repositories.)