### PR TITLE
POV-Ray heuristic: #declare

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -202,6 +202,8 @@ module Linguist
     disambiguate ".inc" do |data|
       if /^<\?(?:php)?/.match(data)
         Language["PHP"]
+      elsif /^\s*#(declare|local|macro|while)\s/.match(data)
+        Language["POV-Ray SDL"]
       end
     end
 

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -122,9 +122,12 @@ class TestHeuristcs < Minitest::Test
     })
   end
 
+  # Candidate languages = ["Assembly", "C++", "HTML", "PAWN", "PHP",
+  #                        "POV-Ray SDL", "Pascal", "SQL", "SourcePawn"]
   def test_inc_by_heuristics
     assert_heuristics({
-      "PHP" => all_fixtures("PHP", "*.inc")
+      "PHP" => all_fixtures("PHP", "*.inc"),
+      "POV-Ray SDL" => all_fixtures("POV-Ray SDL", "*.inc")
     })
   end
 


### PR DESCRIPTION
Add heuristic for `.inc` files: the `#declare` keyword seems to be unique to POV-Ray.

Fixes #3150.