### PR TITLE
Generate language_id

### DIFF
--- a/script/set-language-ids
+++ b/script/set-language-ids
@@ -36,21 +36,23 @@ header = <<-EOF
 # Please keep this list alphabetized. Capitalization comes before lowercase.
 
 EOF
+require 'digest'
 
 generated = true if ARGV[0] == "--force"
 update = true if ARGV[0] == "--update"
+
+def generate_language_id(language)
+  Digest::SHA256.hexdigest(language).to_i(16) % (2**30 - 1)
+end
 
 if generated
   puts "You're regenerating all of the language_id attributes for all Linguist "
   puts "languages defined in languages.yml. This is almost certainly NOT what"
   puts "you meant to do!"
 
-  language_index = 0
-
   languages = YAML.load(File.read("lib/linguist/languages.yml"))
   languages.each do |name, vals|
-    vals.merge!('language_id' => language_index)
-    language_index += 1
+    vals.merge!('language_id' => generate_language_id(name))
   end
 
   File.write("lib/linguist/languages.yml", header + YAML.dump(languages))
@@ -58,20 +60,12 @@ elsif update
   puts "Adding new language_id attributes to languages.yml that don't have one set"
   languages = YAML.load(File.read("lib/linguist/languages.yml"))
 
-  # First grab the maximum language_id
-  language_ids = []
-  languages.each { |name, vals| language_ids << vals['language_id'] if vals.has_key?('language_id')}
-  max_language_id = language_ids.max
-  puts "Current maximum language_id is #{max_language_id}"
-
   missing_count = 0
-  language_index = max_language_id
 
   languages.each do |name, vals|
     unless vals.has_key?('language_id')
-      language_index += 1
       missing_count += 1
-      vals.merge!('language_id' => language_index)
+      vals.merge!('language_id' => generate_language_id(name))
     end
   end
 

--- a/script/set-language-ids
+++ b/script/set-language-ids
@@ -11,6 +11,8 @@ header = <<-EOF
 # ace_mode          - A String name of the Ace Mode used for highlighting whenever
 #                     a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
 #                     Use "text" if a mode does not exist.
+# codemirror_mode   - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
+#                     This must match a mode from https://git.io/vi9Fx
 # wrap              - Boolean wrap to enable line wrapping (default: false)
 # extensions        - An Array of associated extensions (the first one is
 #                     considered the primary extension, the others should be
@@ -20,9 +22,9 @@ header = <<-EOF
 # search_term       - Deprecated: Some languages may be indexed under a
 #                     different alias. Avoid defining new exceptions.
 # language_id       - Integer used as a language-name-independent indexed field so that we can rename
-#                     languages in Linguist without reindexing all the code on GitHub. Must not be 
+#                     languages in Linguist without reindexing all the code on GitHub. Must not be
 #                     changed for existing languages without the explicit permission of GitHub staff.
-# color             - CSS hex color to represent the language.
+# color             - CSS hex color to represent the language. Only used if type is "programming" or "prose".
 # tm_scope          - The TextMate scope that represents this programming
 #                     language. This should match one of the scopes listed in
 #                     the grammars.yml file. Use "none" if there is no grammar

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -426,6 +426,14 @@ class TestLanguage < Minitest::Test
     assert missing.empty?, message
   end
 
+  def test_all_languages_have_a_valid_id
+    invalid = Language.all.select { |language| language.language_id < 0 || language.language_id >= (2**31 - 1) }
+
+    message = "The following languages do not have a valid language_id. Please use script/set-language-ids --update as per the contribution guidelines.\n"
+    invalid.each { |language| message << "#{language.name}\n" }
+    assert invalid.empty?, message
+  end
+
   def test_all_language_id_are_unique
     duplicates = Language.all.group_by{ |language| language.language_id }.select { |k, v| v.size > 1 }.map(&:first)
 


### PR DESCRIPTION
This pull request implements [@bkeepers' idea](https://github.com/github/linguist/pull/3247#issuecomment-252083158), generating the `language_id` from the hash of the language's name. I also added a test to check that all language ids are unsigned 32bit integers.
Supersedes #3247. Fixes #3211.

The `language_id` is the SHA256 hash of the language name modulo-ed to an unsigned 32bit integer:

``` ruby
Digest::SHA256.hexdigest(language).to_i(16) % (2**30 - 1)
```

Therefore, as long as the language names are different, the probability of collision is of 0.009561175% if we reach 1,000 languages [1]. This is important as we might not always be able to detect a collision. For instance, if a language entry is removed from Linguist and we later add a new language id that conflicts with the older removed language, the tests won't help detecting it.

The choice to generate the language id from the language name is based on the idea that we probably want two entries with the same name to have the same id (if we remove a language and add it back later). If we do not want that, I could simply change the pull request to generate random ids, which would give us the same collision probability.

I think it's important that we discuss this thoroughly, as we probably want to avoid changing the strategy to generate language ids too often (it's already our second system :stuck_out_tongue_closed_eyes: ).
/cc @bkeepers @arfon @Alhadis @TwP 

[1] - ![ql_15e041ca4f6190549ca56982ef8053e1_l3](https://cloud.githubusercontent.com/assets/1764210/19452966/665f7ad0-94b3-11e6-84fa-8ffe5e7b1855.png) - Details at [preshing.com](http://preshing.com/20110504/hash-collision-probabilities/). I took into consideration the fact that we already have 422 fixed language ids.
