### PR TITLE
Like `^docs?`, sometimes one `sample` is enough

### DIFF
--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -27,4 +27,4 @@
 - (^|/)[Rr]eadme(\.|$)
 
 # Samples folders
-- ^[Ss]amples/
+- ^[Ss]amples?/


### PR DESCRIPTION
From [the README](https://github.com/github/linguist#using-gitattributes):

> Just like vendored files, Linguist excludes documentation files from your project's language stats. lib/linguist/documentation.yml lists common documentation paths and excludes them from the language statistics for your repository.

I have a folder called `sample` that I would like excluded. The first line in this file is marked as ` ^docs?/` and it stands to reason that `samples?` should also be excluded.