### PR TITLE
Remove Ant from grammar whitelist

### DIFF
--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -6,7 +6,6 @@ class TestGrammars < Minitest::Test
   # List of projects that are allowed without licenses
   PROJECT_WHITELIST = [
     "vendor/grammars/Sublime-Lasso",
-    "vendor/grammars/ant.tmbundle",
     "vendor/grammars/sublime-spintools",
     "vendor/grammars/blitzmax"
   ].freeze
@@ -40,6 +39,7 @@ class TestGrammars < Minitest::Test
     "c9118c370411f2f049c746c0fd096554e877aea2", # perl6fe
     "8ccf886749c32fb7e65d4d1316a7ed0479c93dc9", # language-less
     "2f03492b52d7dd83b4e7472f01b87c6121e5b1a4", # monkey
+    "241e5ddbb4423d792216783e9f668bd670b026e4", # ant.tmbundle
     "bdab9fdc21e6790b479ccb5945b78bc0f6ce2493"  # language-blade
   ].freeze
 


### PR DESCRIPTION
The last version of Licensee ([`v8.7.0`](https://github.com/benbalter/licensee/releases/tag/v8.7.0)) can recognize underlined license headers in READMEs (see benbalter/licensee#138). ~~Thus, the license of the Ant grammar is correctly recognized and whitelisting it is not necessary anymore.~~ EDIT: Unfortunately the Ant grammar doesn't have exactly the usual TextMate bundle license, so the license hash is different and I had to add it to the hash whitelist (meaning we just switched one whitelist entry for another :/). 

Fixes the master branch Travis build.