### PR TITLE
Rakefile and irbrc ruby matching (and remove Gemfile.lock)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3707,7 +3707,6 @@ Ruby:
   - ".fcgi"
   - ".gemspec"
   - ".god"
-  - ".irbrc"
   - ".jbuilder"
   - ".mspec"
   - ".pluginspec"
@@ -3729,6 +3728,7 @@ Ruby:
   - jruby
   - rbx
   filenames:
+  - ".irbrc"
   - ".pryrc"
   - Appraisals
   - Berksfile
@@ -3744,6 +3744,7 @@ Ruby:
   - Mavenfile
   - Podfile
   - Puppetfile
+  - Rakefile
   - Snapfile
   - Thorfile
   - Vagrantfile

--- a/samples/Ruby/filenames/.irbrc
+++ b/samples/Ruby/filenames/.irbrc
@@ -1,0 +1,2 @@
+require "pp"
+IRB.conf[:AUTO_INDENT] = true


### PR DESCRIPTION
Interestingly it has tests to match `Rakefile` and has a `Rakefile` sample but it's not in the ruby's filenames list. And `.irbrc` (like `.pryrc`) is better suited as a filename than a file extension

- Examples of `.irbrc`: https://github.com/search?q=irbrc&ref=searchresults&type=Commits&utf8=%E2%9C%93
- Examples of `.pryrc`: https://github.com/search?utf8=%E2%9C%93&q=pryrc&type=Commits&ref=searchresults
- Gemfile.lock has its own format https://github.com/search?utf8=%E2%9C%93&q=Gemfile.lock&type=Commits&ref=searchresults