### PR TITLE
Add support for rich text format (RTF) as data

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3512,6 +3512,13 @@ RPM Spec:
   codemirror_mode: rpm
   codemirror_mime_type: text/x-rpm-spec
   language_id: 314
+RTF:
+  type: data
+  ace_mode: text
+  extensions:
+  - ".rtf"
+  tm_scope: none
+  language_id: 51601661
 RUNOFF:
   type: markup
   color: "#665a4e"

--- a/samples/RTF/complicated.rtf
+++ b/samples/RTF/complicated.rtf
@@ -1,0 +1,7507 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf810
+{\fonttbl\f0\fnil\fcharset129 AppleMyungjo;\f1\froman\fcharset0 Times-Roman;\f2\froman\fcharset0 TimesNewRomanPSMT;
+}
+{\colortbl;\red255\green255\blue255;\red0\green51\blue153;\red51\green102\blue102;}
+{\*\expandedcolortbl;;\csgenericrgb\c0\c20000\c60000;\csgenericrgb\c20000\c40000\c40000;}
+{\info
+{\title IMPORTANT: PLEASE READ THIS END USER LICENSE AGREEMENT CAREFULLY}
+{\author Cisco Systems, Inc.}
+{\*\company Cisco Systems, Inc.}}\paperw12240\paperh15840\vieww31520\viewh22400\viewkind1\viewscale187
+\deftab720
+\pard\pardeftab720\ri0\qc\partightenfactor0
+
+\f0\fs24 \cf0 \'c3\'d6\'c1\'be
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'b0\'e8\'be\'e0
+\f1\b\fs28 \
+AMP for Endpoints 
+\f0\b0\fs24 \'c1\'a6\'c7\'b0
+\f2\b \
+\pard\pardeftab720\ri0\sb100\sa100\qj\partightenfactor0
+
+\f0\b0 \cf0 \'c1\'df\'bf\'e4
+\f2\b : 
+\f0\b0 \'ba\'bb
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'bb
+\f2  
+\f0 \'c1\'d6\'c0\'c7
+\f2  
+\f0 \'b1\'ed\'b0\'d4
+\f2  
+\f0 \'c0\'d0\'c0\'b8\'bd\'ca\'bd\'c3\'bf\'c0
+\f2\b . 
+\f0\b0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\b Cisco 
+\f0\b0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c0\'e5\'ba\'f1\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'c0\'d4\'c7\'cf\'bf\'b4\'c0\'b8\'b8\'e7
+\f2  
+\f0 \'b1\'cd\'c7\'cf
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'a5\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bd\'c7\'c3\'bc
+\f2\b (
+\f0\b0 \'c5\'eb\'c4\'aa\'c7\'cf\'bf\'a9
+\f2\b , "
+\f0\b0 \'b0\'ed\'b0\'b4
+\f2\b ")
+\f0\b0 \'b0\'a1
+\f2  
+\f0 \'ba\'bb
+\f2  
+\b Cisco 
+\f0\b0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'b7\'ce
+\f2  
+\f0 \'b5\'ee\'b7\'cf\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c0\'d6\'b4\'c2\'c1\'f6
+\f2  
+\f0 \'c8\'ae\'c0\'ce\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'c0\'cc
+\f2  
+\f0 \'b8\'c5\'bf\'ec
+\f2  
+\f0 \'c1\'df\'bf\'e4\'c7\'d5\'b4\'cf\'b4\'d9
+\f2\b .
+\b0 .  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'b7\'ce
+\f2  
+\f0 \'b5\'ee\'b7\'cf\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c0\'d6\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba\'b0\'a1
+\f2  
+\f0 \'be\'f8\'c0\'b8\'b8\'e7
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'c8
+\f2  
+\f0 \'bf\'f6\'b7\'b1\'c6\'bc\'b0\'a1
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2\b .
+\b0   
+\b Cisco 
+\f0\b0 \'b6\'c7\'b4\'c2
+\f2  
+\b Cisco 
+\f0\b0 \'c1\'a6\'b0\'f8
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'b8\'b7\'ce\'ba\'ce\'c5\'cd
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b4\'d9\'bf\'ee\'b7\'ce\'b5\'e5
+\f2\b , 
+\f0\b0 \'bc\'b3\'c4\'a1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'c0\'d4\'b4\'cf\'b4\'d9
+\f2\b .
+\b0  \
+Cisco Systems, Inc. 
+\f0 \'b6\'c7\'b4\'c2
+\f2  Cisco System, Inc.
+\f0 \'b8\'a6
+\f2  
+\f0 \'b4\'eb\'bd\'c5\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b4\'c2
+\f2  Cisco 
+\f0 \'c0\'da\'c8\'b8\'bb\'e7\'b4\'c2
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'c0\'d4\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b1\'d7\'b8\'ae\'b0\'ed
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'b0\'fa
+\f2  
+\f0 \'b4\'f5\'ba\'d2\'be\'ee
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'bf\'a1
+\f2  
+\f0 \'c7\'d4\'b2\'b2
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c7\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c1\'d6\'b9\'ae
+\f2  
+\f0 \'bd\'c3
+\f2  
+\f0 \'c0\'cc\'bf\'eb
+\f2  
+\f0 \'b0\'a1\'b4\'c9\'c7\'d1
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'c0\'c7
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2 (
+\f0 \'c5\'eb\'c4\'aa\'c7\'cf\'bf\'a9
+\f2  "
+\f0 \'b0\'e8\'be\'e0
+\f2 ")
+\f0 \'bf\'a1
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c8
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'c0\'bb
+\f2  
+\f0 \'bc\'f6\'b6\'f4\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'bf\'a1\'b8\'b8
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'ba\'bb
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'c0\'cc
+\f2  
+\f0 \'bb\'f3\'c3\'e6\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b4\'d9\'bf\'ee\'b7\'ce\'b5\'e5
+\f2 , 
+\f0 \'bc\'b3\'c4\'a1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d4\'c0\'b8\'b7\'ce\'bd\'e1
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'b8\'b7\'ce\'ba\'ce\'c5\'cd
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'cf\'bf\'b4\'c0\'b8\'b8\'e7
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c0\'c7\'b9\'ab\'b0\'a1
+\f2  
+\f0 \'c0\'d6\'c0\'bd\'c0\'bb
+\f2  
+\f0 \'b3\'aa\'c5\'b8\'b3\'bb\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'c0\'d4\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'bf\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  Cisco
+\f0 \'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'b8\'b8\'e7
+\f2  (A) 
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b4\'d9\'bf\'ee\'b7\'ce\'b5\'e5
+\f2 , 
+\f0 \'bc\'b3\'c4\'a1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'be\'f8\'b0\'ed
+\f2 , (B) 
+\f0 \'c0\'fc\'be\'d7
+\f2  
+\f0 \'c8\'af\'ba\'d2\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'b0\'b3\'ba\'c0\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  CD 
+\f0 \'c6\'d0\'c5\'b0\'c1\'f6\'bf\'cd
+\f2  
+\f0 \'bc\'ad\'b8\'e9
+\f2  
+\f0 \'c0\'da\'b7\'e1\'b8\'a6
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b9\'dd\'c8\'af\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'c0\'b8\'b8\'e7
+\f2  
+\f0 \'b6\'c7\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bc\'ad\'b8\'e9
+\f2  
+\f0 \'c0\'da\'b7\'e1\'b0\'a1
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'c0\'c7
+\f2  
+\f0 \'c0\'cf\'ba\'ce\'b7\'ce
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c8
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c0\'fc\'be\'d7
+\f2  
+\f0 \'c8\'af\'ba\'d2\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'c0\'fc
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'c0\'bb
+\f2  
+\f0 \'b9\'dd\'c8\'af\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b1\'cd\'c7\'cf\'c0\'c7
+\f2  
+\f0 \'b9\'dd\'c8\'af
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c8\'af\'ba\'d2
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'c0\'ba
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b1\'b8\'c0\'d4
+\f2  
+\f0 \'c8\'c4
+\f2  30
+\f0 \'c0\'cf
+\f2  
+\f0 \'c8\'c4\'bf\'a1
+\f2  
+\f0 \'b8\'b8\'b7\'e1\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'bf\'f8\'b7\'a1
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b5\'ee\'b7\'cf
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c0\'da\'c0\'ce
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'bf\'a1\'b8\'b8
+\f2  
+\f0 \'c0\'cc
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 .  
+\f0 \'ba\'bb
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1\'bc\'ad
+\f2  "
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8
+\f2 "
+\f0 \'c0\'cc\'b6\'f5
+\f2  (A) Cisco 
+\f0 \'b6\'c7\'b4\'c2
+\f2  (B) Cisco 
+\f0 \'c0\'e5\'ba\'f1
+\f2 , 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'c1\'f6\'bf\'aa
+\f2  
+\f0 \'b3\'bb\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'b9\'e8\'c6\'f7
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c6\'c7\'b8\'c5\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  Cisco
+\f0 \'b0\'a1
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'c7\'d1
+\f2  
+\f0 \'b0\'f8\'c0\'ce
+\f2  
+\f0 \'c3\'d1\'c6\'c7\'bb\'e7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bd\'c3\'bd\'ba\'c5\'db
+\f2  
+\f0 \'c5\'eb\'c7\'d5\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  (C) Cisco 
+\f0 \'c0\'e5\'ba\'f1
+\f2 , 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'c1\'f6\'bf\'aa
+\f2  
+\f0 \'b3\'bb\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'b9\'e8\'c6\'f7
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c6\'c7\'b8\'c5\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'c3\'d1\'c6\'c7\'bb\'e7\'c0\'c7
+\f2  Cisco 
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'be\'e0\'b0\'fc\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'c3\'d1\'c6\'c7\'bb\'e7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bd\'c3\'bd\'ba\'c5\'db
+\f2  
+\f0 \'c5\'eb\'c7\'d5\'be\'f7\'c3\'bc\'b0\'a1
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'c7\'d1
+\f2  
+\f0 \'b0\'f8\'c0\'ce
+\f2  
+\f0 \'b8\'ae\'bc\'bf\'b7\'af\'b8\'a6
+\f2  
+\f0 \'c0\'c7\'b9\'cc\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 .\
+
+\f0 \'b4\'d9\'c0\'bd\'c0\'c7
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'c0\'ba
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2\i (
+\f0\i0 \'be\'c6\'b7\'a1\'bf\'a1
+\f2  
+\f0 \'c1\'a4\'c0\'c7
+\f2\i )
+\f0\i0 \'c0\'bb
+\f2  
+\f0 \'b1\'d4\'c1\'a4\'c7\'cf\'b5\'c7
+\f2\i , (A) 
+\f0\i0 \'b0\'ed\'b0\'b4\'b0\'fa
+\f2  
+\i Cisco 
+\f0\i0 \'b0\'a3
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'b1\'d4\'c1\'a4\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'ba\'b0\'b5\'b5\'c0\'c7
+\f2  
+\f0 \'bc\'ad\'b8\'ed\'b5\'c8
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\i (B) 
+\f0\i0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'b1\'d4\'c1\'a4\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bc\'b3\'c4\'a1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b4\'d9\'bf\'ee\'b7\'ce\'b5\'e5
+\f2  
+\f0 \'c7\'c1\'b7\'ce\'bc\'bc\'bd\'ba\'c0\'c7
+\f2  
+\f0 \'c0\'cf\'ba\'ce\'b7\'ce\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'ba\'b0\'b5\'b5\'c0\'c7
+\f2  
+\i "
+\f0\i0 \'c5\'ac\'b8\'af
+\f2\i -
+\f0\i0 \'b5\'bf\'c0\'c7
+\f2\i " 
+\f0\i0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c8
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'b4\'c2
+\f2  
+\f0 \'bf\'b9\'bf\'dc\'c0\'d4\'b4\'cf\'b4\'d9
+\f2\i . 
+\f0\i0 \'c0\'a7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'c0\'c7
+\f2  
+\f0 \'c1\'b6\'c7\'d7
+\f2  
+\f0 \'b0\'a3\'bf\'a1
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c0\'cc
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2\i , (1) 
+\f0\i0 \'bc\'ad\'b8\'ed\'c7\'d1
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\i (2) 
+\f0\i0 \'c5\'ac\'b8\'af
+\f2\i -
+\f0\i0 \'b5\'bf\'c0\'c7
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c5\'b8\'bb\'e7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2\i , (3) 
+\f0\i0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'bc\'f8\'bc\'ad\'b4\'eb\'b7\'ce
+\f2  
+\f0 \'bf\'ec\'bc\'b1\'c7\'d5\'b4\'cf\'b4\'d9
+\f2\i .
+\i0  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\i "
+\f0\i0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2\i "
+\f0\i0 \'b4\'c2
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c8
+\f2  
+\f0 \'b4\'eb\'b7\'ce
+\f2  
+\i Cisco 
+\f0\i0 \'c0\'e5\'ba\'f1\'bf\'a1
+\f2  
+\f0 \'b3\'bb\'c0\'e5\'b5\'c8
+\f2  
+\f0 \'c6\'df\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f2  
+\f0 \'c7\'c1\'b7\'ce\'b1\'d7\'b7\'a5\'c0\'bb
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f2  
+\f0 \'c7\'c1\'b7\'ce\'b1\'d7\'b7\'a5
+\f2\i , 
+\f0\i0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5
+\f2\i , 
+\f0\i0 \'be\'f7\'b5\'a5\'c0\'cc\'c6\'ae
+\f2\i , 
+\f0\i0 \'b9\'f6\'b1\'d7
+\f2  
+\f0 \'bc\'f6\'c1\'a4
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'f6\'c1\'a4\'b5\'c8
+\f2  
+\f0 \'b9\'f6\'c0\'fc
+\f2\i (
+\f0\i0 \'c5\'eb\'c4\'aa
+\f2  
+\i "
+\f0\i0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5
+\f2\i "), Cisco 
+\f0\i0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'be\'e7\'b5\'b5
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c0\'e7\'b6\'f3\'c0\'cc\'bc\'be\'bd\'cc
+\f2  
+\f0 \'c1\'a4\'c3\'a5
+\f2\i (Cisco
+\f0\i0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'be\'f0\'c1\'a6\'b5\'e7\'c1\'f6
+\f2  
+\f0 \'bc\'f6\'c1\'a4\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'c0\'bd
+\f2\i )
+\f0\i0 \'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'c0\'e7\'b6\'f3\'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b5\'c8
+\f2  
+\f0 \'b0\'cd
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'b0\'cd\'c0\'c7
+\f2  
+\f0 \'b9\'e9\'be\'f7
+\f2  
+\f0 \'bb\'e7\'ba\'bb\'c0\'bb
+\f2  
+\f0 \'c0\'c7\'b9\'cc\'c7\'d5\'b4\'cf\'b4\'d9
+\f2\i .
+\i0 \
+
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2\i\b .
+\i0\b0  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'be\'e0\'b0\'fc\'c0\'bb
+\f2  
+\f0 \'c1\'d8\'bc\'f6\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b9\'fc\'c0\'a7\'bf\'a1\'bc\'ad
+\f2  Cisco
+\f0 \'b4\'c2
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1
+\f2  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'b8\'a6
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'b3\'bb\'ba\'ce
+\f2  
+\f0 \'ba\'f1\'c1\'ee\'b4\'cf\'bd\'ba
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'ba\'f1\'b5\'b6\'c1\'a1\'c0\'fb\'c0\'cc\'b0\'ed
+\f2  
+\f0 \'be\'e7\'b5\'b5
+\f2  
+\f0 \'ba\'d2\'b0\'a1\'b4\'c9\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'ba\'ce\'bf\'a9\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . "
+\f0 \'b9\'ae\'bc\'ad
+\f2 "
+\f0 \'b6\'f5
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b0\'fc\'c7\'d8
+\f2  
+\f0 \'c0\'db\'bc\'ba\'b5\'c7\'be\'ee
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'be\'ee\'b6\'b2
+\f2  
+\f0 \'b9\'e6\'bd\'c4\'c0\'b8\'b7\'ce\'b5\'e7
+\f2 (CD-ROM 
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bf\'c2\'b6\'f3\'c0\'ce
+\f2 ) 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'cd
+\f2  
+\f0 \'c7\'d4\'b2\'b2
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b5\'b5\'b7\'cf
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c1\'a4\'ba\'b8
+\f2 (
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'e2\'bc\'fa
+\f2  
+\f0 \'b8\'c5\'b4\'ba\'be\'f3
+\f2 , 
+\f0 \'b1\'b3\'c0\'b0
+\f2  
+\f0 \'c0\'da\'b7\'e1
+\f2 , 
+\f0 \'bb\'e7\'be\'e7
+\f2  
+\f0 \'b5\'ee
+\f2 )
+\f0 \'b8\'a6
+\f2  
+\f0 \'c0\'c7\'b9\'cc\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b7\'c1\'b8\'e9
+\f2  
+\f0 \'b5\'ee\'b7\'cf
+\f2  
+\f0 \'b9\'f8\'c8\'a3\'b3\'aa
+\f2  
+\f0 \'c1\'a6\'c7\'b0
+\f2  
+\f0 \'c0\'ce\'c1\'f5
+\f2  
+\f0 \'c5\'b0\'b8\'a6
+\f2  
+\f0 \'c0\'d4\'b7\'c2\'c7\'cf\'b0\'ed
+\f2  Cisco 
+\f0 \'c0\'a5\'bb\'e7\'c0\'cc\'c6\'ae\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bf\'c2\'b6\'f3\'c0\'ce\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f2  
+\f0 \'bb\'e7\'ba\'bb\'c0\'bb
+\f2  
+\f0 \'b5\'ee\'b7\'cf\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c5\'b0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c6\'c4\'c0\'cf\'c0\'bb
+\f2  
+\f0 \'be\'f2\'be\'ee\'be\'df
+\f2  
+\f0 \'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b4\'c2
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'f6\'b6\'f4\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b1\'b8\'b8\'c5
+\f2  
+\f0 \'c1\'d6\'b9\'ae\'bc\'ad
+\f2 ("
+\f0 \'b1\'b8\'b8\'c5
+\f2  
+\f0 \'c1\'d6\'b9\'ae\'bc\'ad
+\f2 ")
+\f0 \'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'b4\'dc\'c0\'cf
+\f2  
+\f0 \'c7\'cf\'b5\'e5\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bc\'a8\'bd\'c3\'b3\'aa
+\f2  
+\f0 \'c4\'ab\'b5\'e5
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'c0\'cc
+\f2  
+\f0 \'b9\'fc\'c0\'a7\'b8\'a6
+\f2  
+\f0 \'c3\'ca\'b0\'fa\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'be\'f8\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'b9\'ae\'bc\'ad
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c0\'d6\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'bd\'c7\'c7\'e0\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'b3\'bb\'c0\'e5\'b5\'c8
+\f2  
+\f0 \'b4\'eb\'b7\'ce\'b8\'b8
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b0\'c5\'b3\'aa
+\f2 , 
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'b0\'a1
+\f2  Cisco
+\f0 \'b0\'a1
+\f2  
+\f0 \'be\'c6\'b4\'d1
+\f2  
+\f0 \'c0\'e5\'ba\'f1\'bf\'a1
+\f2  
+\f0 \'bc\'b3\'c4\'a1\'b8\'a6
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'bc\'d2\'c0\'af\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c0\'d3\'b4\'eb\'c7\'d1
+\f2  Cisco 
+\f0 \'c0\'e5\'ba\'f1\'bf\'cd\'c0\'c7
+\f2  
+\f0 \'c5\'eb\'bd\'c5\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'b3\'bb\'ba\'ce
+\f2  
+\f0 \'ba\'f1\'c1\'ee\'b4\'cf\'bd\'ba
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d8\'bc\'ad\'b8\'b8
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b4\'c2
+\f2  
+\f0 \'b9\'ac\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2 , 
+\f0 \'b1\'dd\'b9\'dd\'be\'f0\'c0\'c7
+\f2  
+\f0 \'bf\'f8\'c4\'a2\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'be\'ee\'b6\'b0\'c7\'d1
+\f2  
+\f0 \'b9\'e6\'bd\'c4\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8\'bc\'ad
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+Cisco
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f2  
+\f0 \'ba\'ce\'b0\'fa\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c6\'f2\'b0\'a1\'c6\'c7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'a3\'c5\'b8
+\f2  
+\f0 \'bb\'e7\'ba\'bb\'c0\'c7
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c0\'a7\'c0\'c7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'bf\'e4\'b1\'dd
+\f2  
+\f0 \'c1\'f6\'ba\'d2
+\f2  
+\f0 \'bf\'e4\'b0\'c7\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c0\'cf\'b9\'dd
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7
+\f2\i\b . 
+\f0\i0\b0 \'c0\'cc\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'c0\'cc\'b8\'e7
+\f2  
+\f0 \'bc\'d2\'c0\'af\'b1\'c7
+\f2  
+\f0 \'be\'e7\'b5\'b5\'b0\'a1
+\f2  
+\f0 \'be\'c6\'b4\'d5\'b4\'cf\'b4\'d9
+\f2 . Cisco
+\f0 \'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'cd
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c0\'af\'b1\'c7\'c0\'bb
+\f2  
+\f0 \'ba\'b8\'c0\'af\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'cd
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'bf\'a1
+\f2  
+\f0 \'b0\'b3\'ba\'b0
+\f2  
+\f0 \'c7\'c1\'b7\'ce\'b1\'d7\'b7\'a5\'c0\'c7
+\f2  
+\f0 \'c6\'af\'c1\'a4
+\f2  
+\f0 \'b3\'bb\'ba\'ce
+\f2  
+\f0 \'bc\'b3\'b0\'e8
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'b8\'c1\'b6
+\f2  
+\f0 \'b0\'fc\'b7\'c3
+\f2  
+\f0 \'c0\'ce\'c5\'cd\'c6\'e4\'c0\'cc\'bd\'ba
+\f2  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'b3\'aa
+\f2  
+\f0 \'c0\'cc\'bf\'a1
+\f2  
+\f0 \'b1\'b9\'c7\'d1\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  Cisco 
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'c0\'da\'c0\'c7
+\f2  
+\f0 \'bf\'b5\'be\'f7
+\f2  
+\f0 \'b1\'e2\'b9\'d0\'c0\'bb
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c0\'d6\'b4\'d9\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'c0\'bb
+\f2  
+\f0 \'c0\'ce\'c1\'a4\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b4\'de\'b8\'ae
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'b8\'b7\'ce\'ba\'ce\'c5\'cd
+\f2  
+\f0 \'b1\'b8\'c0\'d4\'c7\'d1
+\f2  Cisco 
+\f0 \'c0\'e5\'ba\'f1
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'b0\'fa
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'b8
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b6\'c7\'c7\'d1
+\f2 , 
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4\'b4\'c2
+\f2  
+\f0 \'b4\'d9\'c0\'bd
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'c0\'cc
+\f2  
+\f0 \'be\'f8\'c0\'b8\'b8\'e7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'c6\'af\'ba\'b0\'c8\'f7
+\f2  
+\f0 \'b4\'d9\'c0\'bd
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'bb
+\f2  
+\f0 \'bc\'f6\'c7\'e0\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'bb
+\f2  
+\f0 \'b0\'cd\'bf\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . \
+(i) 
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'bb\'e7\'b6\'f7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bd\'c7\'c3\'bc\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b1\'c7\'c7\'d1
+\f2  
+\f0 \'be\'e7\'b5\'b5
+\f2 , 
+\f0 \'c7\'d2\'b4\'e7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c7\'cf\'c0\'a7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'ba\'ce\'bf\'a9
+\f2 (Cisco 
+\f0 \'c7\'f6\'c7\'e0
+\f2  
+\f0 \'c0\'e7\'b6\'f3\'c0\'cc\'bc\'be\'bd\'cc
+\f2 /
+\f0 \'be\'e7\'b5\'b5
+\f2  
+\f0 \'c1\'a4\'c3\'a5\'c0\'bb
+\f2  
+\f0 \'c1\'d8\'bc\'f6\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'cd
+\f2  
+\f0 \'bf\'dc
+\f2 ) 
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'b8\'b7\'ce\'ba\'ce\'c5\'cd
+\f2  
+\f0 \'b1\'b8\'c0\'d4\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  Cisco 
+\f0 \'c0\'e5\'ba\'f1\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c1\'df\'b0\'ed
+\f2  Cisco 
+\f0 \'c0\'e5\'ba\'f1\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'be\'e7\'b5\'b5
+\f2 , 
+\f0 \'c7\'d2\'b4\'e7
+\f2 , 
+\f0 \'c7\'cf\'c0\'a7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'ba\'ce\'bf\'a9
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'bd\'c3\'b5\'b5\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b9\'ab\'c8\'bf\'c0\'d3\'c0\'bb
+\f2  
+\f0 \'c0\'ce\'c1\'a4\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . \
+(ii) 
+\f0 \'bf\'c0\'b7\'f9\'b8\'a6
+\f2  
+\f0 \'b0\'ed\'c4\'a1\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b4\'de\'b8\'ae
+\f2  
+\f0 \'bc\'f6\'c1\'a4
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'a2\'bb\'f6\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b1\'e2\'b9\'dd\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c6\'c4\'bb\'fd\'b9\'b0\'c0\'bb
+\f2  
+\f0 \'b8\'b8\'b5\'e9\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc\'b0\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'cf\'c7\'d1
+\f2  
+\f0 \'c0\'db\'be\'f7\'c0\'bb
+\f2  
+\f0 \'c7\'cf\'b5\'b5\'b7\'cf
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 . \
+(iii) 
+\f0 \'ba\'bb
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'ba\'d2\'b1\'b8\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b9\'fd\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  Cisco
+\f0 \'b0\'a1
+\f2  
+\f0 \'b9\'fd\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'bf\'c0\'c7\'c2
+\f2  
+\f0 \'bc\'d2\'bd\'ba
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'bf\'cd
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  
+\f0 \'c6\'af\'c1\'a4
+\f2  
+\f0 \'c8\'b0\'b5\'bf\'c0\'bb
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'b8\'a6
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b8\'ae\'b9\'f6\'bd\'ba
+\f2  
+\f0 \'bf\'a3\'c1\'f6\'b4\'cf\'be\'ee\'b8\'b5
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b5\'f0\'c4\'c4\'c6\'c4\'c0\'cf
+\f2 , 
+\f0 \'be\'cf\'c8\'a3
+\f2  
+\f0 \'c7\'d8\'b5\'b6
+\f2 , 
+\f0 \'b5\'f0\'bd\'ba\'be\'ee\'bc\'c0\'ba\'ed
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'b6\'f7\'c0\'cc
+\f2  
+\f0 \'c0\'d0\'c0\'bb
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'c7\'fc\'bd\'c4\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'ba\'af\'b0\'e6\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 . \
+(iv) 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bd\'c7\'c7\'e0\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'ba\'a5\'c4\'a1\'b8\'b6\'c5\'a9
+\f2  
+\f0 \'c5\'d7\'bd\'ba\'c6\'ae
+\f2  
+\f0 \'b0\'e1\'b0\'fa\'b8\'a6
+\f2  
+\f0 \'b0\'d4\'bd\'c3\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 . \
+(v) Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'bc\'ad\'b8\'e9
+\f2  
+\f0 \'c0\'ce\'c1\'f5
+\f2  
+\f0 \'be\'f8\'c0\'cc
+\f2  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba
+\f2  
+\f0 \'bb\'e7\'b9\'ab\'bc\'d2\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bd\'c3\'b0\'a3
+\f2  
+\f0 \'b0\'f8\'c0\'af
+\f2  
+\f0 \'b1\'e2\'b9\'dd\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc\'c0\'c7
+\f2  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'bc\'f6\'c7\'e0\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b5\'a5
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b5\'b5\'b7\'cf
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 . \
+(vi) Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'bb\'e7\'c0\'fc
+\f2  
+\f0 \'bc\'ad\'b8\'e9
+\f2  
+\f0 \'bd\'c2\'c0\'ce
+\f2  
+\f0 \'be\'f8\'c0\'cc
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad
+\f2  
+\f0 \'b3\'bb\'bf\'a1
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c8
+\f2  
+\f0 \'bf\'b5\'be\'f7
+\f2  
+\f0 \'ba\'f1\'b9\'d0\'c0\'bb
+\f2  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b5\'b5\'b7\'cf
+\f2  
+\f0 \'b0\'f8\'b0\'b3
+\f2 , 
+\f0 \'c1\'a6\'b0\'f8
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b4\'de\'b8\'ae
+\f2  
+\f0 \'c1\'b6\'c0\'db\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'bf\'b5\'be\'f7
+\f2  
+\f0 \'ba\'f1\'b9\'d0\'c0\'bb
+\f2  
+\f0 \'ba\'b8\'c8\'a3\'c7\'cf\'b1\'e2
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'c7\'d5\'b4\'e7\'c7\'d1
+\f2  
+\f0 \'ba\'b8\'be\'c8
+\f2  
+\f0 \'c1\'b6\'c4\'a1\'b8\'a6
+\f2  
+\f0 \'c3\'eb\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b9\'fd
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'bc\'ad\'b8\'e9
+\f2  
+\f0 \'bf\'e4\'c3\'bb\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'cc
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'b5\'c7\'b8\'e9
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'cd
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'b5\'b6\'b8\'b3
+\f2  
+\f0 \'bb\'fd\'bc\'ba
+\f2  
+\f0 \'c7\'c1\'b7\'ce\'b1\'d7\'b7\'a5
+\f2  
+\f0 \'b0\'a3
+\f2  
+\f0 \'bb\'f3\'c8\'a3
+\f2  
+\f0 \'bf\'ee\'bf\'eb\'bc\'ba\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d1
+\f2  
+\f0 \'c0\'ce\'c5\'cd\'c6\'e4\'c0\'cc\'bd\'ba
+\f2  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'c1\'a4\'ba\'b8\'bf\'cd
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  
+\f0 \'b1\'e2\'b9\'d0
+\f2  
+\f0 \'c0\'af\'c1\'f6\'c0\'c7
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'bb
+\f2  
+\f0 \'be\'f6\'b0\'dd\'c8\'f7
+\f2  
+\f0 \'c1\'d8\'bc\'f6\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'cf\'b8\'e7
+\f2 , Cisco
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'b0\'a1\'b4\'c9\'c7\'cf\'b0\'d4
+\f2  
+\f0 \'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'be\'e0\'b0\'fc\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2\i\b , 
+\f0\i0\b0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'bb\'e7\'ba\'bb
+\f2\i\b . 
+\f0\i0\b0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'b1\'d7
+\f2  
+\f0 \'b9\'db\'c0\'c7
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'ba\'d2\'b1\'b8\'c7\'cf\'b0\'ed
+\f2  (1) 
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4\'b4\'c2
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb\'c0\'cc\'b3\'aa
+\f2  
+\f0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5\'b8\'a6
+\f2  
+\f0 \'bb\'fd\'bc\'ba\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bd\'c3\'c1\'a1\'bf\'a1
+\f2  
+\f0 \'bf\'f8\'b7\'a1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c0\'af\'c8\'bf\'c7\'d1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'ba\'b8\'c0\'af\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'bf\'f8\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2 , 
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5\'b8\'a6
+\f2  
+\f0 \'bb\'fd\'bc\'ba\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'c0\'cc
+\f2  
+\f0 \'be\'f8\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . (2) 
+\f0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'ba
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'bf\'f8\'b7\'a1
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c0\'da\'c0\'cc\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c0\'d3\'c2\'f7\'c0\'ce\'c0\'cc\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'be\'f7\'b1\'d7\'b7\'b9\'c0\'cc\'b5\'e5\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'c0\'af\'c8\'bf
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'ba\'b8\'c0\'af\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'bf\'a1
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d1
+\f2  Cisco 
+\f0 \'c0\'e5\'ba\'f1\'b7\'ce
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . (3) 
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb
+\f2  
+\f0 \'bb\'fd\'bc\'ba
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'ba
+\f2  
+\f0 \'c7\'ca\'bc\'f6
+\f2  
+\f0 \'b9\'e9\'be\'f7
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'c0\'b8\'b7\'ce\'b8\'b8
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'bc\'d2\'c0\'af\'b1\'c7
+\f2  
+\f0 \'c5\'eb\'c1\'f6
+\f2\i\b .
+\i0\b0  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c0\'fa\'c0\'db\'b1\'c7
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'bc\'d2\'c0\'af\'b1\'c7
+\f2  
+\f0 \'c5\'eb\'c1\'f6\'b0\'a1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b5\'bf\'c0\'cf\'c7\'d1
+\f2  
+\f0 \'c7\'fc\'bd\'c4
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'e6\'bd\'c4\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'c0\'fa\'c0\'db\'b1\'c7
+\f2 , 
+\f0 \'bc\'d2\'c0\'af\'b1\'c7
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'c5\'eb\'c1\'f6\'b8\'a6
+\f2  
+\f0 \'be\'ee\'b6\'b0\'c7\'d1
+\f2  
+\f0 \'c7\'fc\'c5\'c2\'b7\'ce\'b5\'e7
+\f2  
+\f0 \'c0\'af\'c1\'f6\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'ba\'b9\'c1\'a6\'c7\'d1\'b4\'d9\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'bf\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c0\'d6\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'bb\'e7\'c0\'fc
+\f2  
+\f0 \'bc\'ad\'b8\'e9
+\f2  
+\f0 \'c7\'e3\'b0\'a1
+\f2  
+\f0 \'be\'f8\'c0\'cc
+\f2  
+\f0 \'be\'ee\'b6\'b0\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb\'b5\'b5
+\f2  
+\f0 \'b8\'b8\'b5\'e9\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'ba\'b9\'c1\'a6\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'b1\'e2\'b0\'a3
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c1\'be\'b7\'e1
+\f2\i\b . 
+\f0\i0\b0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bf\'a9\'b1\'e2\'bf\'a1
+\f2  
+\f0 \'ba\'ce\'bf\'a9\'b5\'c8
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b4\'c2
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'c1\'be\'b7\'e1\'b5\'c9
+\f2  
+\f0 \'b6\'a7\'b1\'ee\'c1\'f6
+\f2  
+\f0 \'c0\'af\'c8\'bf\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb\'c0\'bb
+\f2  
+\f0 \'c6\'c4\'b1\'e2\'c7\'d4\'c0\'b8\'b7\'ce\'bd\'e1
+\f2  
+\f0 \'be\'f0\'c1\'a6\'b5\'e7\'c1\'f6
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'c1\'be\'b7\'e1\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'be\'ee\'b6\'b2
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'cc\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'c1\'d8\'bc\'f6\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'c5\'eb\'c1\'f6
+\f2  
+\f0 \'be\'f8\'c0\'cc
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b8\'a5
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'c0\'cc
+\f2  
+\f0 \'c1\'ef\'bd\'c3
+\f2  
+\f0 \'c1\'be\'b7\'e1\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'c1\'be\'b7\'e1
+\f2  
+\f0 \'bd\'c3
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'bc\'d2\'c0\'af\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'b0\'fc\'b8\'ae\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'ba\'b9\'bb\'e7\'ba\'bb\'c0\'bb
+\f2  
+\f0 \'c6\'c4\'b1\'e2\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'ba\'f1\'b9\'d0\'c0\'af\'c1\'f6\'c0\'c7\'b9\'ab
+\f2 , "
+\f0 \'c0\'cf\'b9\'dd
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7
+\f2 " 
+\f0 \'bc\'bd\'bc\'c7\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'ba\'ce\'b0\'fa\'b5\'c8
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'b1\'d4\'c1\'a6
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7
+\f2 , 
+\f0 \'ba\'b8\'c1\'f5\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c3\'a5\'c0\'d3
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2 , 
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'ba\'ce\'c0\'ce
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'d4\'c1\'a6\'b4\'c2
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'c1\'be\'b7\'e1\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'c0\'af\'c1\'f6\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b6\'c7\'c7\'d1
+\f2  "
+\f0 \'b9\'cc\'b1\'b9
+\f2  
+\f0 \'c1\'a4\'ba\'ce
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c0\'da
+\f2 " 
+\f0 \'b9\'d7
+\f2  "
+\f0 \'c1\'a6\'c7\'d1\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'be\'c8\'b3\'bb\'b9\'ae
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'c0\'cf\'b9\'dd
+\f2  
+\f0 \'be\'e0\'b0\'fc
+\f2 " 
+\f0 \'bc\'bd\'bc\'c7\'c0\'c7
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'c1\'be\'b7\'e1
+\f2  
+\f0 \'c0\'cc\'c8\'c4\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'c0\'af\'c1\'f6\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'b0\'ed\'b0\'b4
+\f2  
+\f0 \'b1\'e2\'b7\'cf
+\f2\i\b .
+\i0\b0  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'c1\'d8\'bc\'f6
+\f2  
+\f0 \'bf\'a9\'ba\'ce\'b8\'a6
+\f2  
+\f0 \'c8\'ae\'c0\'ce\'c7\'cf\'b1\'e2
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'c1\'a4\'bb\'f3
+\f2  
+\f0 \'bf\'b5\'be\'f7\'bd\'c3\'b0\'a3\'bf\'a1
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'c0\'e5\'ba\'ce
+\f2 , 
+\f0 \'b1\'e2\'b7\'cf
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b0\'e8\'c1\'a4\'c0\'bb
+\f2  
+\f0 \'b0\'cb\'c5\'e4\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'c0\'bb
+\f2  Cisco 
+\f0 \'b9\'d7
+\f2  
+\f0 \'b5\'b6\'b8\'b3
+\f2  
+\f0 \'c8\'b8\'b0\'e8\'bb\'e7\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'ba\'ce\'bf\'a9\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'b0\'a8\'bb\'e7\'b8\'a6
+\f2  
+\f0 \'c5\'eb\'c7\'d8
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'bb
+\f2  
+\f0 \'c1\'d8\'bc\'f6\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'b8\'f8\'c7\'df\'b4\'d9\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bd\'c7\'c0\'cc
+\f2  
+\f0 \'b9\'e0\'c7\'f4\'c1\'f6\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  Cisco
+\f0 \'bf\'a1
+\f2  
+\f0 \'c7\'d8\'b4\'e7\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'ba\'f1\'bf\'eb\'b0\'fa
+\f2  
+\f0 \'b0\'a8\'bb\'e7
+\f2  
+\f0 \'c1\'f8\'c7\'e0\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c0\'fb\'c0\'fd\'c7\'d1
+\f2  
+\f0 \'ba\'f1\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'c1\'ef\'b0\'a2
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'bc\'f6\'c3\'e2
+\f2\i\b , 
+\f0\i0\b0 \'c0\'e7\'bc\'f6\'c3\'e2
+\f2\i\b , 
+\f0\i0\b0 \'be\'e7\'b5\'b5
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'d4\'c1\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2\i\b .
+\i0\b0  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  Cisco
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b0\'f8\'b1\'de\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2 , 
+\f0 \'b9\'ae\'bc\'ad
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'bc\'fa
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c1\'f7\'c1\'a2
+\f2  
+\f0 \'c1\'a6\'c7\'b0
+\f2 (
+\f0 \'c0\'cc\'c8\'c4
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'bc\'fa
+\f2 )
+\f0 \'c0\'ba
+\f2  
+\f0 \'b9\'cc\'b1\'b9\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'d4\'c1\'a4\'b0\'fa
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b1\'b9\'b0\'a1\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'d4\'c1\'a4\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b8\'a5
+\f2  
+\f0 \'bc\'f6\'c3\'e2
+\f2  
+\f0 \'b1\'d4\'c1\'a6\'b8\'a6
+\f2  
+\f0 \'b5\'fb\'b8\'a8\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  Cisco 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'bc\'fa\'c0\'c7
+\f2  
+\f0 \'bc\'f6\'c3\'e2
+\f2 , 
+\f0 \'c0\'e7\'bc\'f6\'c3\'e2
+\f2 , 
+\f0 \'be\'e7\'b5\'b5
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'bf\'a1
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'d4\'c1\'a4\'c0\'bb
+\f2  
+\f0 \'c1\'d8\'bc\'f6\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b9\'cc\'b1\'b9
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c7\'f6\'c1\'f6\'c0\'c7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d1
+\f2  
+\f0 \'bd\'c2\'c0\'ce
+\f2 , 
+\f0 \'c7\'e3\'b0\'a1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . Cisco
+\f0 \'bf\'cd
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'b1\'c7\'c7\'d1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba\'c0\'c7
+\f2  
+\f0 \'ba\'b8\'c8\'a3\'bf\'cd
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'bb\'f3\'b4\'eb\'b9\'e6\'bf\'a1
+\f2  
+\f0 \'c7\'d5\'b8\'ae\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'bf\'e4\'b1\'b8\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'c1\'a4\'ba\'b8
+\f2 , 
+\f0 \'c1\'f6\'bf\'f8
+\f2  
+\f0 \'b9\'ae\'bc\'ad
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c1\'f6\'bf\'f8\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d2
+\f2  
+\f0 \'b0\'cd\'bf\'a1
+\f2  
+\f0 \'b0\'a2\'b0\'a2
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'bc\'f6\'c3\'e2
+\f2 , 
+\f0 \'c0\'e7\'bc\'f6\'c3\'e2
+\f2 , 
+\f0 \'be\'e7\'b5\'b5
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'c7
+\f2  
+\f0 \'b1\'d4\'c1\'a4\'c1\'d8\'bc\'f6\'bf\'cd
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  
+\f0 \'c1\'a4\'ba\'b8\'b4\'c2
+\f2  
+\f0 \'b4\'d9\'c0\'bd
+\f2  URL
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c3\'a3\'c0\'bb
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+\pard\pardeftab720\ri0\sb100\sa100\qj\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "http://www.cisco.com/web/about/doing_business/legal/global_export_trade/general_export/contract_compliance.html"}}{\fldrslt \cf2 \ul \ulc2 http://www.cisco.com/web/about/doing_business/legal/global_export_trade/general_export/contract_compliance.html}}\
+\pard\pardeftab720\ri0\sb100\sa100\qj\partightenfactor0
+
+\f0 \cf0 \'b9\'cc\'b1\'b9
+\f2  
+\f0 \'c1\'a4\'ba\'ce
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c0\'da
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'b4\'c2
+\f2  Federal Acquisition Regulation("FAR")(48 C.F.R.) 2.101
+\f0 \'bf\'a1
+\f2  
+\f0 \'c1\'a4\'c0\'c7\'b5\'c8
+\f2  
+\f0 \'b4\'eb\'b7\'ce
+\f2  "
+\f0 \'bb\'f3\'bf\'eb
+\f2  
+\f0 \'c7\'b0\'b8\'f1
+\f2 "
+\f0 \'c0\'cc\'b8\'e7
+\f2 , FAR 12.212
+\f0 \'bf\'a1
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'b5\'c8
+\f2  "
+\f0 \'bb\'f3\'bf\'eb
+\f2  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2 " 
+\f0 \'b9\'d7
+\f2  "
+\f0 \'bb\'f3\'bf\'eb
+\f2  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'ae\'bc\'ad
+\f2 " 
+\f0 \'b0\'b0\'c0\'ba
+\f2  
+\f0 \'bf\'eb\'be\'ee\'b7\'ce
+\f2  
+\f0 \'b1\'b8\'bc\'ba\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . FAR 12.212 
+\f0 \'b9\'d7
+\f2  DoD FAR Supp. 227.7202-1
+\f0 \'ba\'ce\'c5\'cd
+\f2  227.7202-4
+\f0 \'b1\'ee\'c1\'f6
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  FAR 
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'c5\'eb\'c7\'d5\'b5\'c9
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'b0\'e8\'be\'e0\'b0\'fa
+\f2  
+\f0 \'b9\'dd\'b4\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'ba\'d2\'b1\'b8\'c7\'cf\'b0\'ed
+\f2 , 
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'c1\'a4\'ba\'ce
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'b8\'b8\'c0\'cc
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c8
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'b8\'a6
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b0\'ed
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'c1\'f7\'c1\'a2\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c1\'a4\'ba\'ce
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'b0\'a1
+\f2  
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b3\'aa
+\f2  
+\f0 \'b9\'ae\'bc\'ad
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b5\'d1\'c0\'bb
+\f2  
+\f0 \'b8\'f0\'b5\'ce
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'b4\'c2
+\f2  "
+\f0 \'bb\'f3\'bf\'eb
+\f2  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2 " 
+\f0 \'b9\'d7
+\f2  "
+\f0 \'bb\'f3\'bf\'eb
+\f2  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'ae\'bc\'ad
+\f2 "
+\f0 \'b6\'f3\'b4\'c2
+\f2  
+\f0 \'c1\'a4\'ba\'ce\'bf\'cd\'c0\'c7
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'bc\'ba\'b8\'b3\'b5\'c7\'b0\'ed
+\f2 , 
+\f0 \'bf\'a9\'b1\'e2\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'b1\'c7\'b8\'ae\'bf\'cd
+\f2  
+\f0 \'c1\'a6\'be\'e0\'c0\'bb
+\f2  
+\f0 \'bc\'f6\'b6\'f4\'c7\'d1
+\f2  
+\f0 \'b0\'cd\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c7\'d8\'bc\'ae\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'bd\'c4\'ba\'b0\'b5\'c8
+\f2  
+\f0 \'b1\'b8\'bc\'ba
+\f2  
+\f0 \'bf\'e4\'bc\'d2
+\f2\i\b : 
+\f0\i0\b0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'bf\'eb\'be\'ee
+\f2\i\b .
+\i0\b0  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b4\'c2
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'bb\'e7\'c7\'d7
+\f2  
+\f0 \'c0\'cc\'bf\'dc\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'be\'e0\'b0\'fc
+\f2 , 
+\f0 \'ba\'b8\'c1\'f5\'c0\'c7
+\f2  
+\f0 \'b8\'e9\'c3\'a5\'c1\'b6\'c7\'d7
+\f2 , 
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'be\'e0\'b0\'fc
+\f2 (
+\f0 \'c5\'eb\'c4\'aa
+\f2  "
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'c1\'b6\'b0\'c7
+\f2 ")
+\f0 \'c0\'bb
+\f2  
+\f0 \'b5\'fb\'b8\'a3\'b8\'e7
+\f2  
+\f0 \'b9\'ae\'bc\'ad
+\f2 , Readme.txt 
+\f0 \'c6\'c4\'c0\'cf
+\f2 , 
+\f0 \'c5\'b8\'bb\'e7
+\f2  
+\f0 \'c5\'ac\'b8\'af
+\f2 -
+\f0 \'b5\'bf\'c0\'c7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'c0\'a7\'c4\'a1
+\f2 (
+\f0 \'bf\'b9
+\f2 : {\field{\*\fldinst{HYPERLINK "http://www.cisco.com/"}}{\fldrslt \cf2 \ul \ulc2 www.cisco.com}}))
+\f0 \'bf\'a1\'bc\'ad
+\f2  Cisco
+\f0 \'b0\'a1
+\f2  
+\f0 \'bd\'c4\'ba\'b0\'c7\'d1
+\f2  
+\f0 \'c5\'b8\'bb\'e7
+\f2  
+\f0 \'b1\'b8\'bc\'ba
+\f2  
+\f0 \'bf\'e4\'bc\'d2
+\f2 ("
+\f0 \'bd\'c4\'ba\'b0\'b5\'c8
+\f2  
+\f0 \'b1\'b8\'bc\'ba
+\f2  
+\f0 \'bf\'e4\'bc\'d2
+\f2 ")
+\f0 \'b8\'a6
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'cf\'b3\'aa
+\f2  
+\f0 \'c0\'cc\'bb\'f3\'c0\'c7
+\f2  
+\f0 \'b1\'b8\'bc\'ba
+\f2  
+\f0 \'bf\'e4\'bc\'d2\'b8\'a6
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c0\'cc\'b8\'a6
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c9
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 .\'a0 
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'bd\'c4\'ba\'b0\'b5\'c8
+\f2  
+\f0 \'b1\'b8\'bc\'ba
+\f2  
+\f0 \'bf\'e4\'bc\'d2\'bf\'a1
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'bf\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 .\'a0\
+\pard\pardeftab720\ri0\sb100\sa100\qj\partightenfactor0
+
+\f0 \cf3 \'c1\'a6\'c7\'d1\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\b\fs25 \
+\pard\pardeftab720\ri0\sb100\sa100\qj\partightenfactor0
+
+\f0\b0\fs24 \cf0 \'bf\'a9\'b1\'e2\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b0\'fa
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  Cisco
+\f0 \'b4\'c2
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'b9\'e8\'bc\'db\'b5\'c8
+\f2  
+\f0 \'b3\'af\'c2\'a5
+\f2 (Cisco 
+\f0 \'c0\'cc\'bf\'dc\'c0\'c7
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'c0\'e7\'c6\'c7\'b8\'c5\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'bf\'f8\'b7\'a1
+\f2  
+\f0 \'b9\'e8\'bc\'db\'c0\'cf\'b7\'ce\'ba\'ce\'c5\'cd
+\f2  90
+\f0 \'c0\'cf\'c0\'bb
+\f2  
+\f0 \'b3\'d1\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  
+\f0 \'bd\'c3\'c1\'a1
+\f2 )
+\f0 \'ba\'ce\'c5\'cd
+\f2  (a) 90
+\f0 \'c0\'cf
+\f2  
+\f0 \'b5\'bf\'be\'c8
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  (b) 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b0\'a1
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c8
+\f2  
+\f0 \'c1\'a6\'c7\'b0
+\f2 ("
+\f0 \'c1\'a6\'c7\'b0
+\f2 ")
+\f0 \'bf\'a1
+\f2  
+\f0 \'b5\'bf\'ba\'c0\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'c4\'ab\'b5\'e5\'bf\'a1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c6\'af\'ba\'b0\'c8\'f7
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'b1\'e2\'b0\'a3
+\f2 (
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2 ) 
+\f0 \'b5\'bf\'be\'c8
+\f2  (a) 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bc\'f6\'b7\'cf\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b9\'cc\'b5\'f0\'be\'ee\'b0\'a1
+\f2  
+\f0 \'c1\'a4\'bb\'f3
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'bd\'c3
+\f2  
+\f0 \'c0\'e7\'c1\'fa
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c1\'a6\'c1\'b6\'bb\'f3
+\f2  
+\f0 \'b0\'e1\'c7\'d4\'c0\'cc
+\f2  
+\f0 \'be\'f8\'c0\'b8\'b8\'e7
+\f2 , (b) 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b4\'c2
+\f2  
+\f0 \'bd\'c7\'c1\'a6\'b7\'ce
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'bf\'a1
+\f2  
+\f0 \'ba\'ce\'c7\'d5\'c7\'d4\'c0\'bb
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . Cisco 
+\f0 \'c1\'a6\'c7\'b0
+\f2  
+\f0 \'b9\'e8\'bc\'db
+\f2  
+\f0 \'b3\'af\'c2\'a5\'b4\'c2
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'c0\'cc
+\f2  
+\f0 \'b9\'e8\'bc\'db\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'c6\'f7\'c0\'e5
+\f2  
+\f0 \'c0\'e7\'b7\'e1\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'bb\'f3\'b1\'e2
+\f2  
+\f0 \'b3\'bb\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b4\'c2
+\f2  "
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b1\'d7\'b4\'eb\'b7\'ce
+\f2 " 
+\f0 \'c1\'a6\'b0\'f8\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'ba\'bb
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'c3\'b3\'c0\'bd
+\f2  
+\f0 \'b5\'ee\'b7\'cf\'b5\'c8
+\f2  
+\f0 \'c3\'d6\'c1\'be
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'c0\'ce
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'b8\'b7\'ce\'ba\'ce\'c5\'cd
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1\'b8\'b8
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'ba\'bb
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f2  
+\f0 \'c0\'af\'c0\'cf\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b9\'e8\'c5\'b8\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b1\'b8\'c1\'a6\'c3\'a5
+\f2  
+\f0 \'b9\'d7
+\f2  Cisco
+\f0 \'bf\'cd
+\f2  
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc\'c0\'c7
+\f2  
+\f0 \'c0\'fc\'c3\'bc
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'ba
+\f2  (i) 
+\f0 \'b0\'e1\'c7\'d4
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b9\'cc\'b5\'f0\'be\'ee\'c0\'c7
+\f2  
+\f0 \'b1\'b3\'c3\'bc
+\f2  
+\f0 \'b9\'d7
+\f2 /
+\f0 \'b6\'c7\'b4\'c2
+\f2  (ii) Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'bc\'b1\'c5\'c3\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b8\'a5
+\f2  
+\f0 \'bc\'f6\'b8\'ae
+\f2 , 
+\f0 \'b1\'b3\'c3\'bc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b1\'b8\'b8\'c5
+\f2  
+\f0 \'b0\'a1\'b0\'dd\'c0\'c7
+\f2  
+\f0 \'c8\'af\'ba\'d2\'c0\'cc\'b8\'e7
+\f2 , 
+\f0 \'b5\'ce
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b8\'f0\'b5\'ce
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'c7
+\f2  
+\f0 \'c0\'a7\'b9\'dd\'c0\'bb
+\f2  
+\f0 \'b1\'b8\'bc\'ba\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bf\'c0\'b7\'f9\'b3\'aa
+\f2  
+\f0 \'b0\'e1\'c7\'d4\'c0\'ba
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'b1\'e2\'b0\'a3
+\f2  
+\f0 \'b3\'bb\'bf\'a1
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d1
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'ba\'b8\'b0\'ed\'b5\'c8
+\f2  
+\f0 \'b0\'cd\'c0\'cc\'be\'ee\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . Cisco 
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'b4\'c2
+\f2  
+\f0 \'b1\'b8\'c1\'a6\'c3\'a5\'c0\'c7
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'c0\'b8\'b7\'ce\'bc\'ad
+\f2  
+\f0 \'bc\'b1\'c5\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2 /
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'c0\'c7
+\f2  
+\f0 \'b9\'dd\'c8\'af\'c0\'bb
+\f2  
+\f0 \'bf\'e4\'b1\'b8\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . Cisco
+\f0 \'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'bf\'c0\'b7\'f9\'b0\'a1
+\f2  
+\f0 \'be\'f8\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'b9\'ae\'c1\'a6
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c1\'df\'b4\'dc
+\f2  
+\f0 \'be\'f8\'c0\'cc
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c0\'db\'b5\'bf\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'d9\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'c0\'bb
+\f2  
+\f0 \'ba\'b8\'c0\'e5\'c7\'cf\'c1\'f6\'b4\'c2
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b6\'c7\'c7\'d1
+\f2  
+\f0 \'b3\'d7\'c6\'ae\'bf\'f6\'c5\'a9
+\f2  
+\f0 \'c4\'a7\'c0\'d4\'b0\'fa
+\f2  
+\f0 \'b0\'f8\'b0\'dd\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d1
+\f2  
+\f0 \'bb\'f5\'b7\'ce\'bf\'ee
+\f2  
+\f0 \'b1\'e2\'bc\'fa\'c0\'cc
+\f2  
+\f0 \'b0\'e8\'bc\'d3
+\f2  
+\f0 \'b9\'df\'c0\'fc\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'c0\'d6\'c0\'b8\'b9\'c7\'b7\'ce
+\f2  Cisco
+\f0 \'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b0\'a1
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'c0\'e5\'ba\'f1
+\f2 , 
+\f0 \'bd\'c3\'bd\'ba\'c5\'db
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b3\'d7\'c6\'ae\'bf\'f6\'c5\'a9\'b0\'a1
+\f2  
+\f0 \'c4\'a7\'c0\'d4\'c0\'cc\'b3\'aa
+\f2  
+\f0 \'b0\'f8\'b0\'dd\'bf\'a1
+\f2  
+\f0 \'c3\'eb\'be\'e0\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'bb
+\f2  
+\f0 \'b0\'cd\'c0\'cc\'b6\'f3\'b0\'ed
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c1\'a6\'be\'e0
+\f2  
+\f0 \'c1\'b6\'b0\'c7
+\f2\i\b .
+\i0\b0  
+\f0 \'c0\'cc
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2 , 
+\f0 \'c1\'a6\'c7\'b0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b0\'a1
+\f2  
+\f0 \'c0\'ce\'c1\'f5\'b5\'c7\'be\'ee
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c0\'e5\'ba\'f1\'b0\'a1
+\f2  (a) Cisco 
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'f8\'c0\'ce
+\f2  
+\f0 \'b4\'eb\'b8\'ae\'c0\'ce\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'d1
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'bd\'c7\'c3\'bc\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'ba\'af\'b0\'e6\'b5\'c7\'b0\'ed
+\f2  (b) Cisco
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d1
+\f2  
+\f0 \'c1\'f6\'c4\'a7\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'bc\'b3\'c4\'a1
+\f2 , 
+\f0 \'c0\'db\'b5\'bf
+\f2 , 
+\f0 \'bc\'f6\'b8\'ae
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c0\'af\'c1\'f6\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b0\'ed
+\f2  (c) 
+\f0 \'ba\'f1\'c1\'a4\'bb\'f3\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b9\'b0\'b8\'ae\'c0\'fb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c0\'fc\'b1\'e2\'c0\'fb
+\f2  
+\f0 \'c0\'c0\'b7\'c2
+\f2 , 
+\f0 \'ba\'f1\'c1\'a4\'bb\'f3\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'c8\'af\'b0\'e6
+\f2  
+\f0 \'c1\'b6\'b0\'c7
+\f2 , 
+\f0 \'bf\'c0\'bf\'eb
+\f2 , 
+\f0 \'b0\'fa\'bd\'c7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'b0\'ed\'b8\'a6
+\f2  
+\f0 \'b0\'c5\'c3\'c6\'b0\'c5\'b3\'aa
+\f2  (d) 
+\f0 \'ba\'a3\'c5\'b8
+\f2 , 
+\f0 \'c6\'f2\'b0\'a1
+\f2 , 
+\f0 \'c5\'d7\'bd\'ba\'c6\'ae
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b5\'a5\'b8\'f0
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b0\'a1
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c8
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'bf\'a1\'b4\'c2
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'bf\'aa\'bd\'c3
+\f2  (e) 
+\f0 \'c0\'d3\'bd\'c3
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b8\'f0\'b5\'e2
+\f2 , (f) Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bc\'be\'c5\'cd\'bf\'a1
+\f2  
+\f0 \'b0\'d4\'bd\'c3\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2 , (g) Cisco
+\f0 \'b0\'a1
+\f2  Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bc\'be\'c5\'cd\'bf\'a1
+\f2  "
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'b1\'d7\'b4\'eb\'b7\'ce
+\f2 " 
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2 , (h) 
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'cc
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f2  
+\f0 \'b9\'de\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'ba
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  (i) 
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'c0\'cc
+\f2  
+\f0 \'be\'c6\'b4\'d1
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c5\'b8\'bb\'e7\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d1
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1\'b4\'c2
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 .\
+\pard\pardeftab720\ri0\sb100\sa100\qj\partightenfactor0
+
+\f0 \cf3 \'ba\'b8\'c1\'f5\'c0\'c7
+\f2  
+\f0 \'b8\'e9\'c3\'a5\'c1\'b6\'c7\'d7
+\f2  
+\b\fs25 \
+\pard\pardeftab720\ri0\sb100\sa100\qj\partightenfactor0
+
+\f0\b0\fs24 \cf0 \'ba\'bb
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'bc\'bd\'bc\'c7\'bf\'a1
+\f2  
+\f0 \'c1\'f6\'c1\'a4\'b5\'c8
+\f2  
+\f0 \'b3\'bb\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'cf\'b0\'ed
+\f2\b , 
+\f0\b0 \'bb\'f3\'be\'f7\'bc\'ba
+\f2\b , 
+\f0\b0 \'c6\'af\'c1\'a4
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'bf\'a1\'c0\'c7
+\f2  
+\f0 \'c0\'fb\'c7\'d5\'bc\'ba
+\f2\b , 
+\f0\b0 \'ba\'f1\'c0\'a7\'b9\'dd
+\f2\b , 
+\f0\b0 \'b8\'b8\'c1\'b7\'bd\'ba\'b7\'b1
+\f2  
+\f0 \'c7\'b0\'c1\'fa
+\f2\b , 
+\f0\b0 \'ba\'f1\'c4\'a7\'c7\'d8\'bc\'ba
+\f2\b , 
+\f0\b0 \'c1\'a4\'ba\'b8
+\f2  
+\f0 \'b3\'bb\'bf\'eb\'c0\'c7
+\f2  
+\f0 \'c1\'a4\'c8\'ae\'bc\'ba\'c0\'bb
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'b3\'aa
+\f2  
+\f0 \'c0\'cc\'bf\'a1
+\f2  
+\f0 \'b1\'b9\'c7\'d1\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'c5\'b7\'a1
+\f2\b , 
+\f0\b0 \'b9\'fd\'b7\'fc
+\f2\b , 
+\f0\b0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b9\'ab\'bf\'aa
+\f2  
+\f0 \'b0\'fc\'c7\'e0\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'be\'cf\'bd\'c3\'c0\'fb
+\f2  
+\f0 \'c1\'b6\'b0\'c7
+\f2\b , 
+\f0\b0 \'c7\'a5\'c7\'f6
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b9\'fd\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'d1\'b5\'b5\'b1\'ee\'c1\'f6
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'b5\'c7\'b8\'e7
+\f2  
+\b Cisco, 
+\f0\b0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'ba\'ce\'c0\'ce\'b5\'cb\'b4\'cf\'b4\'d9
+\f2\b . 
+\f0\b0 \'b5\'bf\'c0\'cf\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'b9\'ac\'bd\'c3\'c0\'fb
+\f2  
+\f0 \'c1\'b6\'b0\'c7
+\f2\b , 
+\f0\b0 \'c7\'a5\'c7\'f6
+\f2  
+\f0 \'b9\'d7
+\f2\b /
+\f0\b0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'c0\'a7\'c0\'c7
+\f2  
+\b "
+\f0\b0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2\b " 
+\f0\b0 \'bc\'bd\'bc\'c7\'bf\'a1
+\f2  
+\f0 \'be\'f0\'b1\'de\'b5\'c8
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'b1\'e2\'b0\'a3\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'b5\'cb\'b4\'cf\'b4\'d9
+\f2\b . 
+\f0\b0 \'c0\'cf\'ba\'ce
+\f2  
+\f0 \'b1\'b9\'b0\'a1\'b3\'aa
+\f2  
+\f0 \'b0\'fc\'c7\'d2
+\f2  
+\f0 \'c1\'f6\'bf\'aa\'bf\'a1\'bc\'ad\'b4\'c2
+\f2  
+\f0 \'be\'cf\'bd\'c3\'c0\'fb
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'c7
+\f2  
+\f0 \'c1\'f6\'bc\'d3
+\f2  
+\f0 \'b1\'e2\'b0\'a3\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c0\'bb
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'b8\'b9\'c7\'b7\'ce
+\f2  
+\f0 \'c0\'a7\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'bb
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2\b . 
+\f0\b0 \'c0\'cc
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'c6\'af\'c1\'a4
+\f2  
+\f0 \'b9\'fd\'c0\'fb
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b8\'e7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  
+\f0 \'b0\'fc\'c7\'d2
+\f2  
+\f0 \'c1\'f6\'bf\'aa\'ba\'b0\'b7\'ce
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'b1\'c7\'b8\'ae\'b8\'a6
+\f2  
+\f0 \'ba\'b8\'c0\'af\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2\b . 
+\f0\b0 \'c0\'a7\'bf\'a1
+\f2  
+\f0 \'b1\'e2\'bc\'fa\'c7\'d1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'cc
+\f2  
+\f0 \'ba\'bb\'c1\'fa\'c0\'fb
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'bf\'a1
+\f2  
+\f0 \'b8\'c2\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b8\'e9\'c3\'a5\'c1\'b6\'c7\'d7
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bf\'b9\'bf\'dc\'b4\'c2
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c3\'a5\'c0\'d3\'c0\'c7
+\f2  
+\f0 \'b8\'e9\'c3\'a5\'c1\'b6\'c7\'d7
+\f2  
+\i\b - 
+\f0\i0\b0 \'c3\'a5\'c0\'d3\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7
+\f2\i\b .
+\i0\b0  
+\f0 \'b9\'cc\'b1\'b9
+\f2 , 
+\f0 \'b6\'f3\'c6\'be\'be\'c6\'b8\'de\'b8\'ae\'c4\'ab
+\f2 , 
+\f0 \'c4\'b3\'b3\'aa\'b4\'d9
+\f2 , 
+\f0 \'c0\'cf\'ba\'bb
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c4\'ab\'b8\'ae\'ba\'ea\'c7\'d8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b9\'dd\'b4\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b3\'bb\'bf\'eb\'c0\'cc
+\f2  
+\f0 \'c0\'d6\'b4\'f5\'b6\'f3\'b5\'b5
+\f2 , CISCO, 
+\f0 \'b0\'e8\'bf\'ad\'bb\'e7
+\f2 , 
+\f0 \'c0\'cc\'bb\'e7
+\f2 , 
+\f0 \'b0\'fc\'b8\'ae\'c0\'da
+\f2 , 
+\f0 \'c1\'f7\'bf\'f8
+\f2 , 
+\f0 \'bf\'a1\'c0\'cc\'c0\'fc\'c6\'ae
+\f2 , 
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'c0\'c7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2 , 
+\f0 \'ba\'d2\'b9\'fd
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 (
+\f0 \'b0\'fa\'bd\'c7
+\f2  
+\f0 \'c6\'f7\'c7\'d4
+\f2 ), 
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'c0\'a7\'b9\'dd
+\f2  
+\f0 \'b5\'ee
+\f2  
+\f0 \'b9\'ab\'be\'f9\'c0\'cc\'b5\'e7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'c0\'c7
+\f2  
+\f0 \'bf\'f8\'c0\'ce\'c0\'cc
+\f2  
+\f0 \'b5\'c8
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f2  
+\f0 \'b0\'a1\'b0\'dd\'c0\'bb
+\f2  
+\f0 \'b3\'d1\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'b8\'b8\'e7
+\f2 , 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b0\'a1
+\f2  
+\f0 \'b6\'c7
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'c0\'c7
+\f2  
+\f0 \'c0\'cf\'ba\'ce\'c0\'ce
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f2  
+\f0 \'b0\'a1\'b0\'dd\'c0\'bb
+\f2  
+\f0 \'b3\'d1\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c0\'cc
+\f2  
+\f0 \'c3\'a5\'c0\'d3
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c0\'ba
+\f2  
+\f0 \'b4\'a9\'c0\'fb\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'bb\'e7\'b0\'c7\'ba\'b0\'b7\'ce
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 (
+\f0 \'c1\'ef
+\f2 , 
+\f0 \'b5\'ce
+\f2  
+\f0 \'b0\'b3
+\f2  
+\f0 \'c0\'cc\'bb\'f3\'c0\'c7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'c0\'cc
+\f2  
+\f0 \'c0\'d6\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'c0\'cc
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c0\'cc
+\f2  
+\f0 \'c8\'ae\'b4\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 ). \
+
+\f0 \'c0\'af\'b7\'b4
+\f2 , 
+\f0 \'c1\'df\'b5\'bf
+\f2 , 
+\f0 \'be\'c6\'c7\'c1\'b8\'ae\'c4\'ab
+\f2 , 
+\f0 \'be\'c6\'bd\'c3\'be\'c6
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bf\'c0\'bc\'bc\'be\'c6\'b4\'cf\'be\'c6\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b9\'dd\'b4\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b3\'bb\'bf\'eb\'c0\'cc
+\f2  
+\f0 \'c0\'d6\'b4\'f5\'b6\'f3\'b5\'b5
+\f2 , Cisco, 
+\f0 \'b0\'e8\'bf\'ad\'bb\'e7
+\f2 , 
+\f0 \'c0\'cc\'bb\'e7
+\f2 , 
+\f0 \'b0\'fc\'b8\'ae\'c0\'da
+\f2 , 
+\f0 \'c1\'f7\'bf\'f8
+\f2 , 
+\f0 \'bf\'a1\'c0\'cc\'c0\'fc\'c6\'ae
+\f2 , 
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'c0\'c7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2 , 
+\f0 \'ba\'d2\'b9\'fd
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 (
+\f0 \'b0\'fa\'bd\'c7
+\f2  
+\f0 \'c6\'f7\'c7\'d4
+\f2 ), 
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'c0\'a7\'b9\'dd
+\f2  
+\f0 \'b5\'ee
+\f2  
+\f0 \'b9\'ab\'be\'f9\'c0\'cc\'b5\'e7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'c0\'c7
+\f2  
+\f0 \'bf\'f8\'c0\'ce\'c0\'cc
+\f2  
+\f0 \'b5\'c8
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  Cisco
+\f0 \'bf\'a1
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f2  
+\f0 \'b0\'a1\'b0\'dd\'c0\'bb
+\f2  
+\f0 \'b3\'d1\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'b8\'b8\'e7
+\f2 , 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b0\'a1
+\f2  
+\f0 \'b6\'c7
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'c0\'c7
+\f2  
+\f0 \'c0\'cf\'ba\'ce\'c0\'ce
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'c1\'a6\'c7\'b0\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f2  
+\f0 \'b0\'a1\'b0\'dd\'c0\'bb
+\f2  
+\f0 \'b3\'d1\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c0\'cc
+\f2  
+\f0 \'c3\'a5\'c0\'d3
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c0\'ba
+\f2  
+\f0 \'b4\'a9\'c0\'fb\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'bb\'e7\'b0\'c7\'ba\'b0\'b7\'ce
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 (
+\f0 \'c1\'ef
+\f2 , 
+\f0 \'b5\'ce
+\f2  
+\f0 \'b0\'b3
+\f2  
+\f0 \'c0\'cc\'bb\'f3\'c0\'c7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'c0\'cc
+\f2  
+\f0 \'c0\'d6\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'c0\'cc
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c0\'cc
+\f2  
+\f0 \'c8\'ae\'b4\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 ). 
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'be\'ee\'b6\'b2
+\f2  
+\f0 \'b3\'bb\'bf\'eb\'b5\'b5
+\f2  (I) 
+\f0 \'b0\'fa\'bd\'c7\'b7\'ce
+\f2  
+\f0 \'c0\'ce\'c7\'d1
+\f2  
+\f0 \'b0\'b3\'c0\'ce
+\f2  
+\f0 \'bb\'f3\'c7\'d8
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'b8\'c1\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  Cisco, 
+\f0 \'b0\'e8\'bf\'ad\'bb\'e7
+\f2 , 
+\f0 \'c0\'cc\'bb\'e7
+\f2 , 
+\f0 \'b0\'fc\'b8\'ae\'c0\'da
+\f2 , 
+\f0 \'c1\'f7\'bf\'f8
+\f2 , 
+\f0 \'bf\'a1\'c0\'cc\'c0\'fc\'c6\'ae
+\f2 , 
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'c0\'c7
+\f2  
+\f0 \'b0\'ed\'b0\'b4\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b0\'ed
+\f2 , (II) Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'bb\'e7\'b1\'e2
+\f2  
+\f0 \'c7\'e3\'c0\'a7\'c1\'f8\'bc\'fa\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d1
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'b8\'b8\'e7
+\f2 , 
+\f0 \'b6\'c7\'b4\'c2
+\f2  (III) 
+\f0 \'c0\'fb\'bf\'eb\'b9\'fd\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'be\'f8\'b4\'c2
+\f2  Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c3\'a5\'c0\'d3\'c0\'c7
+\f2  
+\f0 \'b8\'e9\'c3\'a5\'c1\'b6\'c7\'d7
+\f2  
+\i\b - 
+\f0\i0\b0 \'b0\'e1\'b0\'fa\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'c7\'d8
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'bc\'d5\'bd\'c7\'c0\'c7
+\f2  
+\f0 \'b8\'e9\'c1\'a6
+\f2\i\b .
+\i0\b0  
+\f0 \'b9\'cc\'b1\'b9
+\f2 , 
+\f0 \'b6\'f3\'c6\'be\'be\'c6\'b8\'de\'b8\'ae\'c4\'ab
+\f2 , 
+\f0 \'c4\'ab\'b8\'ae\'ba\'ea\'c7\'d8
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c4\'b3\'b3\'aa\'b4\'d9\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'bf\'a9\'b1\'e2\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'b1\'b8\'c1\'a6\'c3\'a5\'c0\'cc
+\f2  
+\f0 \'c7\'d9\'bd\'c9
+\f2  
+\f0 \'b8\'f1\'c0\'fb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'b0\'cd\'b0\'fa
+\f2  
+\f0 \'b8\'c2\'b4\'c2\'c1\'f6
+\f2  
+\f0 \'bf\'a9\'ba\'ce\'bf\'cd
+\f2  
+\f0 \'bb\'f3\'b0\'fc\'be\'f8\'c0\'cc
+\f2  
+\f0 \'be\'ee\'b6\'b2
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'bf\'a1\'b5\'b5
+\f2 , Cisco 
+\f0 \'b9\'d7
+\f2  
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc\'b4\'c2
+\f2  
+\f0 \'c3\'a5\'c0\'d3
+\f2  
+\f0 \'c0\'cc\'b7\'d0\'b0\'fa
+\f2  
+\f0 \'bb\'f3\'b0\'fc\'be\'f8\'c0\'cc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'ba\'d2\'b0\'a1\'b7\'ce
+\f2  
+\f0 \'c0\'ce\'c7\'d8
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2\'c1\'f6
+\f2  
+\f0 \'bf\'a9\'ba\'ce\'bf\'cd
+\f2  
+\f0 \'bb\'f3\'b0\'fc\'be\'f8\'c0\'cc
+\f2  
+\f0 \'b1\'d7\'b8\'ae\'b0\'ed
+\f2  Cisco
+\f0 \'bf\'cd
+\f2  
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'c0\'c7
+\f2  
+\f0 \'b0\'a1\'b4\'c9\'bc\'ba\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c1\'b6\'be\'f0\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'bc\'f6\'c0\'cd
+\f2  
+\f0 \'bc\'d5\'bd\'c7
+\f2 , 
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f2  
+\f0 \'bc\'d5\'bd\'c7\'c0\'cc\'b3\'aa
+\f2  
+\f0 \'bc\'d5\'bb\'f3
+\f2 , 
+\f0 \'bf\'b5\'be\'f7
+\f2  
+\f0 \'c1\'df\'b4\'dc
+\f2 , 
+\f0 \'c0\'da\'ba\'bb
+\f2  
+\f0 \'bc\'d5\'bd\'c7
+\f2 , 
+\f0 \'b0\'a3\'c1\'a2\'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'c6\'af\'ba\'b0\'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'ba\'ce\'bc\'f6\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'c2\'a1\'b9\'fa\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c1\'f6\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c0\'cf\'ba\'ce
+\f2  
+\f0 \'b1\'b9\'b0\'a1\'b3\'aa
+\f2  
+\f0 \'b0\'fc\'c7\'d2
+\f2  
+\f0 \'c1\'f6\'bf\'aa\'bf\'a1\'bc\'ad\'b4\'c2
+\f2  
+\f0 \'b0\'e1\'b0\'fa\'c0\'fb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bf\'ec\'bf\'ac\'c7\'d1
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bf\'b9\'bf\'dc\'b8\'a6
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'b8\'b9\'c7\'b7\'ce
+\f2  
+\f0 \'c0\'a7\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'bb
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c0\'cf\'ba\'bb\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'bb\'e7\'b8\'c1\'c0\'cc\'b3\'aa
+\f2  
+\f0 \'b0\'b3\'c0\'ce
+\f2  
+\f0 \'bb\'f3\'c7\'d8
+\f2 , 
+\f0 \'bb\'e7\'b1\'e2
+\f2  
+\f0 \'c7\'e3\'c0\'a7\'c1\'f8\'bc\'fa\'b7\'ce
+\f2  
+\f0 \'c0\'ce\'c7\'d8
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c0\'cc\'bf\'cd
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'cf\'b0\'ed
+\f2 , 
+\f0 \'bf\'a9\'b1\'e2\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'b1\'b8\'c1\'a6\'c3\'a5\'c0\'cc
+\f2  
+\f0 \'c7\'d9\'bd\'c9
+\f2  
+\f0 \'b8\'f1\'c0\'fb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'b0\'cd\'b0\'fa
+\f2  
+\f0 \'b8\'c2\'b4\'c2\'c1\'f6
+\f2  
+\f0 \'bf\'a9\'ba\'ce\'bf\'cd
+\f2  
+\f0 \'bb\'f3\'b0\'fc\'be\'f8\'c0\'cc
+\f2  Cisco, 
+\f0 \'b0\'e8\'bf\'ad\'bb\'e7
+\f2 , 
+\f0 \'c0\'cc\'bb\'e7
+\f2 , 
+\f0 \'b0\'fc\'b8\'ae\'c0\'da
+\f2 , 
+\f0 \'c1\'f7\'bf\'f8
+\f2 , 
+\f0 \'bf\'a1\'c0\'cc\'c0\'fc\'c6\'ae
+\f2 , 
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'b4\'c2
+\f2  
+\f0 \'c3\'a5\'c0\'d3
+\f2  
+\f0 \'c0\'cc\'b7\'d0\'b0\'fa
+\f2  
+\f0 \'bb\'f3\'b0\'fc\'be\'f8\'c0\'cc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'ba\'d2\'b0\'a1\'b7\'ce
+\f2  
+\f0 \'c0\'ce\'c7\'d8
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2\'c1\'f6
+\f2  
+\f0 \'bf\'a9\'ba\'ce\'bf\'cd
+\f2  
+\f0 \'bb\'f3\'b0\'fc\'be\'f8\'c0\'cc
+\f2  
+\f0 \'b1\'d7\'b8\'ae\'b0\'ed
+\f2  Cisco, 
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8
+\f2 , 
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'c0\'c7
+\f2  
+\f0 \'b0\'a1\'b4\'c9\'bc\'ba\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c1\'b6\'be\'f0\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'bc\'f6\'c0\'cd
+\f2  
+\f0 \'bc\'d5\'bd\'c7
+\f2 , 
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f2  
+\f0 \'bc\'d5\'bd\'c7\'c0\'cc\'b3\'aa
+\f2  
+\f0 \'bc\'d5\'bb\'f3
+\f2 , 
+\f0 \'bf\'b5\'be\'f7
+\f2  
+\f0 \'c1\'df\'b4\'dc
+\f2 , 
+\f0 \'c0\'da\'ba\'bb
+\f2  
+\f0 \'bc\'d5\'bd\'c7
+\f2 , 
+\f0 \'b0\'a3\'c1\'a2\'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'c6\'af\'ba\'b0\'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'ba\'ce\'bc\'f6\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'c2\'a1\'b9\'fa\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c1\'f6\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c0\'af\'b7\'b4
+\f2 , 
+\f0 \'c1\'df\'b5\'bf
+\f2 , 
+\f0 \'be\'c6\'c7\'c1\'b8\'ae\'c4\'ab
+\f2 , 
+\f0 \'be\'c6\'bd\'c3\'be\'c6
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bf\'c0\'bc\'bc\'be\'c6\'b4\'cf\'be\'c6\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'b8\'c5\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  Cisco, 
+\f0 \'b0\'e8\'bf\'ad\'bb\'e7
+\f2 , 
+\f0 \'c0\'d3\'bf\'f8
+\f2 , 
+\f0 \'c0\'cc\'bb\'e7
+\f2 , 
+\f0 \'b0\'fc\'b8\'ae\'c0\'da
+\f2 , 
+\f0 \'bf\'a1\'c0\'cc\'c0\'fc\'c6\'ae
+\f2 , 
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'b4\'c2
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2 , 
+\f0 \'ba\'d2\'b9\'fd
+\f2  
+\f0 \'c7\'e0\'c0\'a7
+\f2 (
+\f0 \'b0\'fa\'bd\'c7
+\f2  
+\f0 \'c6\'f7\'c7\'d4
+\f2 )
+\f0 \'b7\'ce
+\f2  
+\f0 \'c0\'ce\'c7\'d8
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b5\'e7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'ba\'d2\'b0\'a1\'b7\'ce
+\f2  
+\f0 \'c0\'ce\'c7\'d8
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b5\'e7
+\f2  
+\f0 \'bb\'f3\'b0\'fc\'be\'f8\'c0\'cc
+\f2  
+\f0 \'b1\'d7\'b8\'ae\'b0\'ed
+\f2  Cisco, 
+\f0 \'b0\'e8\'bf\'ad\'bb\'e7
+\f2 , 
+\f0 \'c0\'cc\'bb\'e7
+\f2 , 
+\f0 \'b0\'fc\'b8\'ae\'c0\'da
+\f2 , 
+\f0 \'c1\'f7\'bf\'f8
+\f2 , 
+\f0 \'bf\'a1\'c0\'cc\'c0\'fc\'c6\'ae
+\f2 , 
+\f0 \'b0\'f8\'b1\'de\'be\'f7\'c3\'bc
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'be\'f7\'c3\'bc\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'c0\'c7
+\f2  
+\f0 \'b0\'a1\'b4\'c9\'bc\'ba\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c1\'b6\'be\'f0\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'bc\'f6\'c0\'cd
+\f2  
+\f0 \'bc\'d5\'bd\'c7
+\f2 , 
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f2  
+\f0 \'bc\'d5\'bd\'c7\'c0\'cc\'b3\'aa
+\f2  
+\f0 \'bc\'d5\'bb\'f3
+\f2 , 
+\f0 \'bf\'b5\'be\'f7
+\f2  
+\f0 \'c1\'df\'b4\'dc
+\f2 , 
+\f0 \'c0\'da\'ba\'bb
+\f2  
+\f0 \'bc\'d5\'bd\'c7
+\f2 , 
+\f0 \'b0\'a3\'c1\'a2\'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'c6\'af\'ba\'b0\'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'ba\'ce\'bc\'f6\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'c7\'d8
+\f2 , 
+\f0 \'c2\'a1\'b9\'fa\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c1\'f6\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c0\'cf\'ba\'ce
+\f2  
+\f0 \'b1\'b9\'b0\'a1\'b3\'aa
+\f2  
+\f0 \'b0\'fc\'c7\'d2
+\f2  
+\f0 \'c1\'f6\'bf\'aa\'bf\'a1\'bc\'ad\'b4\'c2
+\f2  
+\f0 \'b0\'e1\'b0\'fa\'c0\'fb
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bf\'ec\'bf\'ac\'c7\'d1
+\f2  
+\f0 \'bc\'d5\'c7\'d8\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bf\'b9\'bf\'dc\'b8\'a6
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'b8\'b9\'c7\'b7\'ce
+\f2  
+\f0 \'c0\'a7\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'c3\'e6\'ba\'d0\'c8\'f7
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'bb
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c0\'a7\'c0\'c7
+\f2  
+\f0 \'bf\'b9\'bf\'dc\'b4\'c2
+\f2  
+\f0 \'b4\'d9\'c0\'bd\'b0\'fa
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'bf\'a1\'b4\'c2
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . (I) 
+\f0 \'bb\'e7\'b8\'c1
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'b3\'c0\'ce
+\f2  
+\f0 \'bb\'f3\'c7\'d8
+\f2 , (II) 
+\f0 \'bb\'e7\'b1\'e2
+\f2  
+\f0 \'c7\'e3\'c0\'a7\'c1\'f8\'bc\'fa
+\f2 , 
+\f0 \'b6\'c7\'b4\'c2
+\f2  (III) 
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b9\'fd\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'be\'f8\'b4\'c2
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'b0\'fa
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  Cisco
+\f0 \'c0\'c7
+\f2  
+\f0 \'c3\'a5\'c0\'d3
+\f2 . \
+
+\f0 \'b0\'ed\'b0\'b4\'c0\'ba
+\f2  Cisco
+\f0 \'b0\'a1
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'ba\'ce\'c0\'ce
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'c3\'a5\'c0\'d3\'c0\'c7
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b0\'a1\'b0\'dd\'c0\'bb
+\f2  
+\f0 \'bc\'b3\'c1\'a4\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'bb
+\f2  
+\f0 \'c3\'bc\'b0\'e1\'c7\'df\'c0\'b8\'b8\'e7
+\f2 , 
+\f0 \'b5\'bf\'c0\'cf\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da
+\f2  
+\f0 \'b0\'a3
+\f2  
+\f0 \'c0\'a7\'c7\'e8
+\f2  
+\f0 \'c7\'d2\'b4\'e7
+\f2 (
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b1\'b8\'c1\'a6\'c3\'a5\'c0\'cc
+\f2  
+\f0 \'c7\'d9\'bd\'c9
+\f2  
+\f0 \'b8\'f1\'c0\'fb\'c0\'bb
+\f2  
+\f0 \'c0\'cc\'b7\'e7\'c1\'f6
+\f2  
+\f0 \'b8\'f8\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b0\'e1\'b0\'fa\'c0\'fb
+\f2  
+\f0 \'bc\'d5\'bd\'c7\'c0\'bb
+\f2  
+\f0 \'be\'df\'b1\'e2\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'c0\'a7\'c7\'e8
+\f2  
+\f0 \'c6\'f7\'c7\'d4
+\f2 )
+\f0 \'c0\'bb
+\f2  
+\f0 \'b9\'dd\'bf\'b5\'c7\'cf\'b0\'ed
+\f2 , 
+\f0 \'b5\'bf\'c0\'cf\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da
+\f2  
+\f0 \'b0\'a3
+\f2  
+\f0 \'c7\'f9\'bb\'f3\'c0\'c7
+\f2  
+\f0 \'c7\'d9\'bd\'c9\'c0\'fb
+\f2  
+\f0 \'b1\'e2\'b9\'dd\'c0\'bb
+\f2  
+\f0 \'c0\'cc\'b7\'e9\'b4\'d9\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'c0\'bb
+\f2  
+\f0 \'c0\'ce\'c1\'a4\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'c0\'cc\'bf\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'b1\'d4\'c1\'a6
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2\i\b , 
+\f0\i0\b0 \'b0\'fc\'c7\'d2\'c1\'f6\'bf\'aa
+\f2\i\b .
+\i0\b0  
+\f0 \'bd\'c2\'c0\'ce\'b5\'c8
+\f2  
+\f0 \'b0\'f8\'b1\'de\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'f6\'b6\'f4\'c7\'d1
+\f2  
+\f0 \'b1\'b8\'b8\'c5
+\f2  
+\f0 \'c1\'d6\'b9\'ae\'bc\'ad\'c0\'c7
+\f2  
+\f0 \'c1\'d6\'bc\'d2\'b8\'a6
+\f2  
+\f0 \'c2\'fc\'c1\'b6\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'b9\'cc\'b1\'b9
+\f2 , 
+\f0 \'b6\'f3\'c6\'be
+\f2  
+\f0 \'be\'c6\'b8\'de\'b8\'ae\'c4\'ab
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'c4\'ab\'b8\'ae\'ba\'ea\'c7\'d8
+\f2  
+\f0 \'c1\'f6\'bf\'aa\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2 ("
+\f0 \'ba\'b8\'c1\'f5
+\f2 ")
+\f0 \'c0\'ba
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c7\'cf\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'b9\'cc\'b1\'b9
+\f2  
+\f0 \'c4\'b6\'b8\'ae\'c6\'f7\'b4\'cf\'be\'c6
+\f2  
+\f0 \'c1\'d6\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c7\'d8\'bc\'ae\'b5\'c7\'b8\'e7
+\f2 , 
+\f0 \'c4\'b6\'b8\'ae\'c6\'f7\'b4\'cf\'be\'c6
+\f2  
+\f0 \'c1\'d6
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bf\'ac\'b9\'e6
+\f2  
+\f0 \'b9\'fd\'bf\'f8\'c0\'ba
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'b5\'b6\'c1\'a1\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b0\'fc\'c7\'d2\'b1\'c7\'c0\'bb
+\f2  
+\f0 \'b0\'ae\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c4\'b3\'b3\'aa\'b4\'d9\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c7\'f6\'c1\'f6
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'b1\'dd\'c1\'f6\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c7\'cf\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'c4\'b3\'b3\'aa\'b4\'d9
+\f2  
+\f0 \'bf\'c2\'c5\'b8\'b8\'ae\'bf\'c0
+\f2  
+\f0 \'c1\'f6\'bf\'aa\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c7\'d8\'bc\'ae\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'bf\'c2\'c5\'b8\'b8\'ae\'bf\'c0
+\f2  
+\f0 \'c1\'f6\'bf\'aa
+\f2  
+\f0 \'b9\'fd\'bf\'f8\'c0\'ba
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'b5\'b6\'c1\'a1\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b0\'fc\'c7\'d2\'b1\'c7\'c0\'bb
+\f2  
+\f0 \'b0\'ae\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c0\'af\'b7\'b4
+\f2 , 
+\f0 \'c1\'df\'b5\'bf
+\f2 , 
+\f0 \'be\'c6\'c7\'c1\'b8\'ae\'c4\'ab
+\f2 , 
+\f0 \'be\'c6\'bd\'c3\'be\'c6
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bf\'c0\'bc\'bc\'be\'c6\'b4\'cf\'be\'c6
+\f2 (
+\f0 \'c8\'a3\'c1\'d6
+\f2  
+\f0 \'c1\'a6\'bf\'dc
+\f2 )
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c7\'f6\'c1\'f6
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'b1\'dd\'c1\'f6\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c7\'cf\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'bf\'b5\'b1\'b9\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c7\'d8\'bc\'ae\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'bf\'b5\'b1\'b9
+\f2  
+\f0 \'b9\'fd\'bf\'f8\'c0\'ba
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'b5\'b6\'c1\'a1\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b0\'fc\'c7\'d2\'b1\'c7\'c0\'bb
+\f2  
+\f0 \'b0\'ae\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b6\'c7\'c7\'d1
+\f2  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'bf\'b5\'b1\'b9\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da\'b0\'a1
+\f2  
+\f0 \'be\'c6\'b4\'d1
+\f2  
+\f0 \'bb\'e7\'b6\'f7\'c0\'ba
+\f2  1999
+\f0 \'b3\'e2
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2 (
+\f0 \'c1\'a6
+\f2 3
+\f0 \'c0\'da\'c0\'c7
+\f2  
+\f0 \'b1\'c7\'b8\'ae
+\f2 ) 
+\f0 \'b9\'fd\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b8\'a5
+\f2  
+\f0 \'be\'e0\'b0\'fc\'c0\'c7
+\f2  
+\f0 \'c7\'fd\'c5\'c3\'c0\'bb
+\f2  
+\f0 \'c1\'fd\'c7\'e0\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c0\'cc\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'b4\'c2
+\f2  
+\f0 \'c0\'da\'b0\'dd\'c0\'cc
+\f2  
+\f0 \'be\'f8\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c0\'cf\'ba\'bb\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c7\'f6\'c1\'f6
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'b1\'dd\'c1\'f6\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c7\'cf\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'c0\'cf\'ba\'bb\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c7\'d8\'bc\'ae\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'c0\'cf\'ba\'bb\'c0\'c7
+\f2  
+\f0 \'b5\'b5\'c4\'ec
+\f2  
+\f0 \'b9\'fd\'bf\'f8\'c0\'ba
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'b5\'b6\'c1\'a1\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b0\'fc\'c7\'d2\'b1\'c7\'c0\'bb
+\f2  
+\f0 \'b0\'ae\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'c8\'a3\'c1\'d6\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c7\'f6\'c1\'f6
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'b1\'dd\'c1\'f6\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c7\'cf\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'c8\'a3\'c1\'d6
+\f2  
+\f0 \'b4\'ba\'bb\'e7\'bf\'ec\'bd\'ba\'bf\'fe\'c0\'cf\'bd\'ba\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c7\'d8\'bc\'ae\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'b4\'ba\'bb\'e7\'bf\'ec\'bd\'ba\'bf\'fe\'c0\'cf\'bd\'ba\'c0\'c7
+\f2  
+\f0 \'c1\'d6
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bf\'ac\'b9\'e6
+\f2  
+\f0 \'b9\'fd\'bf\'f8\'c0\'ba
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'b5\'b6\'c1\'a1\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b0\'fc\'c7\'d2\'b1\'c7\'c0\'bb
+\f2  
+\f0 \'b0\'ae\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'b1\'b9\'b0\'a1\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'c8\'b9\'b5\'e6\'c7\'d1
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'c7\'f6\'c1\'f6
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'bf\'a1
+\f2  
+\f0 \'c0\'c7\'c7\'d8
+\f2  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce\'b1\'dd\'c1\'f6\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b4\'c2
+\f2  
+\f0 \'c7\'d1
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'ba
+\f2  
+\f0 \'b9\'fd\'b7\'fc
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'cc
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c7\'cf\'b4\'f5\'b6\'f3\'b5\'b5
+\f2  
+\f0 \'b9\'cc\'b1\'b9
+\f2  
+\f0 \'c4\'b6\'b8\'ae\'c6\'f7\'b4\'cf\'be\'c6
+\f2  
+\f0 \'c1\'d6\'c0\'c7
+\f2  
+\f0 \'b9\'fd\'b7\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'be\'ee
+\f2  
+\f0 \'c7\'d8\'bc\'ae\'b5\'c7\'b8\'e7
+\f2  
+\f0 \'c4\'b6\'b8\'ae\'c6\'f7\'b4\'cf\'be\'c6
+\f2  
+\f0 \'c1\'d6
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bf\'ac\'b9\'e6
+\f2  
+\f0 \'b9\'fd\'bf\'f8\'c0\'ba
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b6\'f3
+\f2  
+\f0 \'b9\'df\'bb\'fd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'c5\'ac\'b7\'b9\'c0\'d3\'bf\'a1
+\f2  
+\f0 \'b4\'eb\'c7\'d8
+\f2  
+\f0 \'b5\'b6\'c1\'a1\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b0\'fc\'c7\'d2\'b1\'c7\'c0\'bb
+\f2  
+\f0 \'b0\'ae\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . \
+
+\f0 \'c0\'a7\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'be\'f0\'b1\'de\'c7\'d1
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'b1\'b9\'b0\'a1\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da\'b5\'e9\'c0\'ba
+\f2  
+\f0 \'b1\'b9\'c1\'a6\'b9\'b0\'c7\'b0\'b8\'c5\'b8\'c5\'b0\'e8\'be\'e0\'bf\'a1
+\f2  
+\f0 \'b0\'fc\'c7\'d1
+\f2  
+\f0 \'b1\'b9\'c1\'a6\'bf\'ac\'c7\'d5\'c7\'f9\'be\'e0
+\f2 (UN Convention on Contracts for the International Sale of Goods)
+\f0 \'c0\'bb
+\f2  
+\f0 \'ba\'ce\'c0\'ce\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'be\'d5\'bc\'ad
+\f2  
+\f0 \'be\'f0\'b1\'de\'c7\'d1
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'bf\'a1\'b5\'b5
+\f2  
+\f0 \'ba\'d2\'b1\'b8\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da\'b4\'c2
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da\'c0\'c7
+\f2  
+\f0 \'c1\'f6\'c0\'fb
+\f2  
+\f0 \'c0\'e7\'bb\'ea\'b1\'c7
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'d2\'c0\'af\'b1\'c7\'c0\'c7
+\f2  
+\f0 \'c7\'f8\'c0\'c7
+\f2  
+\f0 \'c0\'a7\'b9\'dd\'b0\'fa
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'b0\'fc\'c7\'d2
+\f2  
+\f0 \'c1\'f6\'bf\'aa
+\f2  
+\f0 \'b9\'fd\'bf\'f8\'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c0\'e1\'c1\'a4\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'b1\'dd\'c1\'f6\'b8\'ed\'b7\'c9
+\f2  
+\f0 \'b1\'b8\'c1\'a6\'b8\'a6
+\f2  
+\f0 \'b1\'b8\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f2  
+\f0 \'c0\'cf\'ba\'ce\'b0\'a1
+\f2  
+\f0 \'b9\'ab\'c8\'bf\'b0\'a1
+\f2  
+\f0 \'b5\'c7\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c1\'fd\'c7\'e0
+\f2  
+\f0 \'ba\'d2\'b0\'a1\'b4\'c9
+\f2  
+\f0 \'c7\'cf\'b4\'d9\'b0\'ed
+\f2  
+\f0 \'c6\'c7\'b8\'ed\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'ba\'b8\'c1\'f5\'c0\'c7
+\f2  
+\f0 \'b3\'aa\'b8\'d3\'c1\'f6
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'c0\'ba
+\f2  
+\f0 \'bf\'cf\'c0\'fc\'c7\'d1
+\f2  
+\f0 \'c8\'bf\'b7\'c2\'c0\'bb
+\f2  
+\f0 \'b0\'ae\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'b1\'e2\'bc\'fa\'b5\'c8
+\f2  
+\f0 \'bb\'e7\'c7\'d7\'c0\'bb
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'ba
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b9\'ae\'bc\'ad\'c0\'c7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'bf\'cd
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da
+\f2  
+\f0 \'b0\'a3
+\f2  
+\f0 \'c0\'fc\'c3\'bc
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'bb
+\f2  
+\f0 \'b1\'b8\'bc\'ba\'c7\'cf\'b8\'e7
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'b1\'b8\'b8\'c5
+\f2  
+\f0 \'c1\'d6\'b9\'ae\'bc\'ad
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'b4\'d9\'b8\'a5
+\f2  
+\f0 \'c7\'d7\'b8\'f1\'bf\'a1
+\f2  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c8
+\f2  
+\f0 \'c3\'e6\'b5\'b9\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'c3\'df\'b0\'a1\'b5\'c8
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'c0\'bb
+\f2  
+\f0 \'b4\'eb\'c3\'bc\'c7\'cf\'b0\'ed
+\f2 , 
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f2  
+\f0 \'c1\'b6\'b0\'c7\'c0\'ba
+\f2  
+\f0 \'b8\'f0\'b5\'ce
+\f2  
+\f0 \'c1\'a6\'bf\'dc\'b5\'cb\'b4\'cf\'b4\'d9
+\f2 . 
+\f0 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'ba
+\f2  
+\f0 \'bf\'b5\'be\'ee\'b7\'ce
+\f2  
+\f0 \'c0\'db\'bc\'ba\'b5\'c7\'be\'fa\'c0\'b8\'b8\'e7
+\f2  
+\f0 \'b4\'e7\'bb\'e7\'c0\'da\'b4\'c2
+\f2  
+\f0 \'bf\'b5\'be\'ee
+\f2  
+\f0 \'b9\'f6\'c0\'fc\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'b0\'cd\'bf\'a1
+\f2  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f2 . \
+\pard\pardeftab720\ri0\sb100\sa100\partightenfactor0
+\cf0 Cisco 
+\f0 \'c1\'a6\'c7\'b0\'bf\'a1
+\f2  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c7\'b4\'c2
+\f2  
+\f0 \'c1\'a6\'c7\'b0
+\f2  
+\f0 \'ba\'b8\'c1\'f5
+\f2  
+\f0 \'c1\'b6\'c7\'d7
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'c1\'a4\'ba\'b8\'b4\'c2
+\f2  {\field{\*\fldinst{HYPERLINK "http://www.cisco.com/go/warranty"}}{\fldrslt \cf2 \ul \ulc2 http://www.cisco.com/go/warranty}}
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c8\'ae\'c0\'ce\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 .\
+\pard\pardeftab720\ri0\sb100\sa100\qc\partightenfactor0
+\cf0 [
+\f0 \'c3\'df\'b0\'a1
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b0\'e8\'be\'e0
+\f2  
+\f0 \'c0\'d6\'c0\'bd
+\f2 ]\
+\pard\pardeftab720\ri0\sb2\sa2\qc\partightenfactor0
+\cf0 \page \pard\pardeftab720\ri0\sb2\sa2\qc\partightenfactor0
+
+\f0 \cf0 \'c3\'df\'b0\'a1
+\f1  
+\f0 \'c3\'d6\'c1\'be
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'b0\'e8\'be\'e0
+\f1\b\fs28 \
+Cisco AMP 
+\f0\b0\fs24 \'c1\'a6\'c7\'b0
+\f1\b\fs28 \
+\pard\pardeftab720\ri0\sb2\sa2\qj\partightenfactor0
+
+\fs36 \cf0 \
+\pard\pardeftab720\ri0\sb2\sa2\qj\partightenfactor0
+
+\f0\b0\fs24 \cf0 \'c1\'df\'bf\'e4
+\f1\b\fs20 : 
+\f0\b0\fs24 \'bd\'c5\'c1\'df\'c7\'cf\'b0\'d4
+\f1  
+\f0 \'c0\'d0\'be\'ee\'ba\'b8\'bd\'ca\'bd\'c3\'bf\'c0
+\f1\b\fs20 . \
+\pard\pardeftab720\ri0\sb2\sa2\qj\partightenfactor0
+
+\b0 \cf0 \
+\pard\pardeftab720\ri0\sb2\sa2\qj\partightenfactor0
+
+\f0\fs24 \cf0 \'ba\'bb
+\f1  
+\f0 \'c3\'df\'b0\'a1
+\f1  
+\f0 \'c3\'d6\'c1\'be
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'b0\'e8\'be\'e0
+\f1\fs20 ("SEULA")
+\f0\fs24 \'bf\'a1\'b4\'c2
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'bf\'cd
+\f1  
+\fs20 Cisco 
+\f0\fs24 \'b0\'a3
+\f1  
+\f0 \'c3\'d6\'c1\'be
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'b0\'e8\'be\'e0
+\f1\fs20 ("EULA")
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'b5\'fb\'b6\'f3
+\f1  
+\f0 \'bb\'e7\'bf\'eb
+\f1  
+\f0 \'c7\'e3\'b0\'a1\'b5\'c8
+\f1  
+\fs20 Cisco AMP 
+\f0\fs24 \'c1\'a6\'c7\'b0
+\f1\fs20 ("
+\f0\fs24 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1\fs20 ")
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'c3\'df\'b0\'a1
+\f1  
+\f0 \'be\'e0\'b0\'fc\'c0\'cc
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'b5\'c7\'be\'ee
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 . 
+\f0\fs24 \'ba\'bb
+\f1  
+\fs20 SEULA
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'b5\'c7\'be\'fa\'c1\'f6\'b8\'b8
+\f1  
+\f0 \'c1\'a4\'c0\'c7\'b5\'c7\'c1\'f6
+\f1  
+\f0 \'be\'ca\'c0\'ba
+\f1  
+\f0 \'b4\'eb\'b9\'ae\'c0\'da\'b7\'ce
+\f1  
+\f0 \'c7\'a5\'bd\'c3\'b5\'c8
+\f1  
+\f0 \'bf\'eb\'be\'ee\'b4\'c2
+\f1  
+\fs20 EULA
+\f0\fs24 \'bf\'a1\'bc\'ad
+\f1  
+\f0 \'c1\'a4\'c0\'c7\'b5\'c8
+\f1  
+\f0 \'c0\'c7\'b9\'cc\'b7\'ce
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f1\fs20 . EULA
+\f0\fs24 \'bf\'cd
+\f1  
+\f0 \'ba\'bb
+\f1  
+\fs20 SEULA
+\f0\fs24 \'c0\'c7
+\f1  
+\f0 \'be\'e0\'b0\'fc
+\f1  
+\f0 \'bb\'e7\'c0\'cc\'bf\'a1
+\f1  
+\f0 \'c3\'e6\'b5\'b9\'c0\'cc
+\f1  
+\f0 \'c0\'d6\'b4\'c2
+\f1  
+\f0 \'b0\'e6\'bf\'ec
+\f1  
+\f0 \'ba\'bb
+\f1  
+\fs20 SEULA
+\f0\fs24 \'c0\'c7
+\f1  
+\f0 \'be\'e0\'b0\'fc\'c0\'cc
+\f1  
+\f0 \'bf\'ec\'bc\'b1
+\f1  
+\f0 \'c0\'fb\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f1\fs20 . \
+\
+
+\f0\fs24 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f1  
+\f0 \'be\'d7\'bc\'bc\'bd\'ba
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d8
+\f1  
+\fs20 EULA
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f1  
+\f0 \'c1\'a6\'c7\'d1
+\f1  
+\f0 \'bb\'e7\'c7\'d7
+\f1  
+\f0 \'bf\'dc\'bf\'a1\'b5\'b5
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'c7\'d7\'bd\'c3
+\f1  
+\f0 \'ba\'bb
+\f1  
+\fs20 SEULA
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c8
+\f1  
+\f0 \'be\'e0\'b0\'fc\'c0\'bb
+\f1  
+\f0 \'c1\'d8\'bc\'f6\'c7\'d2
+\f1  
+\f0 \'b0\'cd\'bf\'a1
+\f1  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+\
+
+\f0\fs24 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'b4\'d9\'bf\'ee\'b7\'ce\'b5\'e5
+\f1\fs20 , 
+\f0\fs24 \'bc\'b3\'c4\'a1
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'b0\'cd\'c0\'ba
+\f1  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'b5\'bf\'c0\'c7\'b8\'a6
+\f1  
+\f0 \'c0\'c7\'b9\'cc\'c7\'cf\'b8\'e7
+\f1\fs20 , 
+\f0\fs24 \'b1\'cd\'c7\'cf
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'a5\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'bb\'e7\'be\'f7\'c3\'bc\'b4\'c2
+\f1  
+\f0 \'b0\'e8\'be\'e0\'c0\'bb
+\f1  
+\f0 \'c1\'d8\'bc\'f6\'c7\'d8\'be\'df
+\f1  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 . 
+\f0\fs24 \'b0\'e8\'be\'e0\'c0\'c7
+\f1  
+\f0 \'b8\'f0\'b5\'e7
+\f1  
+\f0 \'c1\'b6\'b0\'c7\'bf\'a1
+\f1  
+\f0 \'b5\'bf\'c0\'c7\'c7\'cf\'c1\'f6
+\f1  
+\f0 \'be\'ca\'b4\'c2
+\f1  
+\f0 \'b0\'e6\'bf\'ec
+\f1  
+\fs20 Cisco
+\f0\fs24 \'b4\'c2
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'be\'bd\'ba\'b8\'a6
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'c1\'f6
+\f1  
+\f0 \'be\'ca\'c0\'b8\'b8\'e7
+\f1  
+\fs20 (A) 
+\f0\fs24 \'b1\'cd\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'b4\'d9\'bf\'ee\'b7\'ce\'b5\'e5
+\f1\fs20 , 
+\f0\fs24 \'bc\'b3\'c4\'a1
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'be\'f8\'b0\'ed
+\f1\fs20 , (B) 
+\f0\fs24 \'c0\'fc\'be\'d7
+\f1  
+\f0 \'c8\'af\'ba\'d2\'c0\'bb
+\f1  
+\f0 \'c0\'a7\'c7\'d8
+\f1  
+\f0 \'b0\'b3\'ba\'c0\'c7\'cf\'c1\'f6
+\f1  
+\f0 \'be\'ca\'c0\'ba
+\f1  
+\fs20 CD 
+\f0\fs24 \'c6\'d0\'c5\'b0\'c1\'f6\'bf\'cd
+\f1  
+\f0 \'bc\'ad\'b8\'e9
+\f1  
+\f0 \'c0\'da\'b7\'e1\'b8\'a6
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'c7\'d1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'b9\'dd\'c8\'af\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'c0\'b8\'b8\'e7
+\f1  
+\f0 \'b6\'c7\'c7\'d1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'bc\'ad\'b8\'e9
+\f1  
+\f0 \'c0\'da\'b7\'e1\'b0\'a1
+\f1  
+\f0 \'b4\'d9\'b8\'a5
+\f1  
+\f0 \'c1\'a6\'c7\'b0\'c0\'c7
+\f1  
+\f0 \'c0\'cf\'ba\'ce\'b7\'ce
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'b5\'c8
+\f1  
+\f0 \'b0\'e6\'bf\'ec
+\f1  
+\f0 \'c0\'fc\'be\'d7
+\f1  
+\f0 \'c8\'af\'ba\'d2\'c0\'bb
+\f1  
+\f0 \'c0\'a7\'c7\'d8
+\f1  
+\f0 \'c0\'fc
+\f1  
+\f0 \'c1\'a6\'c7\'b0\'c0\'bb
+\f1  
+\f0 \'b9\'dd\'c8\'af\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 . 
+\f0\fs24 \'b1\'cd\'c7\'cf\'c0\'c7
+\f1  
+\f0 \'b9\'dd\'c8\'af
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c8\'af\'ba\'d2
+\f1  
+\f0 \'b1\'c7\'c7\'d1\'c0\'ba
+\f1  
+\fs20 Cisco 
+\f0\fs24 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'b0\'f8\'c0\'ce
+\f1  
+\fs20 Cisco 
+\f0\fs24 \'b8\'ae\'bc\'bf\'b7\'af\'b7\'ce\'bf\'a1\'bc\'ad
+\f1  
+\f0 \'b1\'b8\'c0\'d4
+\f1  
+\f0 \'c8\'c4
+\f1  
+\fs20 30
+\f0\fs24 \'c0\'cf
+\f1  
+\f0 \'c8\'c4\'bf\'a1
+\f1  
+\f0 \'b8\'b8\'b7\'e1\'b5\'c7\'b8\'e7
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f1  
+\f0 \'bf\'f8\'b7\'a1
+\f1  
+\f0 \'c3\'d6\'c1\'be
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da
+\f1  
+\f0 \'b1\'b8\'b8\'c5\'c0\'da\'c0\'ce
+\f1  
+\f0 \'b0\'e6\'bf\'ec\'bf\'a1\'b8\'b8
+\f1  
+\f0 \'c0\'cc
+\f1  
+\f0 \'bb\'e7\'c7\'d7\'c0\'cc
+\f1  
+\f0 \'c0\'fb\'bf\'eb\'b5\'cb\'b4\'cf\'b4\'d9
+\f1\fs20 . \
+\
+\pard\pardeftab720\ri0\qj\partightenfactor0
+
+\f0\fs24 \cf0 \'c1\'a4\'c0\'c7
+\f1\b\fs20 \
+\pard\pardeftab720\ri0\qj\partightenfactor0
+
+\b0 \cf0 \
+\'93
+\f0\fs24 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae
+\f1\b\fs20 (Endpoint)
+\b0 \'94
+\f0\fs24 \'b4\'c2
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\fs20 Cisco
+\f0\fs24 \'bf\'a1\'bc\'ad
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba\'bf\'cd
+\f1  
+\f0 \'bf\'ac\'b0\'e8\'c7\'cf\'bf\'a9
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd\'b8\'a6
+\f1  
+\f0 \'c3\'b3\'b8\'ae\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'b4\'c2
+\f1  
+\f0 \'c0\'cf\'c3\'bc\'c0\'c7
+\f1  
+\f0 \'b5\'f0\'b9\'d9\'c0\'cc\'bd\'ba\'b8\'a6
+\f1  
+\f0 \'c0\'c7\'b9\'cc\'c7\'cf\'b8\'e7
+\f1\fs20 , 
+\f0\fs24 \'bf\'a9\'b1\'e2\'bf\'a1\'b4\'c2
+\f1  
+\f0 \'b0\'b3\'c0\'ce\'bf\'eb
+\f1  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f1\fs20 , 
+\f0\fs24 \'b8\'f0\'b9\'d9\'c0\'cf
+\f1  
+\f0 \'b5\'f0\'b9\'d9\'c0\'cc\'bd\'ba
+\f1\fs20 , 
+\f0\fs24 \'b3\'d7\'c6\'ae\'bf\'f6\'c5\'a9
+\f1  
+\f0 \'c4\'c4\'c7\'bb\'c5\'cd
+\f1  
+\f0 \'bf\'f6\'c5\'a9\'bd\'ba\'c5\'d7\'c0\'cc\'bc\'c7
+\f1  
+\f0 \'b5\'ee\'c0\'cc
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'b5\'cb\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+\
+\'93
+\f0\fs24 \'ba\'f1
+\f1  
+\f0 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1\b\fs20 (Non-Personal Information)
+\b0 \'94
+\f0\fs24 \'b4\'c2
+\f1  
+\f0 \'bf\'ee\'bf\'b5
+\f1  
+\f0 \'c3\'bc\'c1\'a6
+\f1  
+\f0 \'c0\'af\'c7\'fc
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b9\'f6\'c0\'fc
+\f1\fs20 , 
+\f0\fs24 \'c6\'c4\'c0\'cf
+\f1  
+\f0 \'b8\'de\'c5\'b8\'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'bd\'c4\'ba\'b0\'c0\'da
+\f1\fs20 (
+\f0\fs24 \'bf\'b9
+\f1\fs20 : SHA-256 
+\f0\fs24 \'b0\'aa
+\f1\fs20 ), 
+\f0\fs24 \'b3\'d7\'c6\'ae\'bf\'f6\'c5\'a9
+\f1  
+\f0 \'c8\'a3\'bd\'ba\'c6\'ae
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1\fs20 , 
+\f0\fs24 \'be\'c7\'bc\'ba\'c4\'da\'b5\'e5\'c0\'c7
+\f1  
+\f0 \'c3\'e2\'c3\'b3
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c6\'af\'bc\'ba
+\f1\fs20 , 
+\f0\fs24 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae
+\f1  
+\fs20 GUID(globally unique identifier), \'93IP(Internet Protocol)\'94 
+\f0\fs24 \'c1\'d6\'bc\'d2
+\f1\fs20 , MAC 
+\f0\fs24 \'c1\'d6\'bc\'d2
+\f1\fs20 , 
+\f0\fs24 \'b7\'ce\'b1\'d7
+\f1  
+\f0 \'c6\'c4\'c0\'cf
+\f1\fs20 , 
+\f0\fs24 \'b3\'d7\'c6\'ae\'bf\'f6\'c5\'a9\'b3\'aa
+\f1  
+\f0 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae\'bf\'a1
+\f1  
+\f0 \'bc\'b3\'c4\'a1\'b5\'c8
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'be\'d6\'c7\'c3\'b8\'ae\'c4\'c9\'c0\'cc\'bc\'c7\'c0\'c7
+\f1  
+\f0 \'c0\'af\'c7\'fc
+\f1\fs20 , 
+\f0\fs24 \'c1\'fd\'b0\'e8
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'c0\'ce\'b1\'b8
+\f1  
+\f0 \'c5\'eb\'b0\'e8
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1\fs20 (
+\f0\fs24 \'bf\'b9
+\f1\fs20 : 
+\f0\fs24 \'c4\'ed\'c5\'b0
+\f1\fs20 , 
+\f0\fs24 \'c0\'a5
+\f1  
+\f0 \'b7\'ce\'b1\'d7
+\f1\fs20 , 
+\f0\fs24 \'c0\'a5
+\f1  
+\f0 \'ba\'f1\'c4\'c1
+\f1\fs20 , 
+\f0\fs24 \'b1\'e2\'c5\'b8
+\f1  
+\f0 \'c0\'af\'bb\'e7\'c7\'d1
+\f1  
+\f0 \'be\'d6\'c7\'c3\'b8\'ae\'c4\'c9\'c0\'cc\'bc\'c7
+\f1\fs20 )
+\f0\fs24 \'b8\'a6
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'c0\'cc\'bf\'a1
+\f1  
+\f0 \'b1\'b9\'c7\'d1\'b5\'c7\'c1\'f6
+\f1  
+\f0 \'be\'ca\'b4\'c2
+\f1  
+\f0 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8\'b0\'a1
+\f1  
+\f0 \'be\'c6\'b4\'d1
+\f1  
+\f0 \'c0\'cf\'c3\'bc\'c0\'c7
+\f1  
+\f0 \'b1\'e2\'bc\'fa
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b0\'fc\'b7\'c3
+\f1  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f1  
+\f0 \'c0\'c7\'b9\'cc\'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+\
+\'93
+\f0\fs24 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1\b\fs20 (Personal Information)
+\b0 \'94
+\f0\fs24 \'b6\'f5
+\f1  
+\f0 \'b0\'b3\'c0\'ce\'c0\'bb
+\f1  
+\f0 \'c6\'af\'c1\'a4\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'b5\'a5
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'b4\'c2
+\f1  
+\f0 \'c0\'cf\'c3\'bc\'c0\'c7
+\f1  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f1  
+\f0 \'c0\'c7\'b9\'cc\'c7\'cf\'b8\'e7
+\f1  
+\f0 \'bf\'a9\'b1\'e2\'bf\'a1\'b4\'c2
+\f1  
+\f0 \'b0\'b3\'c0\'ce\'c0\'c7
+\f1  
+\f0 \'c0\'cc\'b8\'a7
+\f1\fs20 , 
+\f0\fs24 \'c1\'d6\'bc\'d2
+\f1\fs20 , 
+\f0\fs24 \'c0\'cc\'b8\'de\'c0\'cf
+\f1  
+\f0 \'c1\'d6\'bc\'d2
+\f1\fs20 , 
+\f0\fs24 \'c0\'fc\'c8\'ad\'b9\'f8\'c8\'a3
+\f1\fs20 , 
+\f0\fs24 \'b0\'e1\'c1\'a6\'c4\'ab\'b5\'e5
+\f1  
+\f0 \'b9\'f8\'c8\'a3
+\f1\fs20 , 
+\f0\fs24 \'bb\'e7\'bf\'eb\'c0\'da
+\f1  
+\f0 \'c0\'cc\'b8\'a7
+\f1  
+\f0 \'b5\'ee\'c0\'cc
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'b5\'cb\'b4\'cf\'b4\'d9
+\f1\fs20 . \
+\pard\pardeftab720\ri0\sb2\sa2\qj\partightenfactor0
+
+\b \cf0 \
+
+\f0\b0\fs24 \'c3\'df\'b0\'a1
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'b1\'c7\'c7\'d1
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c1\'a6\'c7\'d1
+\f1\b\fs20 \
+\
+
+\f0\b0\fs24 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1\b\fs20 .
+\b0   
+\f0\fs24 \'ba\'bb
+\f1  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f1  
+\f0 \'be\'e0\'b0\'fc\'c0\'bb
+\f1  
+\f0 \'c1\'d8\'bc\'f6\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'b9\'fc\'c0\'a7\'bf\'a1\'bc\'ad
+\f1  
+\fs20 Cisco
+\f0\fs24 \'b4\'c2
+\f1  
+\f0 \'b0\'ed\'b0\'b4\'c0\'cc
+\f1  
+\f0 \'c7\'ca\'bc\'f6
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'b9\'d7
+\f1\fs20 /
+\f0\fs24 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7
+\f1  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f1  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b9\'ae\'bc\'ad\'b8\'a6
+\f1  
+\f0 \'b0\'ed\'b0\'b4\'c0\'c7
+\f1  
+\f0 \'b3\'bb\'ba\'ce
+\f1  
+\f0 \'ba\'f1\'c1\'ee\'b4\'cf\'bd\'ba
+\f1  
+\f0 \'b8\'f1\'c0\'fb\'c0\'b8\'b7\'ce
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'b4\'c2
+\f1  
+\f0 \'ba\'f1\'b5\'b6\'c1\'a1\'c0\'fb\'c0\'cc\'b0\'ed
+\f1  
+\f0 \'be\'e7\'b5\'b5\'ba\'d2\'b0\'a1\'b4\'c9\'c7\'cf\'b8\'e7
+\f1  
+\f0 \'c7\'cf\'c0\'a7
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba\'b0\'a1
+\f1  
+\f0 \'ba\'d2\'b0\'a1\'c7\'d1
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba\'b8\'a6
+\f1  
+\f0 \'ba\'ce\'bf\'a9\'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'c0\'cc
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba\'b4\'c2
+\f1  
+\fs20 SKU
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'c1\'d6\'b9\'ae
+\f1  
+\f0 \'b9\'ae\'bc\'ad\'c0\'c7
+\f1  
+\f0 \'b4\'d9\'b8\'a5
+\f1  
+\f0 \'b0\'f7\'bf\'a1
+\f1  
+\f0 \'b8\'ed\'bd\'c3\'b5\'c8
+\f1  
+\f0 \'c1\'f6\'c1\'a4\'b5\'c8
+\f1  
+\f0 \'b1\'e2\'b0\'a3\'bf\'a1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7\'c0\'cc\'be\'ee\'be\'df
+\f1  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'b1\'cd\'c7\'cf\'b0\'a1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b7\'c1\'b8\'e9
+\f1  
+\f0 \'b5\'ee\'b7\'cf
+\f1  
+\f0 \'b9\'f8\'c8\'a3\'b3\'aa
+\f1  
+\f0 \'c1\'a6\'c7\'b0
+\f1  
+\f0 \'c0\'ce\'c1\'f5
+\f1  
+\f0 \'c5\'b0\'b8\'a6
+\f1  
+\f0 \'c0\'d4\'b7\'c2\'c7\'cf\'b0\'ed
+\f1  
+\fs20 Cisco 
+\f0\fs24 \'c0\'a5\'bb\'e7\'c0\'cc\'c6\'ae\'bf\'a1\'bc\'ad
+\f1  
+\f0 \'bf\'c2\'b6\'f3\'c0\'ce\'c0\'b8\'b7\'ce
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f1  
+\f0 \'bb\'e7\'ba\'bb\'c0\'bb
+\f1  
+\f0 \'b5\'ee\'b7\'cf\'c7\'cf\'bf\'a9
+\f1  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d1
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'c5\'b0
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f1  
+\f0 \'c6\'c4\'c0\'cf\'c0\'bb
+\f1  
+\f0 \'be\'f2\'be\'ee\'be\'df
+\f1  
+\f0 \'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f1  
+\f0 \'c6\'af\'c1\'a4
+\f1  
+\f0 \'c5\'ac\'b6\'f3\'bf\'ec\'b5\'e5
+\f1  
+\f0 \'b1\'e2\'b9\'dd
+\f1  
+\f0 \'b1\'b8\'bc\'ba
+\f1  
+\f0 \'bf\'e4\'bc\'d2\'bf\'a1
+\f1  
+\f0 \'be\'d7\'bc\'bc\'bd\'ba\'c7\'cf\'b7\'c1\'b8\'e9
+\f1  
+\f0 \'c0\'ce\'c5\'cd\'b3\'dd
+\f1  
+\f0 \'bf\'ac\'b0\'e1\'c0\'cc
+\f1  
+\f0 \'c7\'ca\'bf\'e4\'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'b8\'f0\'b5\'e7
+\f1  
+\f0 \'c7\'ca\'bc\'f6
+\f1  
+\f0 \'c0\'ce\'c5\'cd\'b3\'dd
+\f1  
+\f0 \'bf\'ac\'b0\'e1\'c0\'bb
+\f1  
+\f0 \'bc\'b3\'c1\'a4\'c7\'cf\'b0\'ed
+\f1  
+\f0 \'c0\'af\'c1\'f6\'c7\'d2
+\f1  
+\f0 \'c3\'a5\'c0\'d3\'c0\'ba
+\f1  
+\f0 \'bf\'c0\'b7\'ce\'c1\'f6
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'bf\'a1\'b0\'d4
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+
+\f0\fs24 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f1  
+\f0 \'c0\'cf\'ba\'ce
+\f1  
+\f0 \'b1\'b8\'bc\'ba
+\f1  
+\f0 \'bf\'e4\'bc\'d2\'b4\'c2
+\f1  
+\f0 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae\'bf\'a1
+\f1  
+\f0 \'bc\'b3\'c4\'a1\'c7\'d8\'be\'df
+\f1  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'b1\'d7\'b7\'af\'c7\'d1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'b1\'b8\'bc\'ba
+\f1  
+\f0 \'bf\'e4\'bc\'d2\'b4\'c2
+\f1  
+\f0 \'c7\'d8\'b4\'e7
+\f1  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f1  
+\f0 \'c1\'f6\'ba\'d2\'c7\'d1
+\f1  
+\f0 \'b0\'b3\'bc\'f6\'c0\'c7
+\f1  
+\f0 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae\'bf\'a1\'bc\'ad\'b8\'b8
+\f1  
+\f0 \'bc\'b3\'c4\'a1\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 . \
+\
+
+\f0\fs24 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc
+\f1\fs20 (
+\f0\fs24 \'bf\'b9
+\f1\fs20 : 
+\f0\fs24 \'b0\'e8\'be\'e0\'be\'f7\'c3\'bc
+\f1\fs20 )
+\f0\fs24 \'b0\'a1
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'b8\'a6
+\f1  
+\f0 \'b4\'eb\'bd\'c5\'c7\'cf\'bf\'a9
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'a1
+\f1  
+\f0 \'be\'d7\'bc\'bc\'bd\'ba\'c7\'cf\'b0\'ed
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'b0\'cd\'c0\'bb
+\f1  
+\f0 \'c7\'e3\'bf\'eb\'c7\'d2
+\f1  
+\f0 \'b0\'e6\'bf\'ec
+\f1  
+\f0 \'b0\'a2
+\f1  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc\'c0\'c7
+\f1  
+\f0 \'b0\'e8\'be\'e0
+\f1  
+\f0 \'c1\'d8\'bc\'f6\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'c3\'a5\'c0\'d3\'b5\'b5
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'bf\'a1\'b0\'d4
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'b1\'cd\'c7\'cf\'b0\'a1
+\f1  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f1  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc\'bf\'a1\'b0\'d4
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'b9\'e8\'c6\'f7\'c7\'cf\'b0\'c5\'b3\'aa
+\f1  
+\f0 \'b1\'d7
+\f1  
+\f0 \'b9\'db\'c0\'c7
+\f1  
+\f0 \'b9\'e6\'bd\'c4\'c0\'b8\'b7\'ce
+\f1  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc\'c0\'c7
+\f1  
+\f0 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae\'bf\'a1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f1  
+\f0 \'be\'ee\'b6\'b2
+\f1  
+\f0 \'b1\'b8\'bc\'ba
+\f1  
+\f0 \'bf\'e4\'bc\'d2\'b6\'f3\'b5\'b5
+\f1  
+\f0 \'bc\'b3\'c4\'a1\'c7\'d2
+\f1  
+\f0 \'b0\'e6\'bf\'ec
+\f1  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f1  
+\f0 \'b9\'e8\'c6\'f7
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'bc\'b3\'c4\'a1\'bf\'a1
+\f1  
+\f0 \'bd\'c3
+\f1  
+\f0 \'ba\'bb
+\f1  
+\f0 \'b0\'e8\'be\'e0\'c0\'c7
+\f1  
+\f0 \'bb\'e7\'ba\'bb\'c0\'bb
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'c7\'d8\'be\'df
+\f1  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+\
+Cisco
+\f0\fs24 \'b0\'a1
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'bf\'a1\'b0\'d4
+\f1  
+\f0 \'be\'ee\'b6\'b2
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'bf\'cd
+\f1  
+\f0 \'c7\'d4\'b2\'b2
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f1  
+\f0 \'be\'d6\'c7\'c3\'b8\'ae\'c4\'c9\'c0\'cc\'bc\'c7
+\f1  
+\fs20 ID, 
+\f0\fs24 \'bc\'ad\'b8\'ed
+\f1\fs20 , 
+\f0\fs24 \'b1\'d4\'c4\'a2
+\f1\fs20 (
+\f0\fs24 \'c5\'eb\'c4\'aa
+\f1  
+\fs20 "
+\f0\fs24 \'b1\'d4\'c4\'a2
+\f1\fs20 ")
+\f0\fs24 \'c0\'bb
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'c7\'d2
+\f1  
+\f0 \'b0\'e6\'bf\'ec
+\f1  
+\f0 \'b1\'d7\'b7\'af\'c7\'d1
+\f1  
+\f0 \'b1\'d4\'c4\'a2
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c0\'cc\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'b8\'f0\'b5\'e7
+\f1  
+\f0 \'bc\'f6\'c1\'a4
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'be\'f7\'b5\'a5\'c0\'cc\'c6\'ae
+\f1  
+\f0 \'bb\'e7\'c7\'d7\'c0\'ba
+\f1  
+\f0 \'b1\'d4\'c4\'a2\'c0\'c7
+\f1  
+\f0 \'b9\'ab\'b0\'e1\'bc\'ba
+\f1\fs20 , 
+\f0\fs24 \'bb\'f3\'c7\'b0\'bc\'ba
+\f1\fs20 , 
+\f0\fs24 \'c6\'af\'c1\'a4
+\f1  
+\f0 \'bf\'eb\'b5\'b5\'c0\'c7
+\f1  
+\f0 \'c0\'fb\'c7\'d5\'bc\'ba
+\f1\fs20 , 
+\f0\fs24 \'bf\'c0\'b7\'f9
+\f1  
+\f0 \'be\'f8\'c0\'bd
+\f1\fs20 , 
+\f0\fs24 \'ba\'f1\'c4\'a7\'c7\'d8\'bc\'ba\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'ba\'b8\'c1\'f5\'c0\'bb
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'c7\'cf\'b3\'aa
+\f1  
+\f0 \'c0\'cc\'bf\'a1
+\f1  
+\f0 \'b1\'b9\'c7\'d1\'b5\'c7\'c1\'f6
+\f1  
+\f0 \'be\'ca\'b4\'c2
+\f1  
+\f0 \'be\'ee\'b6\'b0\'c7\'d1
+\f1  
+\f0 \'c1\'be\'b7\'f9\'c0\'c7
+\f1  
+\f0 \'b8\'ed\'bd\'c3\'c0\'fb
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'be\'cf\'bd\'c3\'c0\'fb
+\f1  
+\f0 \'ba\'b8\'c1\'f5\'b5\'b5
+\f1  
+\f0 \'be\'f8\'c0\'cc
+\f1  
+\fs20 "
+\f0\fs24 \'c0\'d6\'b4\'c2
+\f1  
+\f0 \'b1\'d7\'b4\'eb\'b7\'ce
+\f1\fs20 " 
+\f0\fs24 \'c1\'a6\'b0\'f8\'b5\'cb\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+\
+
+\f0\fs24 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7
+\f2  
+\f0 \'b1\'e2\'b0\'a3\'c0\'ba
+\f2  
+\fs20 EULA
+\f0\fs24 \'c0\'c7
+\f2  
+\f0 \'c1\'be\'b7\'e1
+\f2  
+\f0 \'c1\'b6\'c7\'d7\'bf\'a1
+\f2  
+\f0 \'b5\'fb\'b8\'a8\'b4\'cf\'b4\'d9
+\f2\fs20 .  
+\f0\fs24 \'c1\'df\'b4\'dc
+\f2  
+\f0 \'be\'f8\'c0\'cc
+\f2  
+\f0 \'c0\'fb\'b9\'fd\'c7\'cf\'b0\'d4
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b1\'e2
+\f2  
+\f0 \'c0\'a7\'c7\'d8\'bc\'ad\'b4\'c2
+\f2  
+\f0 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b8\'b8\'b7\'e1\'c0\'cf
+\f2  
+\f0 \'c0\'cc\'c0\'fc\'bf\'a1
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'cf\'b0\'ed
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba\'b8\'a6
+\f2  
+\f0 \'b0\'bb\'bd\'c5\'c7\'d8\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2\fs20 . 
+\f0\fs24 \'c7\'e3\'bf\'eb\'b5\'c8
+\f2  
+\f0 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae
+\f2  
+\f0 \'bc\'f6
+\f2\fs20 , 
+\f0\fs24 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7
+\f2  
+\f0 \'b1\'e2\'b0\'a3
+\f2\fs20 , 
+\f0\fs24 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'b0\'e1\'c1\'a6\'c7\'df\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'b0\'e1\'c1\'a6\'c7\'d2
+\f2  
+\f0 \'b6\'f3\'c0\'cc\'bc\'b1\'bd\'ba
+\f2  
+\f0 \'b6\'c7\'b4\'c2
+\f2  
+\f0 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'b0\'fa
+\f2  
+\f0 \'b0\'fc\'b7\'c3\'b5\'c8
+\f2  
+\f0 \'b1\'e2\'c5\'b8
+\f2  
+\f0 \'c1\'a6\'c7\'d1\'c0\'bb
+\f2  
+\f0 \'c3\'ca\'b0\'fa\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'be\'f8\'bd\'c0\'b4\'cf\'b4\'d9
+\f2\fs20 .  
+\f0\fs24 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7\'c0\'cc
+\f2  
+\f0 \'b0\'bb\'bd\'c5\'b5\'c7\'c1\'f6
+\f2  
+\f0 \'be\'ca\'b0\'ed
+\f2  
+\f0 \'b8\'b8\'b7\'e1\'b5\'c9
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'b1\'e2\'b4\'c9
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba\'c0\'c7
+\f2  
+\f0 \'c0\'db\'b5\'bf\'c0\'cc
+\f2  
+\f0 \'c1\'df\'c1\'f6\'b5\'c9
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2\fs20 .  Cisco
+\f0\fs24 \'b4\'c2
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'c7\'e3\'bf\'eb\'b5\'c8
+\f2  
+\f0 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae
+\f2  
+\f0 \'bc\'f6\'b8\'a6
+\f2  
+\f0 \'c3\'ca\'b0\'fa\'c7\'cf\'bf\'a9
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b0\'c5\'b3\'aa
+\f2  
+\f0 \'bc\'ad\'ba\'ea\'bd\'ba\'c5\'a9\'b8\'b3\'bc\'c7
+\f2  
+\f0 \'b1\'e2\'b0\'a3\'c0\'cc
+\f2  
+\f0 \'b8\'b8\'b7\'e1\'b5\'c7\'be\'fa\'b4\'c2\'b5\'a5
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b0\'a1
+\f2  
+\f0 \'c1\'f6\'bc\'d3\'c0\'fb\'c0\'ce
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'c0\'a7\'c7\'d1
+\f2  
+\f0 \'c7\'d8\'b4\'e7
+\f2  
+\f0 \'bf\'e4\'b1\'dd\'c0\'bb
+\f2  
+\f0 \'c1\'f6\'ba\'d2\'c7\'cf\'c1\'f6
+\f2  
+\f0 \'be\'ca\'c0\'bb
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'bb
+\f2  
+\f0 \'c1\'df\'b4\'dc\'bd\'c3\'c5\'b3
+\f2  
+\f0 \'b1\'c7\'b8\'ae\'b0\'a1
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2\fs20 .  
+\f0\fs24 \'ba\'bb
+\f2  
+\f0 \'b0\'e8\'be\'e0\'c0\'cc
+\f2  
+\f0 \'c1\'be\'b7\'e1\'b5\'c9
+\f2  
+\f0 \'b0\'e6\'bf\'ec
+\f2  
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f2  
+\f0 \'c7\'e3\'b0\'a1\'b9\'de\'c0\'ba
+\f2  
+\f0 \'b8\'f0\'b5\'e7
+\f2  
+\f0 \'bc\'ad\'b5\'e5\'c6\'c4\'c6\'bc
+\f2  
+\f0 \'bb\'e7\'bf\'eb\'c0\'da\'bf\'a1\'b0\'d4
+\f2  
+\f0 \'b1\'d7\'b5\'e9\'c0\'c7
+\f2  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f2  
+\f0 \'be\'d7\'bc\'bc\'bd\'ba
+\f2  
+\f0 \'b9\'d7
+\f2  
+\f0 \'bb\'e7\'bf\'eb
+\f2  
+\f0 \'b1\'c7\'c7\'d1\'b5\'b5
+\f2  
+\f0 \'c1\'be\'b7\'e1\'b5\'c7\'be\'fa\'c0\'bd\'c0\'bb
+\f2  
+\f0 \'be\'cb\'b8\'ae\'b1\'e2
+\f2  
+\f0 \'c0\'a7\'c7\'d8
+\f2  
+\f0 \'bb\'f3\'be\'f7\'c0\'fb\'c0\'b8\'b7\'ce
+\f2  
+\f0 \'c7\'d5\'b4\'e7\'c7\'d1
+\f2  
+\f0 \'b3\'eb\'b7\'c2\'c0\'bb
+\f2  
+\f0 \'b1\'e2\'bf\'ef\'bf\'a9\'be\'df
+\f2  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f2\fs20 .
+\f1 \
+\
+\pard\pardeftab720\ri0\qj\partightenfactor0
+
+\f0\fs24 \cf0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'bc\'f6\'c1\'fd\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'b5\'bf\'c0\'c7
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1  
+\f0 \'ba\'b8\'c8\'a3
+\f1\b\fs20 \
+\pard\pardeftab720\ri0\qj\partightenfactor0
+
+\f2\b0\fs24 \cf0 \
+\pard\pardeftab720\ri0\qj\partightenfactor0
+
+\f1\b\fs20 \cf0 1.\ul  
+\f0\b0\fs24 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'bc\'f6\'c1\'fd
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c3\'b3\'b8\'ae
+\f1\b\fs20 \ulnone .  
+\b0 Cisco
+\f0\fs24 \'b4\'c2
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'c0\'c7
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'bb\'e7\'bf\'eb
+\f1  
+\f0 \'b9\'d7
+\f1\fs20 /
+\f0\fs24 \'b6\'c7\'b4\'c2
+\f1  
+\fs20 Cisco
+\f0\fs24 \'c0\'c7
+\f1  
+\f0 \'b0\'fc\'b7\'c3
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'c0\'c7
+\f1  
+\f0 \'c0\'cf\'c8\'af\'c0\'b8\'b7\'ce
+\f1  
+\f0 \'ba\'f1
+\f1  
+\f0 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b1\'cd\'c7\'cf
+\f1\fs20 , 
+\f0\fs24 \'b1\'cd\'c7\'cf\'c0\'c7
+\f1  
+\f0 \'b3\'d7\'c6\'ae\'bf\'f6\'c5\'a9\'bf\'cd
+\f1  
+\f0 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'c6\'af\'c1\'a4
+\f1  
+\f0 \'bd\'c4\'ba\'b0
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1\fs20 (
+\f0\fs24 \'bf\'b9
+\f1\fs20 : 
+\f0\fs24 \'bf\'a3\'b5\'e5\'c6\'f7\'c0\'ce\'c6\'ae
+\f1  
+\fs20 ID, IP 
+\f0\fs24 \'c1\'d6\'bc\'d2
+\f1\fs20 , 
+\f0\fs24 \'c0\'a7\'c4\'a1
+\f1\fs20 , 
+\f0\fs24 \'b3\'bb\'bf\'eb
+\f1  
+\f0 \'b5\'ee
+\f1\fs20 )
+\f0\fs24 \'b8\'a6
+\f1  
+\f0 \'bc\'f6\'c1\'fd
+\f1\fs20 , 
+\f0\fs24 \'ba\'b8\'c1\'b8
+\f1\fs20 , 
+\f0\fs24 \'bb\'e7\'bf\'eb\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'c0\'cc\'b7\'af\'c7\'d1
+\f1  
+\f0 \'c6\'af\'c1\'a4
+\f1  
+\f0 \'bd\'c4\'ba\'b0
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'c1\'df
+\f1  
+\f0 \'c0\'cf\'ba\'ce\'b4\'c2
+\f1  
+\f0 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f1  
+\f0 \'c6\'f7\'c7\'d4\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 . 
+\f0\fs24 \'b6\'c7\'c7\'d1
+\f1  
+\fs20 Cisco
+\f0\fs24 \'b4\'c2
+\f1  
+\f0 \'b1\'d7\'b7\'b8\'b0\'d4
+\f1  
+\f0 \'bc\'f6\'c1\'fd\'c7\'d1
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd\'b8\'a6
+\f1  
+\f0 \'b9\'cc\'b1\'b9
+\f1  
+\f0 \'b9\'d7
+\f1  
+\fs20 Cisco
+\f0\fs24 \'b3\'aa
+\f1  
+\f0 \'b1\'d7
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'be\'f7\'c3\'bc\'b0\'a1
+\f1  
+\f0 \'bb\'e7\'be\'f7\'c0\'e5\'c0\'bb
+\f1  
+\f0 \'b5\'d0
+\f1  
+\f0 \'b1\'e2\'c5\'b8
+\f1  
+\f0 \'b1\'b9\'b0\'a1\'bf\'a1
+\f1  
+\f0 \'c0\'d6\'b4\'c2
+\f1  
+\fs20 Cisco 
+\f0\fs24 \'c1\'f6\'bb\'e7
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c0\'da\'c8\'b8\'bb\'e7\'bf\'a1
+\f1  
+\f0 \'c0\'fc\'bc\'db\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+\
+\pard\tx810\pardeftab720\ri0\qj\partightenfactor0
+
+\b \cf0 2.
+\b0  
+\f0\fs24 \ul \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'bc\'f6\'c1\'fd
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c3\'b3\'b8\'ae\'c0\'c7
+\f1  
+\f0 \'b8\'f1\'c0\'fb
+\f1\b\fs20 \ulnone . 
+\b0 Cisco
+\f0\fs24 \'b0\'a1
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b7\'ce\'ba\'ce\'c5\'cd
+\f1  
+\f0 \'bc\'f6\'c1\'fd\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd\'b4\'c2
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f1  
+\f0 \'c7\'d9\'bd\'c9
+\f1  
+\f0 \'bf\'eb\'b5\'b5
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b1\'e2\'b4\'c9
+\f1\fs20 (
+\f0\fs24 \'bf\'b9
+\f1\fs20 : 
+\f0\fs24 \'b5\'f0\'b9\'d9\'c0\'cc\'bd\'ba
+\f1  
+\f0 \'c3\'df\'c0\'fb
+\f1\fs20 , 
+\f0\fs24 \'be\'d7\'bc\'bc\'bd\'ba
+\f1  
+\f0 \'c1\'a6\'be\'ee
+\f1\fs20 , 
+\f0\fs24 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c6\'ae\'b7\'a1\'c7\'c8
+\f1  
+\f0 \'ba\'d0\'bc\'ae
+\f1\fs20 , 
+\f0\fs24 \'c0\'a7\'c7\'f9
+\f1  
+\f0 \'c5\'bd\'c1\'f6
+\f1\fs20 , 
+\f0\fs24 \'be\'c7\'bc\'ba\'c4\'da\'b5\'e5
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'c7\'e0\'b5\'bf
+\f1  
+\f0 \'b0\'fc\'b7\'c3
+\f1  
+\f0 \'ba\'d0\'bc\'ae
+\f1  
+\f0 \'b5\'ee
+\f1\fs20 )
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'c7\'ca\'bf\'e4\'c7\'cf\'b8\'e7
+\f1\fs20 , Cisco
+\f0\fs24 \'b0\'a1
+\f1  
+\f0 \'b0\'fc\'b7\'c3
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba\'b8\'a6
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b0\'c5\'b3\'aa
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'c0\'c7
+\f1  
+\f0 \'bf\'ee\'bf\'b5
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b1\'e2\'b4\'c9\'c0\'bb
+\f1  
+\f0 \'b0\'b3\'bc\'b1\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'bf\'eb\'b5\'b5\'b7\'ce
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b1\'e2\'b5\'b5
+\f1  
+\f0 \'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 . 
+\f0\fs24 \'c0\'cc\'b7\'af\'c7\'d1
+\f1  
+\f0 \'c0\'cc\'c0\'af\'b7\'ce
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'c1\'a6\'b0\'c5
+\f1  
+\f0 \'b6\'c7\'b4\'c2
+\f1  
+\f0 \'ba\'f1\'c8\'b0\'bc\'ba\'c8\'ad
+\f1  
+\f0 \'c0\'cc\'bf\'dc\'c0\'c7
+\f1  
+\f0 \'b9\'e6\'b9\'fd\'c0\'b8\'b7\'ce\'b4\'c2
+\f1  
+\f0 \'c0\'cc
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'bc\'f6\'c1\'fd
+\f1  
+\f0 \'c1\'df
+\f1  
+\f0 \'c0\'cf\'ba\'ce\'b8\'a6
+\f1  
+\f0 \'bf\'c9\'c6\'ae\'be\'c6\'bf\'f4\'c7\'cf\'c1\'f6
+\f1  
+\f0 \'b8\'f8\'c7\'d2
+\f1  
+\f0 \'bc\'f6\'b5\'b5
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'b1\'d7\'b7\'af\'b3\'aa
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'c7\'d8\'b4\'e7
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'b9\'ae\'bc\'ad\'bf\'a1
+\f1  
+\f0 \'bc\'b3\'b8\'ed\'b5\'c8
+\f1  
+\f0 \'b4\'eb\'b7\'ce
+\f1  
+\f0 \'bc\'f6\'c1\'fd
+\f1  
+\f0 \'b0\'a1\'b4\'c9\'c7\'d1
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd\'c0\'c7
+\f1  
+\f0 \'c0\'cf\'ba\'ce\'b8\'a6
+\f1  
+\f0 \'c1\'a6\'c7\'d1\'c7\'cf\'b5\'b5\'b7\'cf
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'b1\'b8\'bc\'ba\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .  \
+\pard\pardeftab720\li720\ri0\sb2\sa2\qj\partightenfactor0
+\cf0 \
+\pard\pardeftab720\ri0\qj\partightenfactor0
+
+\b \cf0 3. 
+\f0\b0\fs24 \ul \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'bc\'f6\'c1\'fd
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'bf\'a1
+\f1  
+\f0 \'b4\'eb\'c7\'d1
+\f1  
+\f0 \'b5\'bf\'c0\'c7
+\f1\b\fs20 \ulnone . 
+\f0\b0\fs24 \'b1\'cd\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee\'b8\'a6
+\f1  
+\f0 \'bb\'e7\'bf\'eb\'c7\'cf\'b0\'c5\'b3\'aa
+\f1  
+\fs20 Cisco
+\f0\fs24 \'bf\'a1\'bc\'ad
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'b0\'fc\'b7\'c3
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba\'bf\'a1
+\f1  
+\f0 \'b0\'a1\'c0\'d4\'c7\'cf\'b0\'ed
+\f1  
+\f0 \'ba\'bb
+\f1  
+\f0 \'b0\'e8\'be\'e0\'bf\'a1
+\f1  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d4\'c0\'b8\'b7\'ce\'bd\'e1
+\f1  
+\fs20 Cisco
+\f0\fs24 \'bf\'cd
+\f1  
+\f0 \'b1\'d7
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'be\'f7\'c3\'bc\'b0\'a1
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'c0\'c7
+\f1  
+\f0 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b1\'e2\'c5\'b8
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd\'b8\'a6
+\f1  
+\f0 \'bc\'f6\'c1\'fd
+\f1\fs20 , 
+\f0\fs24 \'bb\'e7\'bf\'eb
+\f1\fs20 , 
+\f0\fs24 \'c0\'fc\'bc\'db
+\f1\fs20 , 
+\f0\fs24 \'b9\'e9\'be\'f7
+\f1\fs20 , 
+\f0\fs24 \'c0\'fa\'c0\'e5\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'b5\'a5
+\f1  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 . Cisco
+\f0\fs24 \'b4\'c2
+\f1  
+\fs20 Cisco
+\f0\fs24 \'c0\'c7
+\f1  
+\f0 \'b0\'b3\'c0\'ce\'c1\'a4\'ba\'b8
+\f1  
+\f0 \'ba\'b8\'c8\'a3\'c1\'a4\'c3\'a5
+\f1\fs20 (
+\f0\fs24 \'be\'c6\'b7\'a1\'c0\'c7
+\f1  
+\f0 \'bc\'bd\'bc\'c7
+\f1  
+\fs20 4 
+\f0\fs24 \'c2\'fc\'c1\'b6
+\f1\fs20 )
+\f0\fs24 \'bf\'a1
+\f1  
+\f0 \'b5\'fb\'b8\'a5
+\f1  
+\f0 \'b0\'e6\'bf\'ec\'b8\'a6
+\f1  
+\f0 \'c1\'a6\'bf\'dc\'c7\'cf\'b0\'ed
+\f1  
+\f0 \'c0\'cc\'b7\'af\'c7\'d1
+\f1  
+\f0 \'c1\'a4\'ba\'b8\'b8\'a6
+\f1  
+\f0 \'c3\'b3\'b8\'ae\'c7\'cf\'c1\'f6
+\f1  
+\f0 \'be\'ca\'bd\'c0\'b4\'cf\'b4\'d9
+\f1\fs20 .  
+\f0\fs24 \'b6\'c7\'c7\'d1
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'b4\'c2
+\f1  
+\fs20 Cisco
+\f0\fs24 \'bf\'cd
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'be\'f7\'c3\'bc\'b0\'a1
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'c0\'c7
+\f1  
+\f0 \'bc\'d2\'c7\'c1\'c6\'ae\'bf\'fe\'be\'ee
+\f1  
+\f0 \'bb\'e7\'bf\'eb
+\f1  
+\f0 \'b9\'d7
+\f1  
+\fs20 Cisco
+\f0\fs24 \'c0\'c7
+\f1  
+\f0 \'b0\'fc\'b7\'c3
+\f1  
+\f0 \'bc\'ad\'ba\'f1\'bd\'ba
+\f1  
+\f0 \'c1\'a6\'b0\'f8\'c0\'c7
+\f1  
+\f0 \'c0\'cf\'c8\'af\'c0\'b8\'b7\'ce
+\f1  
+\f0 \'b9\'cc\'b1\'b9
+\f1\fs20 , 
+\f0\fs24 \'c0\'af\'b7\'b4
+\f1\fs20 , 
+\f0\fs24 \'b5\'a5\'c0\'cc\'c5\'cd
+\f1  
+\f0 \'ba\'b8\'c8\'a3
+\f1  
+\f0 \'c7\'a5\'c1\'d8\'c0\'cc
+\f1  
+\f0 \'b4\'d9\'b8\'a6
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'b4\'c2
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'c0\'c7
+\f1  
+\f0 \'b1\'b9\'b0\'a1\'b0\'a1
+\f1  
+\f0 \'be\'c6\'b4\'d1
+\f1  
+\f0 \'b1\'e2\'c5\'b8
+\f1  
+\f0 \'b1\'b9\'b0\'a1\'b3\'aa
+\f1  
+\f0 \'bb\'e7\'b9\'fd\'b1\'c7\'bf\'a1\'bc\'ad
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'c0\'c7
+\f1  
+\f0 \'b0\'b3\'c0\'ce
+\f1  
+\f0 \'c1\'a4\'ba\'b8
+\f1  
+\f0 \'b9\'d7
+\f1  
+\f0 \'b1\'e2\'c5\'b8
+\f1  
+\f0 \'b5\'a5\'c0\'cc\'c5\'cd\'b8\'a6
+\f1  
+\f0 \'c0\'fc\'bc\'db
+\f1\fs20 , 
+\f0\fs24 \'ba\'b9\'bb\'e7
+\f1\fs20 , 
+\f0\fs24 \'b9\'e9\'be\'f7
+\f1\fs20 , 
+\f0\fs24 \'c0\'fa\'c0\'e5\'c7\'d2
+\f1  
+\f0 \'bc\'f6
+\f1  
+\f0 \'c0\'d6\'b4\'d9\'b4\'c2
+\f1  
+\f0 \'b5\'a5
+\f1  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 .\
+\pard\tx810\pardeftab720\ri0\qj\partightenfactor0
+\cf0 \
+\pard\tx720\pardeftab720\ri0\qj\partightenfactor0
+
+\b \cf0 4.
+\b0  
+\f0\fs24 \ul \'b0\'b3\'c0\'ce\'c1\'a4\'ba\'b8
+\f1  
+\f0 \'ba\'b8\'c8\'a3\'c1\'a4\'c3\'a5
+\f1\b\fs20 \ulnone . 
+\f0\b0\fs24 \'b1\'cd\'c7\'cf\'b4\'c2
+\f1  
+\f0 \'ba\'bb
+\f1  
+\f0 \'b0\'e8\'be\'e0\'c0\'bb
+\f1  
+\f0 \'c3\'bc\'b0\'e1\'c7\'d4\'c0\'b8\'b7\'ce\'bd\'e1
+\f1  
+\f0 \'c0\'d3\'c0\'c7\'c0\'c7
+\f1  
+\f0 \'b0\'fc\'b7\'c3
+\f1  
+\f0 \'bd\'c3\'c1\'a1\'bf\'a1
+\f1  
+\f0 \'bd\'c3\'c7\'e0\'b5\'c7\'b4\'c2
+\f1  
+\fs20 Cisco 
+\f0\fs24 \'b0\'b3\'c0\'ce\'c1\'a4\'ba\'b8
+\f1  
+\f0 \'ba\'b8\'c8\'a3\'c1\'a4\'c3\'a5\'c0\'cc
+\f1  
+\f0 \'b1\'cd\'c7\'cf\'bf\'a1
+\f1  
+\f0 \'c0\'fb\'bf\'eb\'b5\'c8\'b4\'d9\'b4\'c2
+\f1  
+\f0 \'b5\'a5
+\f1  
+\f0 \'b5\'bf\'c0\'c7\'c7\'d5\'b4\'cf\'b4\'d9
+\f1\fs20 . 
+\f0\fs24 \'c3\'d6\'bd\'c5
+\f1  
+\f0 \'b0\'b3\'c0\'ce\'c1\'a4\'ba\'b8
+\f1  
+\f0 \'ba\'b8\'c8\'a3\'c1\'a4\'c3\'a5\'c0\'ba
+\f1  {\field{\*\fldinst{HYPERLINK "http://www.cisco.com/web/siteassets/legal/privacy_full.html"}}{\fldrslt 
+\fs20 \cf2 \ul \ulc2 http://www.cisco.com/web/siteassets/legal/privacy_full.html}}
+\f0 \'bf\'a1\'bc\'ad
+\f2  
+\f0 \'c8\'ae\'c0\'ce\'c7\'d2
+\f2  
+\f0 \'bc\'f6
+\f2  
+\f0 \'c0\'d6\'bd\'c0\'b4\'cf\'b4\'d9
+\f2 .
+\f1\fs20 \cf2 \ul \ulc2 \
+\pard\tx720\pardeftab720\ri0\qc\partightenfactor0
+
+\f2\fs24 \cf0 \ulnone [EULA 
+\f0 \'b3\'a1
+\f2 ]
+\f1\fs20 \
+}

--- a/samples/RTF/simple.rtf
+++ b/samples/RTF/simple.rtf
@@ -1,0 +1,29 @@
+{\rtf0\ansi{\fonttbl\f0\fswiss Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+\paperw9840\paperh8400
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\ql\qnatural
+
+\f0\b\fs24 \cf0 Engineering:
+\b0 \
+	Some people\
+\
+
+\b Human Interface Design:
+\b0 \
+	Some other people\
+\
+
+\b Testing:
+\b0 \
+	Hopefully not nobody\
+\
+
+\b Documentation:
+\b0 \
+	Whoever\
+\
+
+\b With special thanks to:
+\b0 \
+	Mom\
+}

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -147,6 +147,8 @@ class TestFileBlob < Minitest::Test
     assert fixture_blob("Data/md").text?
     assert sample_blob("Shell/script.sh").text?
     assert fixture_blob("Data/txt").text?
+    assert sample_blob("RTF/simple.rtf").text?
+    assert sample_blob("RTF/complicated.rtf").text?
   end
 
   def test_image

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -133,6 +133,7 @@ class TestLanguage < Minitest::Test
 
   def test_data
     assert_equal :data, Language['YAML'].type
+    assert_equal :data, Language['RTF'].type
   end
 
   def test_prose


### PR DESCRIPTION
We've found a few large rich text format (rtf) files are causing timeouts with almost all of the time being spent in linguist:

```
Seconds |   Count | Name
 19.694 |       9 | linguist.strategy
 19.691 |       1 | linguist.detection
[... redacted ...]
  0.000 |       1 | linguist.detected
```

... specifically attempting to unnecessarily tokenise the file:

```
/data/github/870366e/vendor/gems/2.1.7/ruby/2.1.0/gems/github-linguist-4.8.12/lib/linguist/tokenizer.rb:91:in `extract_tokens'
/data/github/870366e/vendor/gems/2.1.7/ruby/2.1.0/gems/github-linguist-4.8.12/lib/linguist/tokenizer.rb:16:in `tokenize'
/data/github/870366e/vendor/gems/2.1.7/ruby/2.1.0/gems/github-linguist-4.8.12/lib/linguist/classifier.rb:99:in `classify'
/data/github/870366e/vendor/gems/2.1.7/ruby/2.1.0/gems/github-linguist-4.8.12/lib/linguist/classifier.rb:78:in `classify'
/data/github/870366e/vendor/gems/2.1.7/ruby/2.1.0/gems/github-linguist-4.8.12/lib/linguist/classifier.rb:20:in `call'
/data/github/870366e/vendor/gems/2.1.7/ruby/2.1.0/gems/github-linguist-4.8.12/lib/linguist.rb:30:in `block (3 levels) in detect'
```

The `samples/RTF/complicated.rtf` file in this PR is an example of such a file.

This is taken from GitHub Enterprise, hence the slightly old version, but github.com exhibits the problem too as you'll be able to see if you attempt to [view the file](https://github.com/lildude/linguist/blob/60253b026b97c0088dd5816e1b518abc33b84324/samples/RTF/complicated.rtf) in this PR.

This PR addresses this problem by explicitly adding support for RTF files and marking them as data so no attempts are made to tokenise the files when rendering.

As for usage: only [434,582 results](https://github.com/search?utf8=%E2%9C%93&q=extension%3Artf+NOT+nothack&type=Code&ref=searchresults) for `.rtf` 😜

I know I'm technically a maintainer of linguist, but this is my first PR for it, so go easy on me 😉