### PR TITLE
Add Genie programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1389,7 +1389,7 @@ Genie:
   ace_mode: text
   extensions:
   - ".gs"
-  color: "#fba53d"
+  color: "#fb855d"
   tm_scope: none
   language_id: 792408528
 Genshi:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1384,6 +1384,14 @@ Game Maker Language:
   codemirror_mode: clike
   codemirror_mime_type: text/x-c++src
   language_id: 125
+Genie:
+  type: programming
+  ace_mode: text
+  extensions:
+  - ".gs"
+  color: "#fba53d"
+  tm_scope: none
+  language_id: 792408528
 Genshi:
   type: programming
   extensions:

--- a/samples/Genie/Class.gs
+++ b/samples/Genie/Class.gs
@@ -1,0 +1,12 @@
+init
+	new Demo( "Demonstration class" ).run()
+
+class Demo
+	_message:string = ""
+
+	construct ( message:string = "Optional argument - no message passed in constructor" )
+		_message = message
+
+	def run()
+		print( _message )
+		

--- a/samples/Genie/Hello.gs
+++ b/samples/Genie/Hello.gs
@@ -1,0 +1,2 @@
+init
+	print( "Hello, World!" )


### PR DESCRIPTION
Genie was introduced in 2008 as part of the GNOME project:
https://wiki.gnome.org/Projects/Genie

It is a programming language that uses the Vala compiler to
produce native binaries. It has good bindings to C libraries
especially those that are part of the GObject world such as
Gtk+3 and GStreamer

At present the .gs extension on GitHub shows as Javascript or Gosu.
A GitHub search shows confusing results:
https://github.com/search?p=15&q=extension%3Ags+-language%3Ajavascript+-language%3Agosu+NOT+nothack&ref=searchresults&type=Code&utf8=%E2%9C%93

For some example projects see:
https://github.com/darkoverlordofdata/shmupwarz-vala
https://github.com/tliron/khovsgol/

The shmupwarz-vala project adds a .gitattributes file containing:
*.gs linguist-language=Genie
This pull request should at least enable Genie to be shown when projects use a relevant .gitattributes file.