### PR TITLE
Update URL for Julia TextMate repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -177,7 +177,7 @@
 	url = https://github.com/mokus0/Agda.tmbundle
 [submodule "vendor/grammars/Julia.tmbundle"]
 	path = vendor/grammars/Julia.tmbundle
-	url = https://github.com/nanoant/Julia.tmbundle
+	url = https://github.com/JuliaEditorSupport/Julia.tmbundle
 [submodule "vendor/grammars/ooc.tmbundle"]
 	path = vendor/grammars/ooc.tmbundle
 	url = https://github.com/nilium/ooc.tmbundle

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -169,7 +169,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **JSONiq:** [wcandillon/language-jsoniq](https://github.com/wcandillon/language-jsoniq)
 - **JSONLD:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **JSX:** [github-linguist/language-babel](https://github.com/github-linguist/language-babel)
-- **Julia:** [nanoant/Julia.tmbundle](https://github.com/nanoant/Julia.tmbundle)
+- **Julia:** [JuliaEditorSupport/Julia.tmbundle](https://github.com/JuliaEditorSupport/Julia.tmbundle)
 - **Jupyter Notebook:** [textmate/json.tmbundle](https://github.com/textmate/json.tmbundle)
 - **Kit:** [textmate/html.tmbundle](https://github.com/textmate/html.tmbundle)
 - **Kotlin:** [vkostyukov/kotlin-sublime-package](https://github.com/vkostyukov/kotlin-sublime-package)

--- a/vendor/licenses/grammar/Julia.tmbundle.txt
+++ b/vendor/licenses/grammar/Julia.tmbundle.txt
@@ -6,7 +6,7 @@ license: mit
 Copyright (c) 2012-2014 Stefan Karpinski, Elliot Saba, Dirk Gadsden,
 Adam Strzelecki, Jonathan Malmaud and other contributors:
 
-https://github.com/nanoant/Julia.tmbundle/contributors
+https://github.com/JuliaEditorSupport/Julia.tmbundle/contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
The repository providing TextMate definitions for the Julia language has been moved from nanoant's personal account to the JuliaEditorSupport organization. This PR updates the URLs used by Linguist accordingly.