### PR TITLE
Add `.mdown` as an extension for Markdown

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2465,6 +2465,7 @@ Markdown:
   extensions:
   - ".md"
   - ".markdown"
+  - ".mdown"
   - ".mkd"
   - ".mkdn"
   - ".mkdown"

--- a/samples/Markdown/README.mdown
+++ b/samples/Markdown/README.mdown
@@ -1,0 +1,20 @@
+# Installation
+
+You can install this bundle in TextMate by opening the preferences and going to the bundles tab. After installation it will be automatically updated for you.
+
+# General
+
+* [Bundle Styleguide](http://kb.textmate.org/bundle_styleguide) — _before you make changes_
+* [Commit Styleguide](http://kb.textmate.org/commit_styleguide) — _before you send a pull request_
+* [Writing Bug Reports](http://kb.textmate.org/writing_bug_reports) — _before you report an issue_
+
+# License
+
+If not otherwise specified (see below), files in this repository fall under the following license:
+
+	Permission to copy, use, modify, sell and distribute this
+	software is granted. This software is provided "as is" without
+	express or implied warranty, and with no claim as to its
+	suitability for any purpose.
+
+An exception is made for files in readable text which contain their own license information, or files where an accompanying file exists (in the same directory) with a “-license” suffix added to the base-name name of the original file, and an extension of txt, html, or similar. For example “tidy” is accompanied by “tidy-license.txt”.


### PR DESCRIPTION
Quite a few of the README's in tmbundles use the `.mdown` extenstion. Also, searching Github, this extension  ([.mdown](https://github.com/search?utf8=✓&q=extension%3Amdown+NOT+nothack&type=Code&ref=searchresults)) appear to be more common than some of the others ([.mkd](https://github.com/search?utf8=✓&q=extension%3Amkd+NOT+nothack&type=Code&ref=searchresults), [.mkdn](https://github.com/search?utf8=✓&q=extension%3Amkdn+NOT+nothack&type=Code&ref=searchresults), [.mkdown](http://[here](https://github.com/search?utf8=✓&q=extension%3Amdown+NOT+nothack&type=Code&ref=searchresults))).