### PR TITLE
Add Cask file as Emacs Lisp

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1121,6 +1121,7 @@ Emacs Lisp:
   - ".gnus"
   - ".spacemacs"
   - ".viper"
+  - Cask
   - Project.ede
   - _emacs
   - abbrev_defs

--- a/samples/Emacs Lisp/filenames/Cask
+++ b/samples/Emacs Lisp/filenames/Cask
@@ -1,8 +1,9 @@
-(package "cask-example" "1.2.3" "Example package for Emacs Cask")
-(source gnu)
+(package "composer" "0.0.7" "Interface to PHP Composer")
 (source "melpa" "https://melpa.org/packages/")
 
-(package-file "cask-example.el")
+(package-file "composer.el")
 
-(development
- (depends-on "dash"))
+(depends-on "f")
+(depends-on "s")
+(depends-on "request")
+(depends-on "seq")

--- a/samples/Emacs Lisp/filenames/Cask
+++ b/samples/Emacs Lisp/filenames/Cask
@@ -1,0 +1,8 @@
+(package "cask-example" "1.2.3" "Example package for Emacs Cask")
+(source gnu)
+(source "melpa" "https://melpa.org/packages/")
+
+(package-file "cask-example.el")
+
+(development
+ (depends-on "dash"))


### PR DESCRIPTION
`Cask` file is Emacs [Cask](https://github.com/cask/cask) configuration file.
The file is included in [user initialization file](https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html) directory (`.emacs.d`) and [Emacs Lisp package](https://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging.html#Packaging).

GitHub search result: https://github.com/search?utf8=%E2%9C%93&q=filename%3ACask&type=Code&ref=searchresults