### PR TITLE
Add support for the Pic language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3132,6 +3132,17 @@ Perl6:
   codemirror_mode: perl
   codemirror_mime_type: text/x-perl
   language_id: 283
+Pic:
+  type: markup
+  group: Groff
+  tm_scope: "source.pic"
+  extensions:
+  - ".pic"
+  - ".chem"
+  ace_mode: text
+  codemirror_mode: troff
+  codemirror_mime_type: text/troff
+  language_id: 424
 Pickle:
   type: data
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3152,7 +3152,7 @@ Pic:
   ace_mode: text
   codemirror_mode: troff
   codemirror_mime_type: text/troff
-  language_id: 424
+  language_id: 425
 Pickle:
   type: data
   extensions:

--- a/samples/Pic/dextroamphetamine.chem
+++ b/samples/Pic/dextroamphetamine.chem
@@ -1,0 +1,13 @@
+# Dextroamphetamine molecule
+.cstart
+	.ps 26
+	size 28
+R1:
+	ring double 1,2 3,4 5,6
+	bond 60 from R1.V2
+	bond 120
+A1:
+	front bond down ; CH3
+	bond 60 from A1 ; NH2
+	.ps
+.cend

--- a/samples/Pic/graph.pic
+++ b/samples/Pic/graph.pic
@@ -1,0 +1,25 @@
+.PS
+	ellipse "Pic" "example"
+	arrow
+	box "This is" "a box" 
+	arrow right
+	box "Another" "box" dashed
+	move down then right;
+Thing: ellipse "This is a" "circle-thing"
+	arrow <-> from last box.r to Thing.l
+	move down then left;
+B: box "Still a box"
+	arrow from Thing.l to B.r
+	sprintf("Width = %g, Height = %g ", B.wid, B.ht) rjust at B.w
+	move down
+.ps 15
+	define sadness {
+		boxwid = 3;
+		boxht = 1;
+		textht = .5;
+		box "\"I run from my depression by" " " "burying myself in code\""
+		arrow down from last box.s
+		"Me"
+	}
+	sadness();
+.PE

--- a/samples/Pic/ritalin.chem
+++ b/samples/Pic/ritalin.chem
@@ -1,0 +1,15 @@
+.\" RITALIN: Methylphenidate Hydrochloride
+.cstart
+.ps 15
+size 15
+	R1: ring double 1,2 3,4 5,6 pointing up
+	bond 60 length .35 from R1.V2 ; BP
+	bond 120 length .35 from BP
+	R2: ring pointing up put N at 1
+	H above R2
+	bond up  length .35 from BP ; BP
+	bond -60 length .35 from BP ; O
+	bond up
+	double bond 60 length .35 from BP ; O
+.ps 10
+.cend


### PR DESCRIPTION
**[Pic](https://en.wikipedia.org/wiki/Pic_language)** is a procedural DSL to generate simple drawings in Roff or TeX, such as flowcharts and diagrams. The language is closely tied with Roff, but its syntax and semantics are very different. Pic is also equipped with Turing-complete programming facilities, such as loops, conditionals, variables and macro definitions, making it a decidedly complex language.

**Extensions:**
- [`.pic`](https://github.com/Alhadis/Linguist-Silo/tree/pic): [21,862 results](https://github.com/search?q=extension%3Apic+NOT+nothack&type=Code)
- [`.chem`](https://github.com/Alhadis/Linguist-Silo/tree/chem): [2,547 results](https://github.com/search?q=extension%3Achem+NOT+nothack&type=Code)

Understandably, most results for `.pic` were binary files. Of the 3,000 files I collated from search results, 43% of the text files were Pic source (the remainder being project-languages or files with weird extensions).
