### PR TITLE
Fix the R sample that is incompatible with roxygen2.

### DIFF
--- a/samples/R/import.r
+++ b/samples/R/import.r
@@ -192,8 +192,8 @@ reload = function (module) {
     module_path = module_path(module)
     module_name = module_name(module)
     rm(list = module_path, envir = .loaded_modules)
-    #' @TODO Once we have `attach`, need also to take care of the search path
-    #' and whatnot.
+    # TODO: Once we have `attach`, need also to take care of the search path
+    # and whatnot.
     mod_ns = do_import(module_name, module_path)
     module_parent = parent.frame()
     mod_env = exhibit_namespace(mod_ns, module_ref, module_parent)


### PR DESCRIPTION
I got the error bellow when try to generate R document from this sample file: https://github.com/github/linguist/blob/master/samples/R/import.r#L195-L196

```r
@TODO [hello.R#196]: unknown tag 
```

In R, lines that starts with `#'` are for [roxygen2](https://cran.r-project.org/web/packages/roxygen2/index.html). So we should use `#` for usual code comments.