### PR TITLE
Allow golang as an alias for Go code fences

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1343,6 +1343,8 @@ Gnuplot:
 Go:
   type: programming
   color: "#375eab"
+  aliases:
+  - golang
   extensions:
   - ".go"
   ace_mode: golang


### PR DESCRIPTION
Goal is for

``` golang
func AFunction() error {
  return nil
}
```

to work like

``` go
func AFunction() error {
  return nil
}
```
