### PR TITLE
Test the uniqueness of language ids

### DIFF
--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -404,6 +404,14 @@ class TestLanguage < Minitest::Test
     assert missing.empty?, message
   end
 
+  def test_all_language_id_are_unique
+    duplicates = Language.all.group_by{ |language| language.language_id }.select { |k, v| v.size > 1 }.map(&:first)
+
+    message = "The following language_id are used several times in languages.yml. Please use script/set-language-ids --update as per the contribution guidelines.\n"
+    duplicates.each { |language_id| message << "#{language_id}\n" }
+    assert duplicates.empty?, message
+  end
+
   def test_all_languages_have_a_valid_ace_mode
     ace_fixture_path = File.join('test', 'fixtures', 'ace_modes.json')
     skip("No ace_modes.json file") unless File.exist?(ace_fixture_path)


### PR DESCRIPTION
A new test for #3205 to check that language ids are unique. With this test I'm hoping to catch some of the incorrect additions of `language_id`s without using `script/set-language-ids`.