### PR TITLE
Release v5.0.4

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'charlock_holmes', '~> 0.7.3'
   s.add_dependency 'escape_utils',    '~> 1.1.0'
   s.add_dependency 'mime-types',      '>= 1.19'
-  s.add_dependency 'rugged',          '0.25.0b10'
+  s.add_dependency 'rugged',          '0.25.1.1'
 
   s.add_development_dependency 'minitest', '>= 5.0'
   s.add_development_dependency 'mocha'

--- a/lib/linguist/version.rb
+++ b/lib/linguist/version.rb
@@ -1,3 +1,3 @@
 module Linguist
-  VERSION = "5.0.3"
+  VERSION = "5.0.4"
 end


### PR DESCRIPTION
- Fixes a null reference on yarn.lock check
- Upgrade of rugged to v0.25.1.1