### PR TITLE
Don't show npm lockfiles by default

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -57,7 +57,7 @@ module Linguist
       composer_lock? ||
       node_modules? ||
       go_vendor? ||
-      npm_shrinkwrap? ||
+      npm_shrinkwrap_or_package_lock? ||
       godeps? ||
       generated_by_zephir? ||
       minified_files? ||
@@ -326,11 +326,11 @@ module Linguist
       !!name.match(/vendor\/((?!-)[-0-9A-Za-z]+(?<!-)\.)+(com|edu|gov|in|me|net|org|fm|io)/)
     end
 
-    # Internal: Is the blob a generated npm shrinkwrap file?
+    # Internal: Is the blob a generated npm shrinkwrap or package lock file?
     #
     # Returns true or false.
-    def npm_shrinkwrap?
-      !!name.match(/npm-shrinkwrap\.json/)
+    def npm_shrinkwrap_or_package_lock?
+      name.match(/npm-shrinkwrap\.json/) || name.match(/package-lock\.json/)
     end
 
     # Internal: Is the blob part of Godeps/,

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -58,6 +58,7 @@ class TestGenerated < Minitest::Test
 
     # npm shrinkwrap file
     generated_sample_without_loading_data("Dummy/npm-shrinkwrap.json")
+    generated_sample_without_loading_data("Dummy/package-lock.json")
 
     # Godep saved dependencies
     generated_sample_without_loading_data("Godeps/Godeps.json")


### PR DESCRIPTION
Like this: https://github.com/npm/node-fetch-npm/commit/efbc7d5bfac8c80f499b15636a05f0a2a39cdb91

/cc @zkat