### PR TITLE
Heuristic rule for TeX .cls files

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -110,6 +110,12 @@ module Linguist
       end
     end
 
+    disambiguate ".cls" do |data|
+      if /\\\w+{/.match(data)
+        Language["TeX"]
+      end
+    end
+
     disambiguate ".cs" do |data|
       if /![\w\s]+methodsFor: /.match(data)
         Language["Smalltalk"]

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -73,6 +73,15 @@ class TestHeuristcs < Minitest::Test
     })
   end
 
+  def test_cls_by_heuristics
+    assert_heuristics({
+      "TeX" => all_fixtures("TeX", "*.cls"),
+      nil => all_fixtures("Apex", "*.cls"),
+      nil => all_fixtures("OpenEdge ABL", "*.cls"),
+      nil => all_fixtures("Visual Basic", "*.cls"),
+    })
+  end
+
   def test_cs_by_heuristics
     assert_heuristics({
       "C#" => all_fixtures("C#", "*.cs"),


### PR DESCRIPTION
This pull request adds a heuristic rule for TeX `.cls` files. The `.cls` file extension is shared by 4 languages (TeX, Apex, OpenEdge ABL, and Visual Basic) and TeX files are often the subject of misclassification by the Bayesian classifier (e.g., #3299).

I'm guessing that this is happening because TeX files contain a lot of text which skew training. The tokenization process is also ignores `\` and `{` which make much of the construct in TeX files. These intuitions can be confirmed by checking the `samples.json` entries for TeX.

Fixes #3299.