### PR TITLE
Add REXX interpreters

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3447,6 +3447,9 @@ REXX:
   - ".rexx"
   - ".pprx"
   - ".rex"
+  interpreters:
+  - regina
+  - rexx
   tm_scope: source.rexx
   ace_mode: text
   language_id: 311


### PR DESCRIPTION
There are at least [7 interpreters](http://www.rexxinfo.org/html/rexxinfo2.html#Download-Rexx) for running REXX, 3 of which run on POSIX systems:

* [BRexx](https://github.com/vlachoudis/brexx/blob/master/doc/running.html)
* [Rexx/imc](http://www.cs.ox.ac.uk/people/ian.collier/Rexx/rexximc.html)
* [Regina](http://regina-rexx.sourceforge.net/)

[BRexx](https://github.com/vlachoudis/brexx/blob/master/doc/running.html#L22) and [Rexx/imc](http://web.archive.org/web/20060107071407/http://users.comlab.ox.ac.uk/ian.collier/distribution/rexx-imc-1.76/rexx.ref) both use `rexx` as the interpreter name. [Regina](https://foicica.com/lists/code/201510/2725.html) uses `regina`, but I couldn't find any other possible variations.

I don't know how different Rexx dialects like [Object Rexx](http://www.oorexx.org/) are from plain Rexx, so I've purposefully omitted any interpreters that're dialect-specific.
