### PR TITLE
Remove deprecated code

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -90,17 +90,6 @@ module Linguist
       language
     end
 
-    # Public: Detects the Language of the blob.
-    #
-    # blob - an object that includes the Linguist `BlobHelper` interface;
-    #       see Linguist::LazyBlob and Linguist::FileBlob for examples
-    #
-    # Returns Language or nil.
-    def self.detect(blob)
-      warn "[DEPRECATED] `Linguist::Language.detect` is deprecated. Use `Linguist.detect`. #{caller[0]}"
-      Linguist.detect(blob)
-    end
-
     # Public: Get all Languages
     #
     # Returns an Array of Languages

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -440,22 +440,6 @@ module Linguist
     # Returns the extensions Array
     attr_reader :filenames
 
-    # Deprecated: Get primary extension
-    #
-    # Defaults to the first extension but can be overridden
-    # in the languages.yml.
-    #
-    # The primary extension can not be nil. Tests should verify this.
-    #
-    # This method is only used by app/helpers/gists_helper.rb for creating
-    # the language dropdown. It really should be using `name` instead.
-    # Would like to drop primary extension.
-    #
-    # Returns the extension String.
-    def primary_extension
-      extensions.first
-    end
-
     # Public: Get URL escaped name.
     #
     # Examples

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -177,11 +177,6 @@ module Linguist
       @extension_index[extname.downcase]
     end
 
-    # DEPRECATED
-    def self.find_by_shebang(data)
-      @interpreter_index[Shebang.interpreter(data)]
-    end
-
     # Public: Look up Languages by interpreter.
     #
     # interpreter - String of interpreter name

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -334,17 +334,6 @@ module Linguist
     # Returns an Array of String names
     attr_reader :aliases
 
-    # Deprecated: Get code search term
-    #
-    # Examples
-    #
-    #   # => "ruby"
-    #   # => "python"
-    #   # => "perl"
-    #
-    # Returns the name String
-    attr_reader :search_term
-
     # Public: Get language_id (used in GitHub search)
     #
     # Examples

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -254,18 +254,6 @@ module Linguist
       @colors ||= all.select(&:color).sort_by { |lang| lang.name.downcase }
     end
 
-    # Public: A List of languages compatible with Ace.
-    #
-    # TODO: Remove this method in a 5.x release. Every language now needs an ace_mode
-    # key, so this function isn't doing anything unique anymore.
-    #
-    # Returns an Array of Languages.
-    def self.ace_modes
-      warn "This method will be deprecated in a future 5.x release. Every language now has an `ace_mode` set."
-      warn caller
-      @ace_modes ||= all.select(&:ace_mode).sort_by { |lang| lang.name.downcase }
-    end
-
     # Internal: Initialize a new Language
     #
     # attributes - A hash of attributes

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -14,8 +14,6 @@
 #                     listed alphabetically)
 # interpreters      - An Array of associated interpreters
 # searchable        - Boolean flag to enable searching (defaults to true)
-# search_term       - Deprecated: Some languages may be indexed under a
-#                     different alias. Avoid defining new exceptions.
 # language_id       - Integer used as a language-name-independent indexed field so that we can rename
 #                     languages in Linguist without reindexing all the code on GitHub. Must not be
 #                     changed for existing languages without the explicit permission of GitHub staff.
@@ -121,7 +119,6 @@ ASN.1:
 ASP:
   type: programming
   color: "#6a40fd"
-  search_term: aspx-vb
   tm_scope: text.html.asp
   aliases:
   - aspx
@@ -154,7 +151,6 @@ ActionScript:
   type: programming
   tm_scope: source.actionscript.3
   color: "#882B0F"
-  search_term: as3
   aliases:
   - actionscript 3
   - actionscript3
@@ -291,7 +287,6 @@ AspectJ:
 Assembly:
   type: programming
   color: "#6E4C13"
-  search_term: nasm
   aliases:
   - nasm
   extensions:
@@ -349,7 +344,6 @@ Awk:
   language_id: 28
 Batchfile:
   type: programming
-  search_term: bat
   aliases:
   - bat
   - batch
@@ -474,7 +468,6 @@ C#:
   codemirror_mode: clike
   codemirror_mime_type: text/x-csharp
   tm_scope: source.cs
-  search_term: csharp
   color: "#178600"
   aliases:
   - csharp
@@ -489,7 +482,6 @@ C++:
   ace_mode: c_cpp
   codemirror_mode: clike
   codemirror_mime_type: text/x-c++src
-  search_term: cpp
   color: "#f34b7d"
   aliases:
   - cpp
@@ -719,7 +711,6 @@ ColdFusion:
   type: programming
   ace_mode: coldfusion
   color: "#ed2cd6"
-  search_term: cfm
   aliases:
   - cfm
   - cfml
@@ -733,7 +724,6 @@ ColdFusion CFC:
   type: programming
   group: ColdFusion
   ace_mode: coldfusion
-  search_term: cfc
   aliases:
   - cfc
   extensions:
@@ -956,7 +946,6 @@ DTrace:
   language_id: 85
 Darcs Patch:
   type: data
-  search_term: dpatch
   aliases:
   - dpatch
   extensions:
@@ -1187,7 +1176,6 @@ Erlang:
 F#:
   type: programming
   color: "#b845fc"
-  search_term: fsharp
   aliases:
   - fsharp
   extensions:
@@ -1437,7 +1425,6 @@ Gentoo Eclass:
   language_id: 128
 Gettext Catalog:
   type: prose
-  search_term: pot
   searchable: false
   aliases:
   - pot
@@ -1847,7 +1834,6 @@ INI:
   language_id: 163
 IRC log:
   type: data
-  search_term: irc
   aliases:
   - irc
   - irc logs
@@ -2025,7 +2011,6 @@ Java:
 Java Server Pages:
   type: programming
   group: Java
-  search_term: jsp
   aliases:
   - jsp
   extensions:
@@ -2282,7 +2267,6 @@ Literate CoffeeScript:
   group: CoffeeScript
   ace_mode: text
   wrap: true
-  search_term: litcoffee
   aliases:
   - litcoffee
   extensions:
@@ -2291,7 +2275,6 @@ Literate CoffeeScript:
 Literate Haskell:
   type: programming
   group: Haskell
-  search_term: lhs
   aliases:
   - lhaskell
   - lhs
@@ -2553,7 +2536,6 @@ Max:
   aliases:
   - max/msp
   - maxmsp
-  search_term: max/msp
   extensions:
   - ".maxpat"
   - ".maxhelp"
@@ -2605,7 +2587,6 @@ MiniD:
   language_id: 231
 Mirah:
   type: programming
-  search_term: mirah
   color: "#c7a938"
   extensions:
   - ".druby"
@@ -3571,7 +3552,6 @@ Ragel in Ruby Host:
   language_id: 317
 Raw token data:
   type: data
-  search_term: raw
   aliases:
   - raw
   extensions:
@@ -3918,7 +3898,6 @@ Self:
   language_id: 345
 Shell:
   type: programming
-  search_term: bash
   color: "#89e051"
   aliases:
   - sh
@@ -4431,7 +4410,6 @@ Verilog:
 VimL:
   type: programming
   color: "#199f4b"
-  search_term: vim
   tm_scope: source.viml
   aliases:
   - vim
@@ -4787,7 +4765,6 @@ desktop:
 eC:
   type: programming
   color: "#913960"
-  search_term: ec
   extensions:
   - ".ec"
   - ".eh"
@@ -4837,7 +4814,6 @@ ooc:
 reStructuredText:
   type: prose
   wrap: true
-  search_term: rst
   aliases:
   - rst
   extensions:

--- a/script/set-language-ids
+++ b/script/set-language-ids
@@ -21,8 +21,6 @@ header = <<-EOF
 #                     listed alphabetically)
 # interpreters      - An Array of associated interpreters
 # searchable        - Boolean flag to enable searching (defaults to true)
-# search_term       - Deprecated: Some languages may be indexed under a
-#                     different alias. Avoid defining new exceptions.
 # language_id       - Integer used as a language-name-independent indexed field so that we can rename
 #                     languages in Linguist without reindexing all the code on GitHub. Must not be
 #                     changed for existing languages without the explicit permission of GitHub staff.

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -372,17 +372,6 @@ class TestLanguage < Minitest::Test
     assert Language['SuperCollider'].extensions.include?('.scd')
   end
 
-  def test_primary_extension
-    assert_equal '.pl', Language['Perl'].primary_extension
-    assert_equal '.py', Language['Python'].primary_extension
-    assert_equal '.rb', Language['Ruby'].primary_extension
-    assert_equal '.js', Language['JavaScript'].primary_extension
-    assert_equal '.coffee', Language['CoffeeScript'].primary_extension
-    assert_equal '.t', Language['Turing'].primary_extension
-    assert_equal '.ts', Language['TypeScript'].primary_extension
-    assert_equal '.sc', Language['SuperCollider'].primary_extension
-  end
-
   def test_eql
     assert Language['Ruby'].eql?(Language['Ruby'])
     assert !Language['Ruby'].eql?(Language['Python'])

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -345,13 +345,6 @@ class TestLanguage < Minitest::Test
     assert_equal 'text', Language['FORTRAN'].ace_mode
   end
 
-  def test_ace_modes
-    silence_warnings do
-      assert Language.ace_modes.include?(Language['Ruby'])
-      assert Language.ace_modes.include?(Language['FORTRAN'])
-    end
-  end
-
   def test_codemirror_mode
     assert_equal 'ruby', Language['Ruby'].codemirror_mode
     assert_equal 'javascript', Language['JavaScript'].codemirror_mode

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -106,39 +106,6 @@ class TestLanguage < Minitest::Test
     end
   end
 
-  # Used for code search indexing. Changing any of these values may
-  # require reindexing repositories.
-  def test_search_term
-    assert_equal 'perl',        Language['Perl'].search_term
-    assert_equal 'python',      Language['Python'].search_term
-    assert_equal 'ruby',        Language['Ruby'].search_term
-    assert_equal 'common-lisp', Language['Common Lisp'].search_term
-    assert_equal 'html+erb',    Language['HTML+ERB'].search_term
-    assert_equal 'max/msp',     Language['Max'].search_term
-    assert_equal 'puppet',      Language['Puppet'].search_term
-    assert_equal 'pure-data',   Language['Pure Data'].search_term
-
-    assert_equal 'aspx-vb',       Language['ASP'].search_term
-    assert_equal 'as3',           Language['ActionScript'].search_term
-    assert_equal 'nasm',          Language['Assembly'].search_term
-    assert_equal 'bat',           Language['Batchfile'].search_term
-    assert_equal 'csharp',        Language['C#'].search_term
-    assert_equal 'cpp',           Language['C++'].search_term
-    assert_equal 'cfm',           Language['ColdFusion'].search_term
-    assert_equal 'dpatch',        Language['Darcs Patch'].search_term
-    assert_equal 'fsharp',        Language['F#'].search_term
-    assert_equal 'pot',           Language['Gettext Catalog'].search_term
-    assert_equal 'irc',           Language['IRC log'].search_term
-    assert_equal 'lhs',           Language['Literate Haskell'].search_term
-    assert_equal 'mirah',         Language['Mirah'].search_term
-    assert_equal 'raw',           Language['Raw token data'].search_term
-    assert_equal 'bash',          Language['Shell'].search_term
-    assert_equal 'vim',           Language['VimL'].search_term
-    assert_equal 'jsp',           Language['Java Server Pages'].search_term
-    assert_equal 'rst',           Language['reStructuredText'].search_term
-    assert_equal 'supercollider', Language['SuperCollider'].search_term
-  end
-
   def test_popular
     assert Language['Ruby'].popular?
     assert Language['Perl'].popular?


### PR DESCRIPTION
This pull request removes deprecated code in preparation of a 5.0 release. In the order, the commits remove:

1. the `find_by_shebang` method: there is now a shebang strategy instead; 
0. the `ace_modes` method: every language has an `ace_mode` field now;
0. the `primary_extension` method: was used in Gists which don't have a language dropdown anymore;
0. the `Linguist::Language.detect` method: replaced by `Linguist.detect`;
0. `search_term` field in each language: not sure if it's still used, might need to remove that last commit.