### PR TITLE
Return early in Classifier.classify if no languages supplied

### DIFF
--- a/lib/linguist/classifier.rb
+++ b/lib/linguist/classifier.rb
@@ -95,7 +95,7 @@ module Linguist
     # Returns sorted Array of result pairs. Each pair contains the
     # String language name and a Float score.
     def classify(tokens, languages)
-      return [] if tokens.nil?
+      return [] if tokens.nil? || languages.empty?
       tokens = Tokenizer.tokenize(tokens) if tokens.is_a?(String)
       scores = {}
 

--- a/test/test_classifier.rb
+++ b/test/test_classifier.rb
@@ -53,4 +53,8 @@ class TestClassifier < Minitest::Test
       assert_equal language.name, results.first[0], "#{sample[:path]}\n#{results.inspect}"
     end
   end
+
+  def test_classify_empty_languages
+    assert_equal [], Classifier.classify(Samples.cache, fixture("Ruby/foo.rb"), [])
+  end
 end


### PR DESCRIPTION
In an attempt to resolve a problem with rendering large, complex RTF files, I added support for RTF in https://github.com/github/linguist/pull/3468, however this wasn't the best approach as @pchaigno pointed out in https://github.com/github/linguist/pull/3468#issuecomment-279247233

On closer inspection, it makes more sense to return early in `Classifier.classify` if no languages have been supplied as by not doing so, we unnecessarily tokenise the data that won't be used when it comes to scoring further down in the method.

This makes a significant difference in the time it takes to perform against the problematic file, before the early return:

```
$ time bin/linguist ~/tmp/trash/linguist-timeout/License.rtf --breakdown
License.rtf: 7507 lines (7457 sloc)
  type:      Text
  mime type: application/rtf
  language:
bin/linguist ~/tmp/trash/linguist-timeout/License.rtf --breakdown  13.56s user 0.13s system 96% cpu 14.156 total
$
```

... versus _with_ the early return:

```
$ time bin/linguist ~/tmp/trash/linguist-timeout/License.rtf --breakdown
License.rtf: 7507 lines (7457 sloc)
  type:      Text
  mime type: application/rtf
  language:
bin/linguist ~/tmp/trash/linguist-timeout/License.rtf --breakdown  0.42s user 0.07s system 90% cpu 0.545 total
$
```

Hopefully I'm not missing anything obvious with this, but please speak up if you think I am.