### PR TITLE
Dev test exclusion

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -251,6 +251,21 @@ module Linguist
       path =~ DocumentationRegexp ? true : false
     end
 
+    test_paths = YAML.load_file(File.expand_path("../test.yml", __FILE__))
+    TestRegexp = Regexp.new(test_paths.join('|'))
+
+    # Public: Is the blob in a test directory?
+    #
+    # Test files are ignored by language statistics.
+    #
+    # See "test.yml" for a list of test conventions that match
+    # this pattern.
+    #
+    # Return true or false
+    def test?
+      path =~ TestRegexp ? true : false
+    end
+
     # Public: Get each line of data
     #
     # Requires Blob#data
@@ -339,6 +354,7 @@ module Linguist
     def include_in_language_stats?
       !vendored? &&
       !documentation? &&
+      !test? &&
       !generated? &&
       language && DETECTABLE_TYPES.include?(language.type)
     end

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -5,6 +5,7 @@ require 'rugged'
 module Linguist
   class LazyBlob
     GIT_ATTR = ['linguist-documentation',
+                'linguist-test',
                 'linguist-language',
                 'linguist-vendored',
                 'linguist-generated']
@@ -38,6 +39,14 @@ module Linguist
 
     def documentation?
       if attr = git_attributes['linguist-documentation']
+        boolean_attribute(attr)
+      else
+        super
+      end
+    end
+
+    def test?
+      if attr = git_attributes['linguist-test']
         boolean_attribute(attr)
       else
         super

--- a/lib/linguist/test.yml
+++ b/lib/linguist/test.yml
@@ -5,7 +5,7 @@
 # pathname.
 #
 # Please add additional test coverage to
-# `test/test_blob.rb#test_test` if you make any changes.
+# `test/test_file_blob.rb#test_test` if you make any changes.
 
 ## Test directories ##
 

--- a/lib/linguist/test.yml
+++ b/lib/linguist/test.yml
@@ -1,0 +1,12 @@
+# Test files and directories are excluded from language
+# statistics.
+#
+# Lines in this file are Regexps that are matched against the file
+# pathname.
+#
+# Please add additional test coverage to
+# `test/test_blob.rb#test_test` if you make any changes.
+
+## Test directories ##
+
+- ^tests?/

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -628,6 +628,11 @@ class TestFileBlob < Minitest::Test
     assert_predicate fixture_blob("INSTALL.txt"), :documentation?
   end
 
+  def test_test
+    assert_predicate fixture_blob("test/foo.html"), :test?
+    assert_predicate fixture_blob("tests/foo.html"), :test?
+  end
+
   def test_language
     Samples.each do |sample|
       blob = sample_blob(sample[:path])


### PR DESCRIPTION
Exclude 'test' dans 'tests' directories from language statistics. Add the possibilities to flag files or directories as test inside the .gitattributes file.

I've met the issue with my project [r-biodb](https://github.com/pierrickrogermele/r-biodb) which is tagged as HTML instead of R. This is because in the 'test' directory are stored some big HTML files.
This issue could also have been solved by excluding the 'res' subdirectory, which is the directory containing resources. However I've thought that, more generally, the language used in the tests is not necessarily the one used in the application.

We could also make the 'test.yml' empty and let repository owners decide to add or not test directories in the .gitattributes file.