### PR TITLE
remove unused disambiguation heuristc for .t

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -435,14 +435,6 @@ module Linguist
       end
     end
     
-    disambiguate ".t" do |data|
-      if /^\s*%|^\s*var\s+\w+\s*:\s*\w+/.match(data)
-        Language["Turing"]
-      elsif /^\s*use\s+v6\s*;/.match(data)
-        Language["Perl6"]
-      end
-    end
-    
     disambiguate ".toc" do |data|
       if /^## |@no-lib-strip@/.match(data)
         Language["World of Warcraft Addon Data"]


### PR DESCRIPTION
There were two disambiguations for .t files. The first one
did only disambiguate between Perl and Perl6. The second one
disambiguated Turing and Perl6, but it was being ignored since
it was repeated.

Turing files were still being correctly classified since they fell
back to the classifier strategy though. This change removes the
unused heuristic.