### PR TITLE
Correct Arduino's Color, Swap MAXScript's

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -258,7 +258,7 @@ Arc:
   language_id: 20
 Arduino:
   type: programming
-  color: "#31a09c"
+  color: "#00979D"
   extensions:
   - ".ino"
   tm_scope: source.c++
@@ -2368,7 +2368,7 @@ M4Sugar:
   language_id: 216
 MAXScript:
   type: programming
-  color: "#bd79d1"
+  color: "#056d6d"
   extensions:
   - ".ms"
   - ".mcr"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -258,7 +258,7 @@ Arc:
   language_id: 20
 Arduino:
   type: programming
-  color: "#bd79d1"
+  color: "#31a09c"
   extensions:
   - ".ino"
   tm_scope: source.c++
@@ -2368,7 +2368,7 @@ M4Sugar:
   language_id: 216
 MAXScript:
   type: programming
-  color: "#00a6a6"
+  color: "#bd79d1"
   extensions:
   - ".ms"
   - ".mcr"


### PR DESCRIPTION
Correct Arduino's color to it's signature blue; Swap Arduino's old purple color to MAXScript whose color is too close. Arduino is a much more commonly used programming language than MAXScript so the color will be correct more of the time.