### PR TITLE
golang alias for Go

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1345,6 +1345,8 @@ Go:
   color: "#375eab"
   extensions:
   - ".go"
+  aliases:
+  - golang
   ace_mode: golang
   language_id: 132
 Golo:


### PR DESCRIPTION
This pull request adds the `golang` alias to Go.

Fixes #3221.