### PR TITLE
Fix error with filenames ending with a dot

### DIFF
--- a/lib/linguist/blob.rb
+++ b/lib/linguist/blob.rb
@@ -63,7 +63,7 @@ module Linguist
     #
     # Returns an Array
     def extensions
-      _, *segments = name.downcase.split(".")
+      _, *segments = name.downcase.split(".", -1)
 
       segments.map.with_index do |segment, index|
         "." + segments[index..-1].join(".")

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -235,6 +235,7 @@ class TestLanguage < Minitest::Test
     assert_equal [Language['Clojure']], Language.find_by_filename('riemann.config')
     assert_equal [Language['HTML+Django']], Language.find_by_filename('index.jinja')
     assert_equal [Language['Chapel']], Language.find_by_filename('examples/hello.chpl')
+    assert_equal [], Language.find_by_filename('F.I.L.E.')
   end
 
   def test_find_by_interpreter


### PR DESCRIPTION
`Blob.extensions()` returns a non empty extension for files ending with a dot. For instance,
```ruby
new Blob("K.U.S.H.", "").extensions => [".u.s.h", ".s.h", ".h"]
```
This pull request fixes that behavior.

Fixes #3348.
