### PR TITLE
Guard against unused colour definitions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -19,7 +19,7 @@
 # language_id       - Integer used as a language-name-independent indexed field so that we can rename
 #                     languages in Linguist without reindexing all the code on GitHub. Must not be
 #                     changed for existing languages without the explicit permission of GitHub staff.
-# color             - CSS hex color to represent the language.
+# color             - CSS hex color to represent the language. Only used if type is "programming" or "prose"
 # tm_scope          - The TextMate scope that represents this programming
 #                     language. This should match one of the scopes listed in
 #                     the grammars.yml file. Use "none" if there is no grammar

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -103,7 +103,6 @@ APL:
   language_id: 6
 ASN.1:
   type: data
-  color: "#aeead0"
   extensions:
   - ".asn"
   - ".asn1"

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -494,4 +494,11 @@ class TestLanguage < Minitest::Test
     message << missing.sort.join("\n")
     assert missing.empty?, message
   end
+
+  def test_no_unused_colours
+    Language.all.each do |language|
+      next unless language.type == :data || language.type == :prose
+      assert !language.color, "Unused colour assigned to #{language.name}"
+    end
+  end
 end


### PR DESCRIPTION
This slipped in unnoticed. Since ASN.1 is classified as "data", there's no reason for it to have a colour assigned.

Should we add a test for this to stop this happening again...?