### PR TITLE
Grammar for OpenSCAD from Textmate bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -833,3 +833,6 @@
 [submodule "vendor/grammars/language-jison"]
 	path = vendor/grammars/language-jison
 	url = https://github.com/cdibbs/language-jison
+[submodule "vendor/grammars/openscad.tmbundle"]
+	path = vendor/grammars/openscad.tmbundle
+	url = https://github.com/tbuser/openscad.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -526,6 +526,8 @@ vendor/grammars/ooc.tmbundle:
 - source.ooc
 vendor/grammars/opa.tmbundle:
 - source.opa
+vendor/grammars/openscad.tmbundle:
+- source.scad
 vendor/grammars/oz-tmbundle/Syntaxes/Oz.tmLanguage:
 - source.oz
 vendor/grammars/parrot:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2930,7 +2930,7 @@ OpenSCAD:
   type: programming
   extensions:
   - ".scad"
-  tm_scope: none
+  tm_scope: source.scad
   ace_mode: scad
   language_id: 266
 OpenType Feature File:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -239,6 +239,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **OpenCL:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **OpenEdge ABL:** [jfairbank/Sublime-Text-2-OpenEdge-ABL](https://github.com/jfairbank/Sublime-Text-2-OpenEdge-ABL)
 - **OpenRC runscript:** [atom/language-shellscript](https://github.com/atom/language-shellscript)
+- **OpenSCAD:** [tbuser/openscad.tmbundle](https://github.com/tbuser/openscad.tmbundle)
 - **OpenType Feature File:** [Alhadis/language-fontforge](https://github.com/Alhadis/language-fontforge)
 - **Ox:** [andreashetland/sublime-text-ox](https://github.com/andreashetland/sublime-text-ox)
 - **Oz:** [eregon/oz-tmbundle](https://github.com/eregon/oz-tmbundle)

--- a/vendor/licenses/grammar/openscad.tmbundle.txt
+++ b/vendor/licenses/grammar/openscad.tmbundle.txt
@@ -1,0 +1,25 @@
+---
+type: grammar
+name: openscad.tmbundle
+license: mit
+---
+Copyright (c) 2017 Tony Buser
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This pull request adds a grammar for OpenSCAD. An MIT license was recently added to https://github.com/tbuser/openscad.tmbundle, enabling the present improvement.
[Example with Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Ftbuser%2Fopenscad.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FOpenSCAD.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fgithub%2Flinguist%2Fmaster%2Fsamples%2FOpenSCAD%2Fnot_simple.scad&code=).