### PR TITLE
Add Support for ABNF

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -797,3 +797,6 @@
 [submodule "vendor/grammars/actionscript3-tmbundle"]
 	path = vendor/grammars/actionscript3-tmbundle
 	url = https://github.com/simongregory/actionscript3-tmbundle
+[submodule "vendor/grammars/ABNF.tmbundle"]
+	path = vendor/grammars/ABNF.tmbundle
+	url = https://github.com/sanssecours/ABNF.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -4,6 +4,8 @@ http://svn.edgewall.org/repos/genshi/contrib/textmate/Genshi.tmbundle/Syntaxes/M
 https://bitbucket.org/Clams/sublimesystemverilog/get/default.tar.gz:
 - source.systemverilog
 - source.ucfconstraints
+vendor/grammars/ABNF.tmbundle:
+- source.abnf
 vendor/grammars/Agda.tmbundle:
 - source.agda
 vendor/grammars/Alloy.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -49,6 +49,13 @@ ABAP:
   - ".abap"
   ace_mode: abap
   language_id: 1
+ABNF:
+  type: data
+  ace_mode: text
+  extensions:
+  - ".abnf"
+  tm_scope: source.abnf
+  language_id: 429
 AGS Script:
   type: programming
   color: "#B9D9FF"

--- a/samples/ABNF/toml.abnf
+++ b/samples/ABNF/toml.abnf
@@ -1,0 +1,190 @@
+; Source:  https://github.com/toml-lang/toml
+; License: MIT
+
+;; This is an attempt to define TOML in ABNF according to the grammar defined
+;; in RFC 4234 (http://www.ietf.org/rfc/rfc4234.txt).
+
+;; TOML
+
+toml = expression *( newline expression )
+expression = (
+  ws /
+  ws comment /
+  ws keyval ws [ comment ] /
+  ws table ws [ comment ]
+)
+
+;; Newline
+
+newline = (
+  %x0A /              ; LF
+  %x0D.0A             ; CRLF
+)
+
+newlines = 1*newline
+
+;; Whitespace
+
+ws = *(
+  %x20 /              ; Space
+  %x09                ; Horizontal tab
+)
+
+;; Comment
+
+comment-start-symbol = %x23 ; #
+non-eol = %x09 / %x20-10FFFF
+comment = comment-start-symbol *non-eol
+
+;; Key-Value pairs
+
+keyval-sep = ws %x3D ws ; =
+keyval = key keyval-sep val
+
+key = unquoted-key / quoted-key
+unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
+quoted-key = quotation-mark 1*basic-char quotation-mark ; See Basic Strings
+
+val = integer / float / string / boolean / date-time / array / inline-table
+
+;; Table
+
+table = std-table / array-table
+
+;; Standard Table
+
+std-table-open  = %x5B ws     ; [ Left square bracket
+std-table-close = ws %x5D     ; ] Right square bracket
+table-key-sep   = ws %x2E ws  ; . Period
+
+std-table = std-table-open key *( table-key-sep key) std-table-close
+
+;; Array Table
+
+array-table-open  = %x5B.5B ws  ; [[ Double left square bracket
+array-table-close = ws %x5D.5D  ; ]] Double right square bracket
+
+array-table = array-table-open key *( table-key-sep key) array-table-close
+
+;; Integer
+
+integer = [ minus / plus ] int
+minus = %x2D                       ; -
+plus = %x2B                        ; +
+digit1-9 = %x31-39                 ; 1-9
+underscore = %x5F                  ; _
+int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
+
+;; Float
+
+float = integer ( frac / frac exp / exp )
+zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
+frac = decimal-point zero-prefixable-int
+decimal-point = %x2E               ; .
+exp = e integer
+e = %x65 / %x45                    ; e E
+
+;; String
+
+string = basic-string / ml-basic-string / literal-string / ml-literal-string
+
+;; Basic String
+
+basic-string = quotation-mark *basic-char quotation-mark
+
+quotation-mark = %x22            ; "
+
+basic-char = basic-unescaped / escaped
+escaped = escape ( %x22 /          ; "    quotation mark  U+0022
+                   %x5C /          ; \    reverse solidus U+005C
+                   %x2F /          ; /    solidus         U+002F
+                   %x62 /          ; b    backspace       U+0008
+                   %x66 /          ; f    form feed       U+000C
+                   %x6E /          ; n    line feed       U+000A
+                   %x72 /          ; r    carriage return U+000D
+                   %x74 /          ; t    tab             U+0009
+                   %x75 4HEXDIG /  ; uXXXX                U+XXXX
+                   %x55 8HEXDIG )  ; UXXXXXXXX            U+XXXXXXXX
+
+basic-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+
+escape = %x5C                    ; \
+
+;; Multiline Basic String
+
+ml-basic-string-delim = quotation-mark quotation-mark quotation-mark
+ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
+ml-basic-body = *( ml-basic-char / newline / ( escape newline ))
+
+ml-basic-char = ml-basic-unescaped / escaped
+ml-basic-unescaped = %x20-5B / %x5D-10FFFF
+
+;; Literal String
+
+literal-string = apostraphe *literal-char apostraphe
+
+apostraphe = %x27 ; ' Apostrophe
+
+literal-char = %x09 / %x20-26 / %x28-10FFFF
+
+;; Multiline Literal String
+
+ml-literal-string-delim = apostraphe apostraphe apostraphe
+ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
+
+ml-literal-body = *( ml-literal-char / newline )
+ml-literal-char = %x09 / %x20-10FFFF
+
+;; Boolean
+
+boolean = true / false
+true    = %x74.72.75.65     ; true
+false   = %x66.61.6C.73.65  ; false
+
+;; Datetime (as defined in RFC 3339)
+
+date-fullyear  = 4DIGIT
+date-month     = 2DIGIT  ; 01-12
+date-mday      = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on month/year
+time-hour      = 2DIGIT  ; 00-23
+time-minute    = 2DIGIT  ; 00-59
+time-second    = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules
+time-secfrac   = "." 1*DIGIT
+time-numoffset = ( "+" / "-" ) time-hour ":" time-minute
+time-offset    = "Z" / time-numoffset
+
+partial-time   = time-hour ":" time-minute ":" time-second [time-secfrac]
+full-date      = date-fullyear "-" date-month "-" date-mday
+full-time      = partial-time time-offset
+
+date-time      = full-date "T" full-time
+
+;; Array
+
+array-open  = %x5B ws  ; [
+array-close = ws %x5D  ; ]
+
+array = array-open array-values array-close
+
+array-values = [ val [ array-sep ] [ ( comment newlines) / newlines ] /
+                 val array-sep [ ( comment newlines) / newlines ] array-values ]
+
+array-sep = ws %x2C ws  ; , Comma
+
+;; Inline Table
+
+inline-table-open  = %x7B ws     ; {
+inline-table-close = ws %x7D     ; }
+inline-table-sep   = ws %x2C ws  ; , Comma
+
+inline-table = inline-table-open inline-table-keyvals inline-table-close
+
+inline-table-keyvals = [ inline-table-keyvals-non-empty ]
+inline-table-keyvals-non-empty = key keyval-sep val /
+                                 key keyval-sep val inline-table-sep inline-table-keyvals-non-empty
+
+;; Built-in ABNF terms, reproduced here for clarity
+
+; ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
+; DIGIT = %x30-39 ; 0-9
+; HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"

--- a/vendor/licenses/grammar/ABNF.tmbundle.txt
+++ b/vendor/licenses/grammar/ABNF.tmbundle.txt
@@ -1,0 +1,206 @@
+---
+type: grammar
+name: ABNF.tmbundle
+license: apache-2.0
+---
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 René Schwaiger
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Hi,

this commit adds support for [Augmented Backus–Naur form][], a metalanguage used to specify language grammars. The language does not seem to be [that popular on GitHub](https://github.com/search?utf8=✓&q=extension%3Aabnf+NOT+nothack&type=Code&ref=searchresults), but important enough to be used in [popular repositories](https://github.com/toml-lang/toml/blob/abnf/toml.abnf). A RFC document, describing the current version of the language, is available [here](https://tools.ietf.org/html/rfc5234).

If I should change anything in this pull request, then please just comment below. Thank you.

Kind regards,
  René

[Augmented Backus–Naur form]: https://en.wikipedia.org/wiki/Augmented_Backus–Naur_form
