### PR TITLE
Add Closure Templates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -845,3 +845,6 @@
 [submodule "vendor/grammars/dartlang"]
 	path = vendor/grammars/dartlang
 	url = https://github.com/dart-atom/dartlang
+[submodule "vendor/grammars/language-closure-templates"]
+	path = vendor/grammars/language-closure-templates
+	url = https://github.com/mthadley/language-closure-templates

--- a/grammars.yml
+++ b/grammars.yml
@@ -358,6 +358,8 @@ vendor/grammars/language-click:
 - source.click
 vendor/grammars/language-clojure:
 - source.clojure
+vendor/grammars/language-closure-templates:
+- text.html.soy
 vendor/grammars/language-coffee-script:
 - source.coffee
 - source.litcoffee

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2,8 +2,7 @@
 #
 # type              - Either data, programming, markup, prose, or nil
 # aliases           - An Array of additional aliases (implicitly
-#                     includes the lowercase name with spaces replaced
-#                     by dashes)
+#                     includes name.downcase)
 # ace_mode          - A String name of the Ace Mode used for highlighting whenever
 #                     a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
 #                     Use "text" if a mode does not exist.
@@ -698,6 +697,7 @@ Closure Templates:
   extensions:
   - ".soy"
   tm_scope: text.html.soy
+  language_id: 357046146
 CoffeeScript:
   type: programming
   tm_scope: source.coffee

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -692,6 +692,7 @@ Closure Templates:
   group: HTML
   ace_mode: soy_template
   codemirror_mode: soy
+  codemirror_mime_type: text/x-soy
   alias:
   - soy
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -688,6 +688,16 @@ Clojure:
   filenames:
   - riemann.config
   language_id: 62
+Closure Templates:
+  type: markup
+  group: HTML
+  ace_mode: soy_template
+  codemirror_mode: soy
+  alias:
+  - soy
+  extensions:
+  - ".soy"
+  tm_scope: text.html.soy
 CoffeeScript:
   type: programming
   tm_scope: source.coffee

--- a/samples/Closure Templates/example.soy
+++ b/samples/Closure Templates/example.soy
@@ -1,0 +1,24 @@
+{namespace Exmaple}
+
+/**
+ * Example
+ */
+{template .foo}
+  {@param count: string}
+  {@param? name: int}
+
+  {if isNonnull($name)}
+    <h1>{$name}</h1>
+  {/if}
+
+  <div class="content">
+    {switch count}
+      {case 0}
+        {call Empty.view}
+          {param count: $count /}
+        {/call}
+      {default}
+        <h2>Wow, so many!</h2>
+    {/switch}
+  </div>
+{/template}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -59,6 +59,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Click:** [stenverbois/language-click](https://github.com/stenverbois/language-click)
 - **CLIPS:** [psicomante/CLIPS-sublime](https://github.com/psicomante/CLIPS-sublime)
 - **Clojure:** [atom/language-clojure](https://github.com/atom/language-clojure)
+- **Closure Templates:** [mthadley/language-closure-templates](https://github.com/mthadley/language-closure-templates)
 - **CMake:** [textmate/cmake.tmbundle](https://github.com/textmate/cmake.tmbundle)
 - **COBOL:** [bitbucket:bitlang/sublime_cobol](https://bitbucket.org/bitlang/sublime_cobol)
 - **CoffeeScript:** [atom/language-coffee-script](https://github.com/atom/language-coffee-script)

--- a/vendor/licenses/grammar/language-closure-templates.txt
+++ b/vendor/licenses/grammar/language-closure-templates.txt
@@ -1,0 +1,26 @@
+---
+type: grammar
+name: language-closure-templates
+license: mit
+---
+MIT License
+
+Copyright (c) 2017 Michael T. Hadley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
[Closure Templates](https://developers.google.com/closure/templates/) is a templating system created by Google to run on both the client and the server. After a quick search (see [here](https://github.com/search?utf8=%E2%9C%93&q=extension%3Asoy+NOT+nothack&type=Code)), there seem to be over 16,000 examples of usage currently on github.

You can find the grammar over at [mthadley/language-closure-templates](https://github.com/mthadley/language-closure-templates).

Thanks, and let me know if I missed anything!