### PR TITLE
Add Reason, a variant of OCaml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2835,6 +2835,7 @@ OCaml:
   - ".mli"
   - ".mll"
   - ".mly"
+  - ".re"
   interpreters:
   - ocaml
   - ocamlrun


### PR DESCRIPTION
Reason is a new variant of OCaml. For now, we can just highlight it as OCaml code. In the future we may have better support for more specific features.