### PR TITLE
Add disambiguate for .w files

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -475,5 +475,14 @@ module Linguist
         Language["XML"]
       end
     end
+
+    disambiguate ".w" do |data|
+      if (data.include?("&ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS C-Win"))
+        Language["OpenEdge ABL"]
+      else
+        Language["C"]
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Add a obrigatory text "&ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS C-Win" that indicates a OpenEdge .w file and differentiate of C files.