### PR TITLE
Makefile.boot misclassified as Clojure.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2427,6 +2427,7 @@ Makefile:
   - Kbuild
   - Makefile
   - Makefile.am
+  - Makefile.boot
   - Makefile.frag
   - Makefile.in
   - Makefile.inc


### PR DESCRIPTION
Clojure has claimed the `.boot` file extension.  The bulk of all `.boot` files seem to be named [`Makefile.boot`](https://github.com/search?q=extension%3Aboot+NOT+slartibartfast&type=Code), which are decidedly *not* Clojure.

This is an easy fix to undo most of the damage.  The [remaining files](https://github.com/search?q=extension%3Aboot+-filename%3AMakefile.boot&type=Code) also seem to be mostly makefiles, but it's late and I need to sleep.