### PR TITLE
Lock language-babel grammar to v2.22.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -602,9 +602,6 @@
 [submodule "vendor/grammars/X10"]
 	path = vendor/grammars/X10
 	url = https://github.com/x10-lang/x10-highlighting
-[submodule "vendor/grammars/language-babel"]
-	path = vendor/grammars/language-babel
-	url = https://github.com/gandm/language-babel
 [submodule "vendor/grammars/UrWeb-Language-Definition"]
 	path = vendor/grammars/UrWeb-Language-Definition
 	url = https://github.com/gwalborn/UrWeb-Language-Definition.git
@@ -788,3 +785,6 @@ url = https://github.com/austinwagner/sublime-sourcepawn
 [submodule "vendor/grammars/language-emacs-lisp"]
 	path = vendor/grammars/language-emacs-lisp
 	url = https://github.com/Alhadis/language-emacs-lisp
+[submodule "vendor/grammars/language-babel"]
+	path = vendor/grammars/language-babel
+	url = https://github.com/github-linguist/language-babel


### PR DESCRIPTION
Same as #3091, except this time we use our own fork to make sure we don't update it again by mistake. Fixes #3178.