### PR TITLE
.pod disambiguation heuristic fix

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -346,7 +346,7 @@ module Linguist
     end
 
     disambiguate ".pod" do |data|
-      if /^=\w+$/.match(data)
+      if /^=\w+\b/.match(data)
         Language["Pod"]
       else
         Language["Perl"]


### PR DESCRIPTION
Look for any line starting with "=\w+", not full lines, otherwise we miss e.g. "=head1 HEADING".