### PR TITLE
Mark .indent.pro files as vendored

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -50,6 +50,9 @@
 # Go dependencies
 - Godeps/_workspace/
 
+# GNU indent profiles
+- .indent.pro
+
 # Minified JavaScript and CSS
 - (\.|-)min\.(js|css)$
 

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -294,6 +294,8 @@ class TestFileBlob < Minitest::Test
     assert !sample_blob("Godeps/Godeps.json").vendored?
     assert sample_blob("Godeps/_workspace/src/github.com/kr/s3/sign.go").vendored?
 
+    assert sample_blob(".indent.pro").vendored?
+
     # Rails vendor/
     assert sample_blob("vendor/plugins/will_paginate/lib/will_paginate.rb").vendored?
 


### PR DESCRIPTION
This pull request marks [`.indent.pro` files](https://github.com/search?o=desc&q=filename%3A.indent.pro&s=indexed&type=Code&utf8=%E2%9C%93) (GNU Indent profiles) as vendored.

Fixes #3202.