### PR TITLE
Merge heuristics for disambiguating ".t" files

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -344,11 +344,11 @@ module Linguist
       end
     end
 
-    disambiguate ".pm", ".t" do |data|
-      if /use strict|use\s+v?5\./.match(data)
-        Language["Perl"]
-      elsif /^(use v6|(my )?class|module)/.match(data)
+    disambiguate ".pm" do |data|
+      if /^\s*(?:use\s+v6\s*;|(?:\bmy\s+)?class|module)\b/.match(data)
         Language["Perl6"]
+      elsif /\buse\s+(?:strict\b|v?5\.)/.match(data)
+        Language["Perl"]
       end
     end
 
@@ -443,10 +443,12 @@ module Linguist
     end
     
     disambiguate ".t" do |data|
-      if /^\s*%|^\s*var\s+\w+\s*:\s*\w+/.match(data)
+      if /^\s*%[ \t]+|^\s*var\s+\w+\s*:=\s*\w+/.match(data)
         Language["Turing"]
-      elsif /^\s*use\s+v6\s*;/.match(data)
+      elsif /^\s*(?:use\s+v6\s*;|\bmodule\b|\b(?:my\s+)?class\b)/.match(data)
         Language["Perl6"]
+      elsif /\buse\s+(?:strict\b|v?5\.)/.match(data)
+        Language["Perl"]
       end
     end
     


### PR DESCRIPTION
Follow-up of @pchaigno's [suggestion](https://github.com/github/linguist/pull/3546#issuecomment-297942194) in #3546. This PR merges the heuristics used for matching `.t` files on GitHub, but also applies a few other enhancements I made along the way:

1. **Perl 6 is now checked before Perl 5**  
Both languages understand `use strict;`, but the pragma is less likely to surface in the former. [According to the docs](https://docs.perl6.org/language/5to6-nutshell#Pragmas), Perl 6 enables strict mode by default, making the `use strict;` pragma redundant. Conversely, Perl 5 has strict mode *off* by default for compatibility reasons only - but every Perl programmer knows to enable strict-mode (and warnings) before starting work on any halfway-serious program.

2. **Multiple blanks are now checked, instead of matching a single space**  
`/use strict/` won't catch pragmas that use tabs, or have multiple spaces between each word. Newlines are even permitted too: the following chunk is valid Perl:
	~~~perl
	use

	strict;

	use
		v5.24.0;
	~~~

3. **Turing's heuristic now looks for `:=` instead of `:`**  
The tests failed because a [Terra file](https://github.com/github/linguist/blob/9b8b39f/samples/Terra/arith.t#L49) was misclassified as Turing. I realised a pattern like `var abc : xyz` is bound to surface in other languages, so I changed it to match `var abc := xyz` instead. `:=` wasn't mentioned anywhere in [Terra's language reference](http://terralang.org/getting-started.html#the-terra-language), so I'm guessing it won't occur there.

### Other observations

* **Semicolons are valid Turing**  
In #3546, I wondered if the original Turing/Perl heuristic could be refined to check for trailing semicolons (since Turing doesn't use the). I installed and ran [Open Turing](http://tristan.hume.ca/openturing/), and it evaluated `put 2 * 8;` perfectly fine. I guess they're legal characters, but ignored. Noting this for future reference if needed.

* **Many of the other heuristics could be (micro-)optimised**  
There're numerous capturing groups that aren't referred to by back-references, which requires a little extra overhead at runtime (since the regex engine needs to retain references to captured substrings). Using `(?:…)` instead of `(…)` is generally best practice when referencing the capture isn't needed.
Granted, the performance boost is only minimal, but if this code has to check millions of files, well... I'd wring every drop of performance I could get.

* **Our heuristics are making naive assumptions about whitespace**  
Going back to point \#2 above, it's likely that some heuristics aren't matching files they should be because the subject's source code contains multiple whitespace characters.