### PR TITLE
Add .mdwn for Markdown

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2466,6 +2466,7 @@ Markdown:
   - ".md"
   - ".markdown"
   - ".mdown"
+  - ".mdwn"
   - ".mkd"
   - ".mkdn"
   - ".mkdown"


### PR DESCRIPTION
This was included by https://github.com/github/markup when recognising Markdown files; now it uses Linguist to recognise them (github/markup#537), so it'd be good to continue to recognise the same set of extensions.