### PR TITLE
Remove VimL grammar from whitelist

### DIFF
--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -9,7 +9,6 @@ class TestGrammars < Minitest::Test
     "vendor/grammars/go-tmbundle",
     "vendor/grammars/jflex.tmbundle",
     "vendor/grammars/language-csharp",
-    "vendor/grammars/language-viml",
     "vendor/grammars/sublimeassembly"
   ].freeze
 


### PR DESCRIPTION
Since @Alhadis changed the VimL grammar for a new grammar with an MIT license (#3223), the "whitelisting" is not necessary anymore.