### PR TITLE
Add .eye files to be used as ruby

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3738,6 +3738,7 @@ Ruby:
   extensions:
   - ".rb"
   - ".builder"
+  - ".eye"
   - ".fcgi"
   - ".gemspec"
   - ".god"


### PR DESCRIPTION
Usually files that are used for [eye](https://github.com/kostya/eye) have the file extension `.eye`.
A eye definition file always contains ruby code.