### PR TITLE
Add the Solidity language without an associated extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -680,3 +680,6 @@
 [submodule "vendor/grammars/language-babel"]
 	path = vendor/grammars/language-babel
 	url = https://github.com/gandm/language-babel
+[submodule "vendor/grammars/SublimeEthereum"]
+	path = vendor/grammars/SublimeEthereum
+	url = https://github.com/davidhq/SublimeEthereum

--- a/grammars.yml
+++ b/grammars.yml
@@ -130,6 +130,8 @@ vendor/grammars/SublimeBrainfuck:
 - source.bf
 vendor/grammars/SublimeClarion/:
 - source.clarion
+vendor/grammars/SublimeEthereum:
+- source.solidity
 vendor/grammars/SublimePapyrus/:
 - source.compiled-papyrus
 - source.papyrus

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3239,6 +3239,13 @@ Smarty:
   ace_mode: smarty
   tm_scope: text.html.smarty
 
+Solidity:
+  type: programming
+  extensions:
+  - .sol
+  ace_mode: text
+  tm_scope: source.sol
+
 SourcePawn:
   type: programming
   color: "#5c7611"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3244,7 +3244,7 @@ Solidity:
   extensions:
   - .sol
   ace_mode: text
-  tm_scope: source.sol
+  tm_scope: source.solidity
 
 SourcePawn:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3241,8 +3241,6 @@ Smarty:
 
 Solidity:
   type: programming
-  extensions:
-  - .sol
   ace_mode: text
   tm_scope: source.solidity
 

--- a/samples/Solidity/crowdsale.sol
+++ b/samples/Solidity/crowdsale.sol
@@ -1,0 +1,73 @@
+contract token { 
+    mapping (address => uint) public balance; 
+    function token() {}  
+    function sendToken(address receiver, uint amount) returns(bool sufficient) {  } 
+}
+
+contract CrowdSale {
+    
+    address public admin;
+    address public beneficiary;
+    uint public fundingGoal;
+    uint public amountRaised;
+    uint public deadline;
+    uint public price;
+    token public tokenReward;   
+    Funder[] public funders;
+    
+    /* data structure to hold information about campaign contributors */
+    struct Funder {
+        address addr;
+        uint amount;
+    }
+    
+    /*  at initialization, setup the owner */
+    function CrowdSale() {
+        admin = msg.sender;
+    }   
+    
+    function setup(address _beneficiary, uint _fundingGoal, uint _duration, uint _price, address _reward) returns (bytes32 response){
+        if (msg.sender == admin && !(beneficiary > 0 && fundingGoal > 0 && deadline > 0)) {
+            beneficiary = _beneficiary;
+            fundingGoal = _fundingGoal;
+            deadline = now + _duration * 1 days;
+            price = _price;
+            tokenReward = token(_reward);    
+            return "campaign is set";
+        } else if (msg.sender != admin) {
+            return "not authorized";
+        } else  {
+            return "campaign cannot be changed";
+        }
+    }
+    
+    /* The function without name is the default function that is called whenever anyone sends funds to a contract without specifying any extra data or if the data does not match any of the function signatures */
+    function () returns (bytes32 response) {
+        if (msg.data.length != 0) return;
+        var numFunders = funders.length;
+        Funder f = funders[numFunders++];
+        f.addr = msg.sender;
+        f.amount = msg.value;
+        amountRaised += f.amount;
+        tokenReward.sendToken(msg.sender, f.amount/price);
+        return "thanks for your contribution";
+    }
+        
+    /* checks if the goal or time limit has been reached and ends the campaign */
+    function checkGoalReached() returns (bytes32 response) {
+        if (amountRaised >= fundingGoal){
+            beneficiary.send(amountRaised);
+            suicide(beneficiary);
+        }
+        else if (deadline <= block.number){
+            for (uint i = 0; i < funders.length; i++) {
+                funders[i].addr.send(funders[i].amount);
+                funders[i].addr = 0;
+                funders[i].amount = 0;
+            }
+            suicide(beneficiary);
+            return "Deadline passed";
+        }
+        return "Not reached yet";
+    }
+}

--- a/samples/Solidity/democraticdao.sol
+++ b/samples/Solidity/democraticdao.sol
@@ -1,0 +1,92 @@
+contract token{
+    function sendToken(address receiver,uint256 amount)returns(bool sufficient){}
+    function getBalance(address account)returns(uint256 balance){}
+}
+
+contract Democracy {
+    
+    uint public minimumQuorum = 10;
+    uint public debatingPeriod = 7 days;
+    token public voterShare;
+    address public founder;
+    Proposal[] public proposals;
+    
+    struct Proposal {
+        address recipient;
+        uint amount;
+        bytes32 data;
+        bytes32 descriptionHash;
+        uint creationDate;
+        uint quorum;
+        bool active;
+        Vote[] votes;
+        mapping (address => bool) voted;
+    }
+    
+    struct Vote {
+        int position;
+        address voter;
+    }
+    
+    function Democracy() {
+        founder = msg.sender;   
+    }
+    
+    function setup(address _voterShareAddress){
+        if (msg.sender == founder && proposals.length == 0) {
+            voterShare = token(_voterShareAddress);
+        }       
+    }
+    
+    function newProposal(address _recipient, uint _amount, bytes32 _data, bytes32 _descriptionHash) returns (uint proposalID) {
+        if (voterShare.balances(msg.sender)>0) {
+            proposalID = proposals.length++;
+            Proposal p = proposals[proposalID];
+            p.recipient = _recipient;
+            p.amount = _amount;
+            p.data = _data;
+            p.descriptionHash = _descriptionHash;
+            p.creationDate = now;
+            p.active = true;
+        } else {
+            return 0;
+        }
+    }
+    
+    function vote(uint _proposalID, int _position) returns (uint voteID){
+        if (voterShare.balances(msg.sender)>0 && (_position >= -1 || _position <= 1 )) {
+            Proposal p = proposals[_proposalID];
+            if (p.voted[msg.sender] != true) {
+                voteID = p.votes.length++;
+                Vote v = p.votes[voteID];
+                v.position = _position;
+                v.voter = msg.sender;   
+                p.voted[msg.sender] = true;
+            }
+        } else {
+            return 0;
+        }
+    }
+    
+    function executeProposal(uint _proposalID) returns (int result) {
+        Proposal p = proposals[_proposalID];
+        /* Check if debating period is over */
+        if (now > (p.creationDate + debatingPeriod) && p.active){   
+            
+            /* tally the votes */
+            for (uint i = 0; i <=  p.votes.length; i++) {
+                Vote v = p.votes[i];
+                int voteWeight = int(voterShare.balances(v.voter)); 
+                p.quorum += uint(voteWeight);
+                result += voteWeight * v.position;
+            }
+            /* execute result */
+            if (p.quorum > minimumQuorum && result > 0 ) {
+                p.recipient.call.value(p.amount)(p.data);
+                p.active = false;
+            } else if (p.quorum > minimumQuorum && result < 0) {
+                p.active = false;
+            }
+        }
+    }
+}

--- a/samples/Solidity/greeter.sol
+++ b/samples/Solidity/greeter.sol
@@ -1,0 +1,33 @@
+contract greeter {
+    /* Declare variable admin which will store an address */
+    address public admin;
+
+    /* this function is executed at initialization and sets the owner of the contract */
+    function greeter() {
+        admin = msg.sender;
+    }
+
+    /* main function */
+    function greet(bytes32 input) returns (bytes32) {
+        if (input == "") {  return "Hello, World"; }
+
+        /* Try it yourself: the joker 
+        if (input=="Who's there?") { 
+            // insert a joke here 
+        } else if (msg.value > 1000) { 
+            // a trillionth of an ether. It's a cheap joke. 
+            return "Knock knock!"; 
+        }
+        */
+
+        return input; 
+    }
+   
+    /* Function to recover the funds on the contract */
+    function kill() {
+        if (msg.sender == admin) {
+            suicide(admin);
+        }
+    }
+}
+

--- a/samples/Solidity/token.sol
+++ b/samples/Solidity/token.sol
@@ -1,0 +1,28 @@
+contract token { 
+    mapping (address => uint) public balances;
+    
+    /* Initializes contract with 10 000 tokens to the creator of the contract */
+    function token() {
+        balances[msg.sender] = 10000;
+    }
+    
+    /* Very simple trade function */
+    function sendToken(address receiver, uint amount) returns(bool sufficient) {
+        if (balances[msg.sender] < amount) return false;
+        balances[msg.sender] -= amount;
+        balances[receiver] += amount;
+        return true;
+    }
+
+    /* Try it yourself: merged mining
+
+    mapping (uint => address) miningReward;
+    function claimMiningReward() {
+        if (miningReward[block.number] == 0) {
+            balances[block.coinbase] += 1;
+            miningReward[block.number] = block.coinbase;
+        }
+    }
+
+    */
+}


### PR DESCRIPTION
As discussed in #2634 we can't associate the `.sol` extension with Solidity until the `not-a-language` feature is implemented.

Meanwhile, though, the language should be included in Linguist so that repositories can manually set the language via `.gitattributes`.