### PR TITLE
Add CodeMirror modes for GPG keys and IRC logs

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1844,6 +1844,8 @@ IRC log:
   - ".weechatlog"
   tm_scope: none
   ace_mode: text
+  codemirror_mode: mirc
+  codemirror_mime_type: text/mirc
   language_id: 164
 Idris:
   type: programming
@@ -3284,6 +3286,8 @@ Public Key:
   - ".pub"
   tm_scope: none
   ace_mode: text
+  codemirror_mode: asciiarmor
+  codemirror_mime_type: application/pgp
   language_id: 298
 Puppet:
   type: programming


### PR DESCRIPTION
CodeMirror bundles two modes for [ASCII PGP keys](https://codemirror.net/mode/asciiarmor/index.html) and [mIRC logs](https://codemirror.net/mode/mirc/index.html), which currently aren't listed in `languages.yml`.

It also includes a mode for [GAS/Unix Assembly](https://codemirror.net/mode/gas/index.html), but the [source file](https://github.com/codemirror/CodeMirror/blob/master/mode/gas/gas.js) doesn't declare the `text/x-gas` MIME type that the mode's page says it does. Ergo, the tests failed due to an undefined mode-type.
