### PR TITLE
fix heuristic for Unix Assembly with .ms extension

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -298,7 +298,7 @@ module Linguist
       if /^[.'][a-z][a-z](\s|$)/i.match(data)
         Language["Groff"]
       elsif /(?<!\S)\.(include|globa?l)\s/.match(data) || /(?<!\/\*)(\A|\n)\s*\.[A-Za-z]/.match(data.gsub(/"([^\\"]|\\.)*"|'([^\\']|\\.)*'|\\\s*(?:--.*)?\n/, ""))
-        Language["GAS"]
+        Language["Unix Assembly"]
       else
         Language["MAXScript"]
       end

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -178,6 +178,13 @@ class TestHeuristcs < Minitest::Test
     })
   end
 
+  def test_ms_by_heuristics
+    assert_heuristics({
+      "Unix Assembly" => all_fixtures("Unix Assembly", "*.ms"),
+      "MAXScript" => all_fixtures("MAXScript", "*.ms")
+    })
+  end
+
   # Candidate languages = ["C++", "Objective-C"]
   def test_obj_c_by_heuristics
     # Only calling out '.h' filenames as these are the ones causing issues


### PR DESCRIPTION
It was left unrenamed from GAS, which lead to heuristic not working for this case.
See here: abfb698550a40dc51212de075fde5fe670f529b4

Without this patch, if I enable only the extension+heuristic strategies, I get:

```
$ bundle exec linguist samples/Unix\ Assembly/hello.ms
hello.ms: 92 lines (63 sloc)
  type:      Text
  mime type: application/x-troff-ms
  language:  MAXScript
```

with this patch:

```
$ bundle exec linguist samples/Unix\ Assembly/hello.ms
hello.ms: 92 lines (63 sloc)
  type:      Text
  mime type: application/x-troff-ms
  language:  Unix Assembly
$ bundle exec linguist samples/MAXScript/volume-calc.ms 
volume-calc.ms: 23 lines (22 sloc)
  type:      Text
  mime type: application/x-troff-ms
  language:  MAXScript
```