### PR TITLE
Register "Emakefile" as an Erlang filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1156,6 +1156,7 @@ Erlang:
   - ".xrl"
   - ".yrl"
   filenames:
+  - Emakefile
   - rebar.config
   - rebar.config.lock
   - rebar.lock

--- a/samples/Erlang/filenames/Emakefile
+++ b/samples/Erlang/filenames/Emakefile
@@ -1,0 +1,7 @@
+{"src/*", [
+   report, 
+   verbose, 
+   {i, "include"}, 
+   {outdir, "ebin"},
+   debug_info 
+]}.


### PR DESCRIPTION
As such a name would suggest, `Emakefile` files are a Make-like build facility for the Erlang language. The site's [official documentation](http://erlang.org/doc/man/make.html) has the full details of what these things contain.

**In-the-wild usage:** [~3,444 results](https://github.com/search?q=filename%3AEmakefile+NOT+nothack&type=Code), with no discrepancies. Total of 1421 unique repos among 1019 users.