### PR TITLE
Fix for GDScript language

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -192,6 +192,12 @@ module Linguist
       end
     end
 
+    disambiguate ".gd" do |data|
+      if /^((extends\s+(([A-Za-z]\w+)|(['"]\S[\s\w+.\-\\\/:@]+\S['"](\s*\.\s*[A-Za-z]\S*)?))\s*($|[;#]))|(class\s+[A-Za-z]\w*))/m.match(data)
+        Language["GDScript"]
+      end
+    end
+
     disambiguate ".gs" do |data|
       Language["Gosu"] if /^uses java\./.match(data)
     end

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1339,7 +1339,6 @@ GDB:
   language_id: 122
 GDScript:
   type: programming
-  color: "#478cbf"
   extensions:
   - ".gd"
   tm_scope: source.gdscript

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1339,6 +1339,7 @@ GDB:
   language_id: 122
 GDScript:
   type: programming
+  color: "#478cbf"
   extensions:
   - ".gd"
   tm_scope: source.gdscript


### PR DESCRIPTION
This is a "partial" fix for #1528 (*.gd files mis-recognized as GAP).

### Added a heuristic rule to match 2 common expressions in GDScript

* `extends` expression:
```gdscript
# Inherit/extend a globally available class
extends SomeClass

# Inherit/extend a named class file
extends "somefile.gd"

# Inherit/extend an inner class in another file
extends "somefile.gd".SomeInnerClass
```

* `class` expression:
```gdscript
class SomeClass:
```

I've tested these rules with some GDScript and GAP repos.

### Added a color to GDScript

* Language color from [official logo](https://godotengine.org/themes/godotengine/assets/logo.svg).
