### PR TITLE
Prefer Markdown over GCC Machine Description

### DIFF
--- a/lib/linguist.rb
+++ b/lib/linguist.rb
@@ -15,9 +15,9 @@ class << Linguist
   #       see Linguist::LazyBlob and Linguist::FileBlob for examples
   #
   # Returns Language or nil.
-  def detect(blob)
+  def detect(blob, options={})
     # Bail early if the blob is binary or empty.
-    return nil if blob.likely_binary? || blob.binary? || blob.empty?
+    return nil if blob.likely_binary? || blob.binary? || (!options[:allow_empty] && blob.empty?)
 
     Linguist.instrument("linguist.detection", :blob => blob) do
       # Call each strategy until one candidate is returned.

--- a/lib/linguist.rb
+++ b/lib/linguist.rb
@@ -15,9 +15,9 @@ class << Linguist
   #       see Linguist::LazyBlob and Linguist::FileBlob for examples
   #
   # Returns Language or nil.
-  def detect(blob, options={})
+  def detect(blob, allow_empty: false)
     # Bail early if the blob is binary or empty.
-    return nil if blob.likely_binary? || blob.binary? || (!options[:allow_empty] && blob.empty?)
+    return nil if blob.likely_binary? || blob.binary? || (!allow_empty && blob.empty?)
 
     Linguist.instrument("linguist.detection", :blob => blob) do
       # Call each strategy until one candidate is returned.

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -264,6 +264,8 @@ module Linguist
         Language["Markdown"]
       elsif /^(;;|\(define_)/.match(data)
         Language["GCC machine description"]
+      else
+        Language["Markdown"]
       end
     end
 

--- a/samples/Markdown/minimal.md
+++ b/samples/Markdown/minimal.md
@@ -1,0 +1,1 @@
+_This_ is a **Markdown** readme.


### PR DESCRIPTION
We currently use a heuristic to determine if a `.md` file should be recognised as "Markdown" or "GCC Machine Description". If neither regex matches the heuristic, the existing guesses are retained. Because "GCC Machine Description" sorts lexicographically before "Markdown", then, it's preferred as the first choice.

This is very unlikely to be what we want in the majority of cases, so let's prefer Markdown unless we're sure.