### PR TITLE
Fix Elm highlighting

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -20,7 +20,7 @@ vendor/grammars/ColdFusion:
 - text.html.cfm
 vendor/grammars/Docker.tmbundle:
 - source.dockerfile
-vendor/grammars/Elm:
+vendor/grammars/Elm/Syntaxes:
 - source.elm
 - text.html.mediawiki.elm-build-output
 - text.html.mediawiki.elm-documentation


### PR DESCRIPTION
Elm grammar repository contains several YAML files with a `source.elm` scope ([Preferences/Metadata.YAML-tmLanguage](https://github.com/elm-community/Elm.tmLanguage/blob/master/Preferences/Metadata.YAML-tmLanguage) and [Syntaxes/Elm.YAML-tmLanguage](https://github.com/elm-community/Elm.tmLanguage/blob/master/Syntaxes/Elm.YAML-tmLanguage)).
We need to restrict the path to the Syntaxes directory to make sure we select the appropriate YAML file.

I'm not sure how we could test this for subsequent pull requests...

Fixes #3204.

/cc @arfon 