### PR TITLE
Exclude "_examples" directory from language statistics.

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -50,6 +50,9 @@
 # Go dependencies
 - Godeps/_workspace/
 
+# Examples directory with underscore, usually in Go projects
+- _examples/
+
 # Minified JavaScript and CSS
 - (\.|-)min\.(js|css)$
 


### PR DESCRIPTION
Exclude GoLang "_examples" directory from language statistics.

At Go Programming Language we mostly put our examples in the `_examples` directory, because `_` is Excluded from `go build` tool which provides us the binary, executable program file.

For example if someone develop a template parser in Go and the project has `_examples/` directory with tons of html examples, then the project will act as `HTML` project and not `Go`