### PR TITLE
Allow for split(",") returning nil

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -215,7 +215,14 @@ module Linguist
     # Returns the Language or nil if none was found.
     def self.[](name)
       return nil if name.to_s.empty?
-      name && (@index[name.downcase] || @index[name.split(',').first.downcase])
+
+      lang = @index[name.downcase]
+      return lang if lang
+
+      name = name.split(',').first
+      return nil if name.to_s.empty?
+
+      @index[name.downcase]
     end
 
     # Public: A List of popular languages

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -460,4 +460,8 @@ class TestLanguage < Minitest::Test
       assert !language.color, "Unused colour assigned to #{language.name}"
     end
   end
+
+  def test_non_crash_on_comma
+    assert_nil Language[',']
+  end
 end


### PR DESCRIPTION
If you try to look up a non-existent language, you get `nil`. Unless you look up the string `","`. Then you get an exception.

(Fixes it so you don't get an exception.)