### PR TITLE
Be able to configure the number of threads for git submodules update

### DIFF
--- a/script/fast-submodule-update
+++ b/script/fast-submodule-update
@@ -51,7 +51,7 @@ SUBMODULES.partition { |submodule| SLOW_SUBMODULES.include?(submodule) }.flatten
   submodules.push(submodule)
 end
 
-(ENV['LINGUIST_SUBMODULE_THREADS'] || 8).to_i.times do
+(ARGV.first || 8).to_i.times do
   Thread.new { run_thread(submodules, results) }
 end
 

--- a/script/fast-submodule-update
+++ b/script/fast-submodule-update
@@ -51,7 +51,7 @@ SUBMODULES.partition { |submodule| SLOW_SUBMODULES.include?(submodule) }.flatten
   submodules.push(submodule)
 end
 
-8.times do
+(ENV['LINGUIST_SUBMODULE_THREADS'] || 8).to_i.times do
   Thread.new { run_thread(submodules, results) }
 end
 


### PR DESCRIPTION
This PR enables, via the `LINGUIST_SUBMODULE_THREADS ` env variable the number of threads that will be used for the submodule update operation.

This will let users to set this value at will in case they have beefier (or less powerful) machines.
