### PR TITLE
Update grammar for ActionScript

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -202,9 +202,6 @@
 [submodule "vendor/grammars/sublime-robot-plugin"]
 	path = vendor/grammars/sublime-robot-plugin
 	url = https://github.com/shellderp/sublime-robot-plugin
-[submodule "vendor/grammars/actionscript3-tmbundle"]
-	path = vendor/grammars/actionscript3-tmbundle
-	url = https://github.com/honzabrecka/actionscript3-tmbundle
 [submodule "vendor/grammars/Sublime-QML"]
 	path = vendor/grammars/Sublime-QML
 	url = https://github.com/skozlovf/Sublime-QML
@@ -794,3 +791,6 @@
 [submodule "vendor/CodeMirror"]
 	path = vendor/CodeMirror
 	url = https://github.com/codemirror/CodeMirror
+[submodule "vendor/grammars/actionscript3-tmbundle"]
+	path = vendor/grammars/actionscript3-tmbundle
+	url = https://github.com/simongregory/actionscript3-tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -134,7 +134,7 @@ vendor/grammars/X10:
 - source.x10
 vendor/grammars/abap.tmbundle:
 - source.abap
-vendor/grammars/actionscript3-tmbundle:
+vendor/grammars/actionscript3-tmbundle/:
 - source.actionscript.3
 - text.html.asdoc
 - text.xml.flex-config

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -29,7 +29,6 @@ class TestGrammars < Minitest::Test
     "9f0c0b0926a18f5038e455e8df60221125fc3111", # elixir-tmbundle
     "90af581219debd4e90ef041b46c294e8b4ae6d14", # mako-tmbundle
     "b9b24778619dce325b651f0d77cbc72e7ae0b0a3", # Julia.tmbundle
-    "2d4f8807be850efd925751a8e1839cfc539985b0", # actionscript3-tmbundle
     "e06722add999e7428048abcc067cd85f1f7ca71c", # r.tmbundle
     "50b14a0e3f03d7ca754dac42ffb33302b5882b78", # smalltalk-tmbundle
     "eafbc4a2f283752858e6908907f3c0c90188785b", # gap-tmbundle


### PR DESCRIPTION
We changed the grammar for ActionScript to a fork some time ago (#2100) because it had some highlighting issues. Most of the fixes have now been upstreamed. The upstream repository also has a recognized license, which makes one less entry on our whitelist :tada: 