### PR TITLE
Adding comp, tesc, and tese as GLSL file extensions, as per Glslang, plus a GLSL compute shader sample.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1347,6 +1347,7 @@ GDScript:
 GLSL:
   type: programming
   extensions:
+  - ".glsl"
   - ".comp"
   - ".fp"
   - ".frag"
@@ -1356,7 +1357,6 @@ GLSL:
   - ".fshader"
   - ".geo"
   - ".geom"
-  - ".glsl"
   - ".glslv"
   - ".gshader"
   - ".shader"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1347,6 +1347,9 @@ GDScript:
 GLSL:
   type: programming
   extensions:
+  - ".comp"
+  - ".tesc"
+  - ".tese"
   - ".glsl"
   - ".fp"
   - ".frag"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1348,9 +1348,6 @@ GLSL:
   type: programming
   extensions:
   - ".comp"
-  - ".tesc"
-  - ".tese"
-  - ".glsl"
   - ".fp"
   - ".frag"
   - ".frg"
@@ -1359,9 +1356,12 @@ GLSL:
   - ".fshader"
   - ".geo"
   - ".geom"
+  - ".glsl"
   - ".glslv"
   - ".gshader"
   - ".shader"
+  - ".tesc"
+  - ".tese"
   - ".vert"
   - ".vrx"
   - ".vsh"

--- a/samples/GLSL/particle.comp
+++ b/samples/GLSL/particle.comp
@@ -1,0 +1,27 @@
+#version 430 core
+
+layout (local_size_x = 128) in;
+
+struct particle
+{
+    vec2 position;
+    vec2 velocity;
+};
+
+layout(std430, binding = 0) buffer particles_block
+{
+    particle particles[];
+};
+
+uniform uint particle_count;
+uniform float time_delta;
+
+void main()
+{
+    uint index = gl_GlobalInvocationID.x;
+    if (index >= particle_count)
+    {
+        return;
+    }
+    particles[index].position += particles[index].velocity * time_delta;
+}


### PR DESCRIPTION
1. Add comp, tesc, and tese as GLSL file extensions, as per Glslang.
`.comp` for a compute shader
`.tesc` for a tessellation control shader
`.tese` for a tessellation evaluation shader
See https://github.com/KhronosGroup/glslang
2. Sort the GLSL file extensions in alphabetical order.
3. Add GLSL compute shader sample.