### PR TITLE
Whitelist troublesome licenses

### DIFF
--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -5,7 +5,9 @@ class TestGrammars < Minitest::Test
 
   # List of projects that are allowed without licenses
   PROJECT_WHITELIST = [
-    # Dual MIT and GPL license
+    "vendor/grammars/factor",
+    "vendor/grammars/go-tmbundle",
+    "vendor/grammars/jflex.tmbundle",
     "vendor/grammars/language-csharp",
     "vendor/grammars/sublimeassembly"
   ].freeze


### PR DESCRIPTION
The recently Licensee update has increased the confidence threshold required to detect a license. This means that three of the grammars we use now fail our license check.

This PR temporarily whitelists these build failures but we need to find a better long term fix here. Perhaps we could make use of the `curated: true` check that we have in `licenses/grammar/...` files?

/ cc @mlinksva @pchaigno

/ cc https://github.com/github/linguist/issues/3225