### PR TITLE
Fix heuristics after rename

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -165,7 +165,7 @@ module Linguist
       elsif data.include?("flowop")
         Language["Filebench WML"]
       elsif fortran_rx.match(data)
-        Language["FORTRAN"]
+        Language["Fortran"]
       end
     end
 
@@ -173,7 +173,7 @@ module Linguist
       if /^: /.match(data)
         Language["Forth"]
       elsif fortran_rx.match(data)
-        Language["FORTRAN"]
+        Language["Fortran"]
       end
     end
 

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -270,7 +270,7 @@ module Linguist
       if /(^[-a-z0-9=#!\*\[|>])|<\//i.match(data) || data.empty?
         Language["Markdown"]
       elsif /^(;;|\(define_)/.match(data)
-        Language["GCC machine description"]
+        Language["GCC Machine Description"]
       else
         Language["Markdown"]
       end

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -226,7 +226,7 @@ module Linguist
       elsif /^(%[%{}]xs|<.*>)/.match(data)
         Language["Lex"]
       elsif /^\.[a-z][a-z](\s|$)/i.match(data)
-        Language["Groff"]
+        Language["Roff"]
       elsif /^\((de|class|rel|code|data|must)\s/.match(data)
         Language["PicoLisp"]
       end
@@ -296,7 +296,7 @@ module Linguist
 
     disambiguate ".ms" do |data|
       if /^[.'][a-z][a-z](\s|$)/i.match(data)
-        Language["Groff"]
+        Language["Roff"]
       elsif /(?<!\S)\.(include|globa?l)\s/.match(data) || /(?<!\/\*)(\A|\n)\s*\.[A-Za-z]/.match(data.gsub(/"([^\\"]|\\.)*"|'([^\\']|\\.)*'|\\\s*(?:--.*)?\n/, ""))
         Language["Unix Assembly"]
       else
@@ -306,7 +306,7 @@ module Linguist
 
     disambiguate ".n" do |data|
       if /^[.']/.match(data)
-        Language["Groff"]
+        Language["Roff"]
       elsif /^(module|namespace|using)\s/.match(data)
         Language["Nemerle"]
       end
@@ -392,7 +392,7 @@ module Linguist
       if /^\.!|^\.end lit(?:eral)?\b/i.match(data)
         Language["RUNOFF"]
       elsif /^\.\\" /.match(data)
-        Language["Groff"]
+        Language["Roff"]
       end
     end
 

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -183,7 +183,7 @@ class TestHeuristcs < Minitest::Test
   def test_md_by_heuristics
     assert_heuristics({
       "Markdown" => all_fixtures("Markdown", "*.md"),
-      "GCC machine description" => all_fixtures("GCC machine description", "*.md")
+      "GCC Machine Description" => all_fixtures("GCC Machine Description", "*.md")
     })
   end
 

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -106,7 +106,7 @@ class TestHeuristcs < Minitest::Test
 
   def test_f_by_heuristics
     assert_heuristics({
-      "FORTRAN" => all_fixtures("FORTRAN", "*.f") + all_fixtures("FORTRAN", "*.for"),
+      "Fortran" => all_fixtures("Fortran", "*.f") + all_fixtures("Fortran", "*.for"),
       "Forth" => all_fixtures("Forth", "*.f") + all_fixtures("Forth", "*.for")
     })
   end

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -144,6 +144,15 @@ class TestHeuristcs < Minitest::Test
     })
   end
 
+  def test_l_by_heuristics
+    assert_heuristics({
+      "Common Lisp" => all_fixtures("Common Lisp", "*.l"),
+      "Lex" => all_fixtures("Lex", "*.l"),
+      "Roff" => all_fixtures("Roff", "*.l"),
+      "PicoLisp" => all_fixtures("PicoLisp", "*.l")
+    })
+  end
+
   def test_ls_by_heuristics
     assert_heuristics({
       "LiveScript" => all_fixtures("LiveScript", "*.ls"),
@@ -180,8 +189,16 @@ class TestHeuristcs < Minitest::Test
 
   def test_ms_by_heuristics
     assert_heuristics({
+      "Roff" => all_fixtures("Roff", "*.ms"),
       "Unix Assembly" => all_fixtures("Unix Assembly", "*.ms"),
       "MAXScript" => all_fixtures("MAXScript", "*.ms")
+    })
+  end
+
+  def test_n_by_heuristics
+    assert_heuristics({
+      "Roff" => all_fixtures("Roff", "*.n"),
+      "Nemerle" => all_fixtures("Nemerle", "*.n")
     })
   end
 
@@ -234,6 +251,13 @@ class TestHeuristcs < Minitest::Test
     assert_heuristics({
       "R" => all_fixtures("R", "*.r") + all_fixtures("R", "*.R"),
       "Rebol" => all_fixtures("Rebol", "*.r")
+    })
+  end
+
+  def test_rno_by_heuristics
+    assert_heuristics({
+      "RUNOFF" => all_fixtures("RUNOFF", "*.rno"),
+      "Roff" => all_fixtures("Roff", "*.rno")
     })
   end
 


### PR DESCRIPTION
This is similar to https://github.com/github/linguist/pull/3550 for the remaining languages where the name used in heuristics.rb does not match the one in samples directory.