### PR TITLE
Add '</' to Markdown heuristic.

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -254,7 +254,7 @@ module Linguist
     end
 
     disambiguate ".md" do |data|
-      if /^[-a-z0-9=#!\*\[|]/i.match(data)
+      if /(^[-a-z0-9=#!\*\[|])|<\//i.match(data) || data.empty?
         Language["Markdown"]
       elsif /^(;;|\(define_)/.match(data)
         Language["GCC machine description"]

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -162,6 +162,13 @@ class TestHeuristcs < Minitest::Test
     })
   end
 
+  def test_md_by_heuristics
+    assert_heuristics({
+      "Markdown" => all_fixtures("Markdown", "*.md"),
+      "GCC machine description" => all_fixtures("GCC machine description", "*.md")
+    })
+  end
+
   # Candidate languages = ["C++", "Objective-C"]
   def test_obj_c_by_heuristics
     # Only calling out '.h' filenames as these are the ones causing issues


### PR DESCRIPTION
Possibly also other HTML tags?

EDIT: Changed to just `</` and also include empty files.

Fixes #3172.