### PR TITLE
Treat bcsymbolmap as binary

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -52,6 +52,7 @@ module Linguist
     # Return true or false
     def generated?
       xcode_file? ||
+      bitcode_symbolmap? ||
       generated_net_designer_file? ||
       generated_net_specflow_feature_file? ||
       composer_lock? ||
@@ -85,9 +86,19 @@ module Linguist
     # Generated if the file extension is an Xcode
     # file extension.
     #
-    # Returns true of false.
+    # Returns true or false.
     def xcode_file?
       ['.nib', '.xcworkspacedata', '.xcuserstate'].include?(extname)
+    end
+
+    # Internal: Is the blob bitcode symbol map?
+    #
+    # Generated if the file extension is a bitcode
+    # symbol map.
+    #
+    # Returns true or false.
+    def bitcode_symbolmap?
+      return extname.downcase == '.bcsymbolmap'
     end
 
     # Internal: Is the blob minified files?

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -42,6 +42,9 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data("Dummy/foo.xcworkspacedata")
     generated_sample_without_loading_data("Dummy/foo.xcuserstate")
 
+    # Bitcode symbol map
+    generated_sample_without_loading_data("Dummy/1234-5678-01234.bcsymbolmap")
+
     # Go-specific vendored paths
     generated_sample_without_loading_data("go/vendor/github.com/foo.go")
     generated_sample_without_loading_data("go/vendor/golang.org/src/foo.c")


### PR DESCRIPTION
There are reasons why people need to keep these in the repo, so at least lets treat these files as binary.