### PR TITLE
Add Nunjucks highlighting

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1659,13 +1659,16 @@ HTML+Django:
   tm_scope: text.html.django
   group: HTML
   extensions:
-  - ".mustache"
   - ".jinja"
+  - ".mustache"
+  - ".njk"
   aliases:
   - django
   - html+django/jinja
   - html+jinja
   - htmldjango
+  - njk
+  - nunjucks
   ace_mode: django
   codemirror_mode: django
   codemirror_mime_type: text/x-django

--- a/samples/HTML+Django/nunjucks.njk
+++ b/samples/HTML+Django/nunjucks.njk
@@ -1,0 +1,48 @@
+{% from "forms.html" import label as description %}
+
+
+{% macro field(name, value='', type='text') %}
+    <div class="field">
+        <input type="{{ type }}" name="{{ name }}"
+                value="{{ value | escape }}" />
+    </div>
+{% endmacro %}
+
+<html>
+<head>
+    {% extends "head.html" %}
+</head>
+<body>
+{% if horse %}
+    Chuck Norris once kicked a horse in the chin. Its descendants are known today as Giraffes.
+{% elif optimus %}
+    Chuck Norris once urinated in a semi truck's gas tank as a joke....that truck is now known as Optimus Prime.
+{% else %}
+    Chuck Norris threw a grenade and killed 50 people, then the grenade exploded.
+{% endif %}
+
+{% block left %}
+    This is the left side!
+{% endblock %}
+
+{% block right %}
+    This is the right side!
+{% endblock %}
+
+{{ description('Username') }}
+{{ field('user') }}
+{{ field('pass', type='password') }}
+
+<h1>Posts</h1>
+<ul>
+    {% for item in items %}
+        <li>{{ item.title }}</li>
+    {% else %}
+        <li>This would display if the 'item' collection were empty</li>
+    {% endfor %}
+</ul>
+
+{# Don't escape foo #}
+{{ foo | safe }}
+</body>
+</html>


### PR DESCRIPTION
Search results: https://github.com/search?utf8=%E2%9C%93&q=extension%3Anjk+NOT+nothack&type=Code&ref=searchresults

Nunjucks docs on file extension: https://mozilla.github.io/nunjucks/templating.html#file-extensions

> # File extensions
> Although you are free to use any file extension you wish for your Nunjucks template files, the Nunjucks community has adopted `.njk`.
> If you are developing tools or editor syntax helpers for Nunjucks, please include recognition of the `.njk` extension.