### PR TITLE
Add syntax grammar for Shen language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -839,3 +839,6 @@
 [submodule "vendor/grammars/language-jolie"]
 	path = vendor/grammars/language-jolie
 	url = https://github.com/fmontesi/language-jolie
+[submodule "vendor/grammars/sublime-shen"]
+	path = vendor/grammars/sublime-shen
+	url = https://github.com/rkoeninger/sublime-shen

--- a/grammars.yml
+++ b/grammars.yml
@@ -639,6 +639,8 @@ vendor/grammars/sublime-rexx:
 - source.rexx
 vendor/grammars/sublime-robot-plugin:
 - text.robot
+vendor/grammars/sublime-shen:
+- source.shen
 vendor/grammars/sublime-spintools:
 - source.regexp.spin
 - source.spin

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4098,7 +4098,7 @@ Shen:
   color: "#120F14"
   extensions:
   - ".shen"
-  tm_scope: none
+  tm_scope: source.shen
   ace_mode: text
   language_id: 348
 Slash:

--- a/vendor/licenses/grammar/sublime-shen.txt
+++ b/vendor/licenses/grammar/sublime-shen.txt
@@ -1,0 +1,34 @@
+---
+type: grammar
+name: sublime-shen
+license: bsd-3-clause
+---
+License
+------------
+
+Copyright (c) 2017, Robert Koeninger
+All rights reserved.
+
+https://opensource.org/licenses/BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Shen was already recognized, just adding submodule for grammar file and specifying the TextMate scope `source.shen`.