### PR TITLE
Add Fortran keyword "data"

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -144,7 +144,7 @@ module Linguist
       end
     end
 
-    fortran_rx = /^([c*][^abd-z]|      (subroutine|program|end)\s|\s*!)/i
+    fortran_rx = /^([c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)/i
 
     disambiguate ".f" do |data|
       if /^: /.match(data)

--- a/samples/FORTRAN/bug-185631.f
+++ b/samples/FORTRAN/bug-185631.f
@@ -1,0 +1,6 @@
+! Codes/HYCOM/hycom/ATLb2.00/src_2.0.01_22_one/
+      real onemu, twomu
+      data onemu/0.0098/
+      data twomu/1./
+      data threemu/0.e9/
+      end


### PR DESCRIPTION
Add the Fortran `data` keyword to the `.f` and `.for` heuristics.

Fixes misclassification of https://github.com/jbuonagurio/RHTDP.