### PR TITLE
Fix usage line in binary

### DIFF
--- a/bin/linguist
+++ b/bin/linguist
@@ -75,7 +75,7 @@ elsif File.file?(path)
 else
   abort <<-HELP
   Linguist v#{Linguist::VERSION}
-  Detect language type for a file, or, given a directory, determine language breakdown.
+  Detect language type for a file, or, given a repository, determine language breakdown.
 
   Usage: linguist <path>
          linguist <path> [--breakdown] [--json]


### PR DESCRIPTION
Linguist cannot work on any directory; it needs to be a Git repository.
Fixes #3563.