### PR TITLE
Add .admx and .adml as extensions for XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4691,8 +4691,8 @@ XML:
   - wsdl
   extensions:
   - ".xml"
-  - ".admx"
   - ".adml"
+  - ".admx"
   - ".ant"
   - ".axml"
   - ".builds"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4691,6 +4691,8 @@ XML:
   - wsdl
   extensions:
   - ".xml"
+  - ".admx"
+  - ".adml"
   - ".ant"
   - ".axml"
   - ".builds"

--- a/samples/XML/MDM.adml
+++ b/samples/XML/MDM.adml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  (c) 2016 Microsoft Corporation  -->
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <displayName>enter display name here</displayName>
+  <description>enter description here</description>
+  <resources>
+    <stringTable>
+      <string id="MDM">MDM</string>
+      <string id="MDM_MDM_DisplayName">Disable MDM Enrollment</string>
+      <string id="MDM_MDM_Help">This policy setting specifies whether Mobile Device Management (MDM) Enrollment is allowed. When MDM is enabled, it allows the user to have the computer remotely managed by a MDM Server.  
+
+If you do not configure this policy setting, MDM Enrollment will be enabled. 
+
+If you enable this policy setting, MDM Enrollment will be disabled for all users. It will not unenroll existing MDM enrollments.
+
+If you disable this policy setting, MDM Enrollment will be enabled for all users.
+</string>
+    </stringTable>
+  </resources>
+</policyDefinitionResources>

--- a/samples/XML/MDM.admx
+++ b/samples/XML/MDM.admx
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--  (c) 2016 Microsoft Corporation  -->
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.0" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <policyNamespaces>
+    <target prefix="mdm" namespace="Microsoft.Policies.MDM" />
+    <using prefix="windows" namespace="Microsoft.Policies.Windows" />
+  </policyNamespaces>
+  <resources minRequiredRevision="1.0" />
+  <categories>
+    <category name="MDM" displayName="$(string.MDM)">
+      <parentCategory ref="windows:WindowsComponents" />
+    </category>
+  </categories>
+  <policies>
+    <policy name="MDM_MDM_DisplayName" class="Machine" displayName="$(string.MDM_MDM_DisplayName)" explainText="$(string.MDM_MDM_Help)" key="Software\Policies\Microsoft\Windows\CurrentVersion\MDM" valueName="DisableRegistration">
+      <parentCategory ref="MDM" />
+      <supportedOn ref="windows:SUPPORTED_Windows_10_0_NOSERVER" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+  </policies>
+</policyDefinitions>


### PR DESCRIPTION
ADMX and ADML files are XML-based and are [used by Windows](https://technet.microsoft.com/en-us/library/cc772507(v=ws.10).aspx) to create a user interface for Group Policy settings. There are approximately [1.5K such files](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aadmx+NOT+nothack&type=Code&ref=searchresults) at GitHub.

The samples are sourced from [Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=48257).