### PR TITLE
Fix ambiguous classification test

### DIFF
--- a/test/test_classifier.rb
+++ b/test/test_classifier.rb
@@ -46,7 +46,7 @@ class TestClassifier < Minitest::Test
   def test_classify_ambiguous_languages
     Samples.each do |sample|
       language  = Linguist::Language.find_by_name(sample[:language])
-      languages = Language.find_by_filename(sample[:path]).map(&:name)
+      languages = Language.find_by_extension(sample[:path]).map(&:name)
       next unless languages.length > 1
 
       results = Classifier.classify(Samples.cache, File.read(sample[:path]), languages)


### PR DESCRIPTION
Found while preparing #3490.

This change means that the test does now find some ambiguous languages, and tests that the relevant samples resolve to the correct language, but it fails with this assertion:

```
  1) Failure:
TestClassifier#test_classify_ambiguous_languages [/Users/timjones/Code/github/linguist/test/test_classifier.rb:53]:
/Users/timjones/Code/github/linguist/samples/Makefile/filenames/Makefile.frag
[["JavaScript", -3411.2346496412188], ["GLSL", -3498.798416469136]].
Expected: "Makefile"
  Actual: "JavaScript"
```

Presumably this is because there are some filename overrides, including for `Makefile`, that aren't picked up if we use `Language.find_by_extension`. Any suggestions for fixing this?