### PR TITLE
Add alias for pandoc

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2456,6 +2456,8 @@ Mako:
   language_id: 221
 Markdown:
   type: prose
+  aliases:
+  - pandoc
   ace_mode: markdown
   codemirror_mode: gfm
   codemirror_mime_type: text/x-gfm


### PR DESCRIPTION
I use the modeline `vim: set filetype=pandoc:` for [this documentation Mustache template](https://github.com/klpn/Mortchartgen.jl/blob/master/data/mortchartdoc.mustache) to have it recognized as Pandoc markdown (this filetype is used by e.g. [the vim-pandoc plugin](https://github.com/vim-pandoc/vim-pandoc)). However, the `pandoc` filetype is not recognized by Linguist, and the file is incorrectly classified as `HTML+Django`. So, this request adds an alias for `pandoc` to `Markdown`.