### PR TITLE
Improved the documentation regex's

### DIFF
--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -9,11 +9,12 @@
 
 ## Documentation directories ##
 
-- ^docs?/
+- ^[Dd]ocs?/
 - (^|/)[Dd]ocumentation/
-- (^|/)javadoc/
-- ^man/
+- (^|/)[Jj]avadoc/
+- ^[Mm]an/
 - ^[Ee]xamples/
+- ^[Dd]emos?/
 
 ## Documentation files ##
 


### PR DESCRIPTION
In one of my repositories, I have 2 folders:
* Demos
* Docs

With the previous regex's for documentation.yml, those 2 folders would have not been matched. I have updated them to include folders called demos and be less case sensitive.