### PR TITLE
Use official HTML logo primary color as color for HTML syntax

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1605,7 +1605,7 @@ HTML:
   ace_mode: html
   codemirror_mode: htmlmixed
   codemirror_mime_type: text/html
-  color: "#e44b23"
+  color: "#e34c26"
   aliases:
   - xhtml
   extensions:


### PR DESCRIPTION
Use primary color of HTML5 logo as defined on [Logo FAQ page](https://www.w3.org/html/logo/faq#colors).

Currently used color is `#e44b23` (which is closer to HSL 12° 78% 52%), but the logo primary color is defined as `#e34c26` (or HSL 12° 77% 52%).

As a side note: the official [logo in SVG format](https://www.w3.org/html/logo/downloads/HTML5_Badge.svg) has its primary color set to `#e34f26`, so go figure.