### PR TITLE
Fix invocation of script/list-grammars

### DIFF
--- a/script/add-grammar
+++ b/script/add-grammar
@@ -93,4 +93,4 @@ log "Confirming license"
 `script/licensed --module "#{repo_new}"`
 
 log "Updating grammar documentation in vendor/REAEDME.md"
-`script list-grammars`
+`script/list-grammars`


### PR DESCRIPTION
This wasn't added correctly in 43fa563. In fact, it causes the running session to hang, since it's making a call to `/usr/bin/script`. To quote `script`'s manpage:

>  The **script** utility makes a typescript of everything printed on your terminal.  It is useful for students who need a hardcopy record of an interactive session as proof of an assignment, as the typescript file can be printed out later with lpr(1).
>
> If the argument `file` is given, script saves all dialogue in `file`. If no file name is given, the typescript is saved in the file `typescript`.

What makes this truly nasty is the running process can't be killed in the usual manner, since it's directing SIGTERM to the session's transcript. I had to force-quit using Finder.