### PR TITLE
Remove support for .sublime-syntax

### DIFF
--- a/script/convert-grammars
+++ b/script/convert-grammars
@@ -42,7 +42,7 @@ class DirectoryPackage
       case File.extname(path.downcase)
       when '.plist'
         path.split('/')[-2] == 'Syntaxes'
-      when '.tmlanguage', '.yaml-tmlanguage', '.sublime-syntax'
+      when '.tmlanguage', '.yaml-tmlanguage'
         true
       when '.cson', '.json'
         path.split('/')[-2] == 'grammars'
@@ -114,7 +114,7 @@ class SVNPackage
   def fetch(tmp_dir)
     `svn export -q "#{url}/Syntaxes" "#{tmp_dir}/Syntaxes"`
     raise "Failed to export SVN repository: #{url}: #{$?.to_s}" unless $?.success?
-    Dir["#{tmp_dir}/Syntaxes/*.{plist,tmLanguage,tmlanguage,YAML-tmLanguage,sublime-syntax}"]
+    Dir["#{tmp_dir}/Syntaxes/*.{plist,tmLanguage,tmlanguage,YAML-tmLanguage}"]
   end
 end
 
@@ -148,7 +148,7 @@ def load_grammar(path)
   case File.extname(path.downcase)
   when '.plist', '.tmlanguage'
     Plist::parse_xml(path)
-  when '.yaml-tmlanguage', '.sublime-syntax'
+  when '.yaml-tmlanguage'
     content = File.read(path)
     # Attempt to parse YAML file even if it has a YAML 1.2 header
     if content.lines[0] =~ /^%YAML[ :]1\.2/
@@ -180,7 +180,7 @@ def load_grammars(tmp_dir, source, all_scopes)
         else
           SingleFile.new(source)
         end
-      elsif source.end_with?('.tmLanguage', '.plist', '.YAML-tmLanguage', '.sublime-syntax')
+      elsif source.end_with?('.tmLanguage', '.plist', '.YAML-tmLanguage')
         SingleGrammar.new(source)
       elsif source.start_with?('https://github.com')
         GitHubPackage.new(source)


### PR DESCRIPTION
This pull request removes support for `.sublime-syntax` grammar files in `convert-grammars` until we find a better solution.