### PR TITLE
Accomodate Markdown lines which begin with '>'.

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -260,7 +260,7 @@ module Linguist
     end
 
     disambiguate ".md" do |data|
-      if /(^[-a-z0-9=#!\*\[|])|<\//i.match(data) || data.empty?
+      if /(^[-a-z0-9=#!\*\[|>])|<\//i.match(data) || data.empty?
         Language["Markdown"]
       elsif /^(;;|\(define_)/.match(data)
         Language["GCC machine description"]


### PR DESCRIPTION
This should resolve #3451.

I haven't tested it yet, but I'll do that as soon as the azure-docs repo has finished downloading.