### PR TITLE
Add .eb as Python like filetype

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1084,6 +1084,16 @@ Eagle:
   codemirror_mode: xml
   codemirror_mime_type: text/xml
   language_id: 97
+Easybuild:
+  type: data
+  group: Python
+  ace_mode: python
+  codemirror_mode: python
+  codemirror_mime_type: text/x-python
+  tm_scope: source.python
+  extensions:
+  - ".eb"
+  language_id: 342840477
 Ecere Projects:
   type: data
   group: JavaScript

--- a/samples/Easybuild/bzip2-1.0.6-GCC-4.9.2.eb
+++ b/samples/Easybuild/bzip2-1.0.6-GCC-4.9.2.eb
@@ -1,0 +1,20 @@
+# not really (there's an EB_bzip2 easyblock), but fine for use in unit tests
+easyblock = 'ConfigureMake'
+
+name = 'bzip2'
+version = '1.0.6'
+
+homepage = 'http://www.bzip.org/'
+description = """bzip2 is a freely available, patent free, high-quality data compressor. It typically
+compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
+compressors), whilst being around twice as fast at compression and six times faster at decompression."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.2'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.bzip.org/%(version)s']
+
+builddependencies = [('gzip', '1.6')]
+
+moduleclass = 'tools'


### PR DESCRIPTION
The hpcugent/easybuild-framework is a python framework for installation of applications on HPC envirnments. The actual package build description are written in python but having _.eb_ as extension.