### PR TITLE
Remove unused color attributes

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -712,7 +712,6 @@ CoffeeScript:
   language_id: 63
 ColdFusion:
   type: programming
-  group: ColdFusion
   ace_mode: coldfusion
   color: "#ed2cd6"
   search_term: cfm

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -227,7 +227,6 @@ Apex:
   language_id: 17
 Apollo Guidance Computer:
   type: programming
-  color: "#0B3D91"
   group: Assembly
   extensions:
   - ".agc"
@@ -369,7 +368,6 @@ Bison:
   extensions:
   - ".bison"
   ace_mode: text
-  color: "#6A463F"
   language_id: 31
 BitBake:
   type: programming
@@ -728,7 +726,6 @@ ColdFusion CFC:
   type: programming
   group: ColdFusion
   ace_mode: coldfusion
-  color: "#ed2cd6"
   search_term: cfc
   aliases:
   - cfc
@@ -1046,7 +1043,6 @@ ECLiPSe:
   language_id: 94
 EJS:
   type: markup
-  color: "#a91e50"
   group: HTML
   extensions:
   - ".ejs"
@@ -1734,11 +1730,9 @@ Haml:
   ace_mode: haml
   codemirror_mode: haml
   codemirror_mime_type: text/x-haml
-  color: "#ECE2A9"
   language_id: 154
 Handlebars:
   type: markup
-  color: "#01a9d6"
   group: HTML
   aliases:
   - hbs
@@ -1917,7 +1911,6 @@ J:
   language_id: 172
 JFlex:
   type: programming
-  color: "#DBCA00"
   group: Lex
   extensions:
   - ".flex"
@@ -2121,7 +2114,6 @@ LFE:
   type: programming
   extensions:
   - ".lfe"
-  color: "#004200"
   group: Erlang
   tm_scope: source.lisp
   ace_mode: lisp
@@ -2178,7 +2170,6 @@ Lasso:
   language_id: 195
 Latte:
   type: markup
-  color: "#A8FF97"
   group: HTML
   extensions:
   - ".latte"
@@ -2203,7 +2194,6 @@ Less:
   ace_mode: less
   codemirror_mode: css
   codemirror_mime_type: text/css
-  color: "#A1D9A1"
   language_id: 198
 Lex:
   type: programming
@@ -2791,7 +2781,6 @@ NumPy:
   ace_mode: text
   codemirror_mode: python
   codemirror_mime_type: text/x-python
-  color: "#9C8AF9"
   language_id: 254
 OCaml:
   type: programming
@@ -3675,7 +3664,6 @@ SCSS:
   codemirror_mime_type: text/x-scss
   extensions:
   - ".scss"
-  color: "#CF649A"
   language_id: 329
 SMT:
   type: programming
@@ -3801,7 +3789,6 @@ Sass:
   ace_mode: sass
   codemirror_mode: sass
   codemirror_mime_type: text/x-sass
-  color: "#CF649A"
   language_id: 340
 Scala:
   type: programming
@@ -3928,7 +3915,6 @@ Slash:
 Slim:
   group: HTML
   type: markup
-  color: "#ff8f77"
   extensions:
   - ".slim"
   tm_scope: text.slim
@@ -4283,7 +4269,6 @@ Unified Parallel C:
   ace_mode: c_cpp
   codemirror_mode: clike
   codemirror_mime_type: text/x-csrc
-  color: "#4e3617"
   extensions:
   - ".upc"
   tm_scope: source.c

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -497,7 +497,8 @@ class TestLanguage < Minitest::Test
 
   def test_no_unused_colours
     Language.all.each do |language|
-      next unless language.type == :data || language.type == :prose
+      next unless language.type == :data || language.type == :prose ||
+        language.group.to_s != language.name
       assert !language.color, "Unused colour assigned to #{language.name}"
     end
   end


### PR DESCRIPTION
This removes the color attribute from all languages with a group attribute.  Also updates the test which checks for unused color attributes.

Sorry @Alhadis, the Apollo Guidance System is one of the causualities.

Bonus perk: Removes the redundant `ColdFusion` group from the `ColdFusion` language.