### PR TITLE
Add PowerShell color.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3226,6 +3226,7 @@ PowerBuilder:
   language_id: 292
 PowerShell:
   type: programming
+  color: "#012456"
   ace_mode: powershell
   codemirror_mode: powershell
   codemirror_mime_type: application/x-powershell


### PR DESCRIPTION
Adding color to PowerShell repos. Color is the default background color of a PowerShell console on Windows.