### PR TITLE
Auto increment language_id to avoid duplicates

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -561,6 +561,8 @@ module Linguist
   end
 
   languages.each do |name, options|
+    next if name == 'NEXT_LANGUAGE_ID'
+
     options['extensions'] ||= []
     options['interpreters'] ||= []
     options['filenames'] ||= []

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -33,6 +33,7 @@
 # Please keep this list alphabetized. Capitalization comes before lowercase.
 
 ---
+NEXT_LANGUAGE_ID: 422
 1C Enterprise:
   type: programming
   color: "#814CCC"

--- a/script/set-language-ids
+++ b/script/set-language-ids
@@ -11,6 +11,8 @@ header = <<-EOF
 # ace_mode          - A String name of the Ace Mode used for highlighting whenever
 #                     a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
 #                     Use "text" if a mode does not exist.
+# codemirror_mode   - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
+#                     This must match a mode from https://git.io/vi9Fx
 # wrap              - Boolean wrap to enable line wrapping (default: false)
 # extensions        - An Array of associated extensions (the first one is
 #                     considered the primary extension, the others should be
@@ -20,7 +22,7 @@ header = <<-EOF
 # search_term       - Deprecated: Some languages may be indexed under a
 #                     different alias. Avoid defining new exceptions.
 # language_id       - Integer used as a language-name-independent indexed field so that we can rename
-#                     languages in Linguist without reindexing all the code on GitHub. Must not be 
+#                     languages in Linguist without reindexing all the code on GitHub. Must not be
 #                     changed for existing languages without the explicit permission of GitHub staff.
 # color             - CSS hex color to represent the language.
 # tm_scope          - The TextMate scope that represents this programming

--- a/script/set-language-ids
+++ b/script/set-language-ids
@@ -49,8 +49,12 @@ if generated
 
   languages = YAML.load(File.read("lib/linguist/languages.yml"))
   languages.each do |name, vals|
-    vals.merge!('language_id' => language_index)
-    language_index += 1
+    if name == 'NEXT_LANGUAGE_ID'
+      languages.size
+    else
+      vals.merge!('language_id' => language_index)
+      language_index += 1
+    end
   end
 
   File.write("lib/linguist/languages.yml", header + YAML.dump(languages))
@@ -59,21 +63,20 @@ elsif update
   languages = YAML.load(File.read("lib/linguist/languages.yml"))
 
   # First grab the maximum language_id
-  language_ids = []
-  languages.each { |name, vals| language_ids << vals['language_id'] if vals.has_key?('language_id')}
-  max_language_id = language_ids.max
+  max_language_id = languages['NEXT_LANGUAGE_ID']
   puts "Current maximum language_id is #{max_language_id}"
 
   missing_count = 0
   language_index = max_language_id
 
   languages.each do |name, vals|
-    unless vals.has_key?('language_id')
+    unless name == 'NEXT_LANGUAGE_ID' || vals.has_key?('language_id')
+      vals.merge!('language_id' => language_index)
       language_index += 1
       missing_count += 1
-      vals.merge!('language_id' => language_index)
     end
   end
+  languages['NEXT_LANGUAGE_ID'] = language_index
 
   File.write("lib/linguist/languages.yml", header + YAML.dump(languages))
   puts "Updated language_id attributes for #{missing_count} languages"

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -2,7 +2,7 @@ require_relative "./helper"
 
 class TestPedantic < Minitest::Test
   filename = File.expand_path("../../lib/linguist/languages.yml", __FILE__)
-  LANGUAGES = YAML.load(File.read(filename))
+  LANGUAGES = YAML.load(File.read(filename)).reject!{ |name| name == 'NEXT_LANGUAGE_ID' }
   GRAMMARS = YAML.load(File.read(File.expand_path("../../grammars.yml", __FILE__)))
 
   def test_language_names_are_sorted

--- a/test/test_samples.rb
+++ b/test/test_samples.rb
@@ -46,6 +46,8 @@ class TestSamples < Minitest::Test
   # aren't explicitly defined in languages.yml
   languages_yml = File.expand_path("../../lib/linguist/languages.yml", __FILE__)
   YAML.load_file(languages_yml).each do |name, options|
+    next if name == 'NEXT_LANGUAGE_ID'
+
     define_method "test_samples_have_parity_with_languages_yml_for_#{name}" do
       options['extensions'] ||= []
       if extnames = Samples.cache['extnames'][name]


### PR DESCRIPTION
Fixes #3211.

Anyone has a better idea on where/how to store the `NEXT_LANGUAGE_ID`? The current way (in `languages.yml`) requires a few modifications to `language.rb` and tests, which I don't really like.

/cc @arfon @TwP