### PR TITLE
Accomodate Markdown lines which begin with '`' and '"'.

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -260,7 +260,7 @@ module Linguist
     end
 
     disambiguate ".md" do |data|
-      if /(^[-a-z0-9=#!\*\[|>])|<\//i.match(data) || data.empty?
+      if /(^[-a-z0-9=#!\*\[|>`"])|<\//i.match(data) || data.empty?
         Language["Markdown"]
       elsif /^(;;|\(define_)/.match(data)
         Language["GCC machine description"]


### PR DESCRIPTION
With this fix in place, all but two files in #3451 are properly detected as Markdown.