### PR TITLE
[Add Language] Marko

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -833,3 +833,6 @@
 [submodule "vendor/grammars/openscad.tmbundle"]
 	path = vendor/grammars/openscad.tmbundle
 	url = https://github.com/tbuser/openscad.tmbundle
+[submodule "vendor/grammars/marko-tmbundle"]
+	path = vendor/grammars/marko-tmbundle
+	url = https://github.com/marko-js/marko-tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -489,6 +489,8 @@ vendor/grammars/make.tmbundle:
 - source.makefile
 vendor/grammars/mako-tmbundle:
 - text.html.mako
+vendor/grammars/marko-tmbundle:
+- text.marko
 vendor/grammars/mathematica-tmbundle:
 - source.mathematica
 vendor/grammars/matlab.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2472,14 +2472,13 @@ Markdown:
   tm_scope: source.gfm
   language_id: 222
 Marko:
-  type: programming
+  group: HTML
+  type: markup
   tm_scope: text.marko
-  color: "#d8104d"
   extensions:
   - ".marko"
   aliases:
   - markojs
-  - marco
   ace_mode: text
   codemirror_mode: htmlmixed
   codemirror_mime_type: text/html

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2471,6 +2471,19 @@ Markdown:
   - ".ron"
   tm_scope: source.gfm
   language_id: 222
+Marko:
+  type: programming
+  tm_scope: text.marko
+  color: "#d8104d"
+  extensions:
+  - ".marko"
+  aliases:
+  - markojs
+  - marco
+  ace_mode: text
+  codemirror_mode: htmlmixed
+  codemirror_mime_type: text/html
+  language_id: 932782397
 Mask:
   type: markup
   color: "#f97732"

--- a/samples/Marko/counter.marko
+++ b/samples/Marko/counter.marko
@@ -1,0 +1,26 @@
+class {
+    constructor() {
+        this.state = { count:0 };
+    }
+    increment() {
+        this.state.count++;
+    }
+}
+
+style {
+    .count {
+        color:#09c;
+        font-size:3em;
+    }
+    .example-button {
+        font-size:1em;
+        padding:0.5em;
+    }
+}
+
+<div.count>
+    ${state.count}
+</div>
+<button.example-button on-click('increment')>
+    Click me!
+</button>

--- a/samples/Marko/hello.marko
+++ b/samples/Marko/hello.marko
@@ -1,0 +1,15 @@
+$ var name = 'Frank';
+$ var colors = ['red', 'green', 'blue'];
+
+<h1>
+    Hello ${name}!
+</h1>
+
+<ul if(colors.length)>
+    <li style={color: color} for(color in colors)>
+        ${color}
+    </li>
+</ul>
+<div else>
+    No colors!
+</div>

--- a/samples/Marko/rgb-sliders.marko
+++ b/samples/Marko/rgb-sliders.marko
@@ -1,0 +1,36 @@
+static const colors = ['red', 'green', 'blue'];
+static const defaultColor = [255, 0, 0];
+
+class {
+	onInput(input) {
+		this.state = { color: input.color || defaultColor };
+	}
+
+	updateColor() {
+    	this.state.color = colors.map((color) => {
+        	return parseInt(this.getEl(color + 'Input').value, 10);
+        });
+    }
+
+    getStyleColor() {
+    	return 'rgb(' + this.state.color.join(',') + ')';
+    }
+}
+
+<div.rgb-sliders>
+    <div.inputs>
+    	<for(i, color in colors)>
+        	<div>
+                <label for-key=color+"Input">
+                    ${color}:
+                </label>
+                <input type="range" max="255"
+                    key=color+"Input"
+                    on-input('updateColor')
+                    value=state.color[i] >
+            </div>
+        </for>
+    </div>
+    <div.color style={backgroundColor: component.getStyleColor()}>
+    </div>
+</div>

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -195,6 +195,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Makefile:** [textmate/make.tmbundle](https://github.com/textmate/make.tmbundle)
 - **Mako:** [marconi/mako-tmbundle](https://github.com/marconi/mako-tmbundle)
 - **Markdown:** [atom/language-gfm](https://github.com/atom/language-gfm)
+- **Marko:** [marko-js/marko-tmbundle](https://github.com/marko-js/marko-tmbundle)
 - **Mask:** [tenbits/sublime-mask](https://github.com/tenbits/sublime-mask)
 - **Mathematica:** [shadanan/mathematica-tmbundle](https://github.com/shadanan/mathematica-tmbundle)
 - **Matlab:** [textmate/matlab.tmbundle](https://github.com/textmate/matlab.tmbundle)

--- a/vendor/licenses/grammar/marko-tmbundle.txt
+++ b/vendor/licenses/grammar/marko-tmbundle.txt
@@ -1,0 +1,25 @@
+---
+type: grammar
+name: marko-tmbundle
+license: mit
+---
+The MIT License (MIT)
+
+Copyright (c) 2014 David Rios
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
[Marko](http://markojs.com/) is a language that is used to build user interfaces.  

**Usage stats**

[In the wild](https://github.com/search?utf8=%E2%9C%93&q=extension%3Amarko+NOT+nothack&type=Code&ref=searchresults) there's over 25k `.marko` files &mdash; admittedly, a number of these are from `.dotfile` repos that have checked in `node_modules`, but as far as I can tell all these results are examples of the Marko UI language.  

The [main repo](https://github.com/marko-js/marko) has over 2k stargazers and over 2m downloads on npm.

**Enterprise & private**

Marko is an open source project of eBay (a GitHub Enterprise customer) and we would love to have language recognition and syntax highlighting within our Enterprise repos as well. (_side question: In general, how soon after merging changes to `linguist` do they make it to Enterprise deployments?_)

Additionally, we know of at least a few companies that are using Marko in either Enterprise deployments or in private GitHub repos that would benefit from this as well.

Thanks and please let me know if there are any additional changes required!

