### PR TITLE
Use https://github.com/textmate/diff.tmbundle/pull/6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -252,7 +252,7 @@
 	url = https://github.com/textmate/d.tmbundle
 [submodule "vendor/grammars/diff.tmbundle"]
 	path = vendor/grammars/diff.tmbundle
-	url = https://github.com/textmate/diff.tmbundle
+	url = https://github.com/kivikakk/diff.tmbundle
 [submodule "vendor/grammars/dylan.tmbundle"]
 	path = vendor/grammars/dylan.tmbundle
 	url = https://github.com/textmate/dylan.tmbundle


### PR DESCRIPTION
We have an issue highlighting diffs where, on a line that's been removed, the `-` only at the beginning of the line is highlighted as an insertion. The source turned out to be a slight bug in the upstream diff bundle.

This PR is a holdover until upstream merges; I'll issue a new PR to revert back to upstream once it's merged.