### PR TITLE
Clarify description of implicit alias.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2,7 +2,7 @@
 #
 # type              - Either data, programming, markup, prose, or nil
 # aliases           - An Array of additional aliases (implicitly
-#                     includes name.downcase)
+#                     includes name.downcase.split(' ').join('-'))
 # ace_mode          - A String name of the Ace Mode used for highlighting whenever
 #                     a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
 #                     Use "text" if a mode does not exist.

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2,7 +2,8 @@
 #
 # type              - Either data, programming, markup, prose, or nil
 # aliases           - An Array of additional aliases (implicitly
-#                     includes name.downcase.split(' ').join('-'))
+#                     includes the lowercase name with spaces replaced
+#                     by dashes)
 # ace_mode          - A String name of the Ace Mode used for highlighting whenever
 #                     a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
 #                     Use "text" if a mode does not exist.


### PR DESCRIPTION
I was trying to look up the alias to use for DNS Zone. From the docs
the alias I should use would be dns zone, but in reality it is dns-zone.
This change updates the comments to describe how to derive the
implicit name of a given alias.