### PR TITLE
Update MD5 digest for testing under Ruby 2.4

### DIFF
--- a/test/test_md5.rb
+++ b/test/test_md5.rb
@@ -17,7 +17,7 @@ class TestMD5 < Minitest::Test
 
   def test_hexdigest_integer
     # Ruby 2.4.0 merged Bignum and Fixnum into Integer which means we get different digests
-    if RUBY_VERSION >= "2.4.0"
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.0")
       assert_equal "eb70b9dc51f70acc91b4d984ef81570e", MD5.hexdigest(1)
       assert_equal "41f415a79361937c28fff32c2c6d056d", MD5.hexdigest(2)
     else
@@ -45,7 +45,7 @@ class TestMD5 < Minitest::Test
   def test_hexdigest_array
     assert_equal "4410ec34d9e6c1a68100ca0ce033fb17", MD5.hexdigest([])
     # Ruby 2.4.0 merged Bignum and Fixnum into Integer which means we get different digests
-    if RUBY_VERSION >= "2.4.0"
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.0")
       assert_equal "7c6285c53bb82c9b58c0c28329f8d8f4", MD5.hexdigest([1])
       assert_equal "fdfbe9b65f652acb927b50ccba9f3270", MD5.hexdigest([1, 2])
       assert_equal "ba631f6acc179689c45be854705c08c9", MD5.hexdigest([1, 2, 3])
@@ -61,7 +61,7 @@ class TestMD5 < Minitest::Test
   def test_hexdigest_hash
     assert_equal "fae8a9257e154175da4193dbf6552ef6", MD5.hexdigest({})
     # Ruby 2.4.0 merged Bignum and Fixnum into Integer which means we get different digests
-    if RUBY_VERSION >= "2.4.0"
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.0")
       assert_equal "edfd4aed358b4d346b7eb7adf0fd21d1", MD5.hexdigest({:a => 1})
       assert_equal "39bb725ffe02392759e0a075001e6119", MD5.hexdigest({:b => 2})
     else

--- a/test/test_md5.rb
+++ b/test/test_md5.rb
@@ -16,8 +16,14 @@ class TestMD5 < Minitest::Test
   end
 
   def test_hexdigest_integer
-    assert_equal "7605ec17fd7fd213fdcd23cac302cbb4", MD5.hexdigest(1)
-    assert_equal "097c311a46d330e4e119ba2b1dc0f9a5", MD5.hexdigest(2)
+    # Ruby 2.4.0 merged Bignum and Fixnum into Integer which means we get different digests
+    if RUBY_VERSION >= "2.4.0"
+      assert_equal "eb70b9dc51f70acc91b4d984ef81570e", MD5.hexdigest(1)
+      assert_equal "41f415a79361937c28fff32c2c6d056d", MD5.hexdigest(2)
+    else
+      assert_equal "7605ec17fd7fd213fdcd23cac302cbb4", MD5.hexdigest(1)
+      assert_equal "097c311a46d330e4e119ba2b1dc0f9a5", MD5.hexdigest(2)
+    end
 
     refute_equal MD5.hexdigest("1"), MD5.hexdigest(1)
   end
@@ -38,16 +44,30 @@ class TestMD5 < Minitest::Test
 
   def test_hexdigest_array
     assert_equal "4410ec34d9e6c1a68100ca0ce033fb17", MD5.hexdigest([])
-    assert_equal "759f28c1d0c20c22e79c91d339855d95", MD5.hexdigest([1])
-    assert_equal "9efe07b352dd94cd1cdc9d1a8d054f8f", MD5.hexdigest([1, 2])
-    assert_equal "60b1ef7201404f20c3d12f47499c3a1f", MD5.hexdigest([1, 2, 3])
-    assert_equal "2f82cdc166616208077ff1dd0a8faeff", MD5.hexdigest([1, 2, [3]])
+    # Ruby 2.4.0 merged Bignum and Fixnum into Integer which means we get different digests
+    if RUBY_VERSION >= "2.4.0"
+      assert_equal "7c6285c53bb82c9b58c0c28329f8d8f4", MD5.hexdigest([1])
+      assert_equal "fdfbe9b65f652acb927b50ccba9f3270", MD5.hexdigest([1, 2])
+      assert_equal "ba631f6acc179689c45be854705c08c9", MD5.hexdigest([1, 2, 3])
+      assert_equal "d6eed665798037ebccaa2cc54a37ce93", MD5.hexdigest([1, 2, [3]])
+    else
+      assert_equal "759f28c1d0c20c22e79c91d339855d95", MD5.hexdigest([1])
+      assert_equal "9efe07b352dd94cd1cdc9d1a8d054f8f", MD5.hexdigest([1, 2])
+      assert_equal "60b1ef7201404f20c3d12f47499c3a1f", MD5.hexdigest([1, 2, 3])
+      assert_equal "2f82cdc166616208077ff1dd0a8faeff", MD5.hexdigest([1, 2, [3]])
+    end
   end
 
   def test_hexdigest_hash
     assert_equal "fae8a9257e154175da4193dbf6552ef6", MD5.hexdigest({})
-    assert_equal "868ee214faf277829a85667cf332749f", MD5.hexdigest({:a => 1})
-    assert_equal "fa9df957c2b26de6fcca9d062ea8701e", MD5.hexdigest({:b => 2})
+    # Ruby 2.4.0 merged Bignum and Fixnum into Integer which means we get different digests
+    if RUBY_VERSION >= "2.4.0"
+      assert_equal "edfd4aed358b4d346b7eb7adf0fd21d1", MD5.hexdigest({:a => 1})
+      assert_equal "39bb725ffe02392759e0a075001e6119", MD5.hexdigest({:b => 2})
+    else
+      assert_equal "868ee214faf277829a85667cf332749f", MD5.hexdigest({:a => 1})
+      assert_equal "fa9df957c2b26de6fcca9d062ea8701e", MD5.hexdigest({:b => 2})
+    end
 
     refute_equal MD5.hexdigest([:b, 2]), MD5.hexdigest({:b => 2})
 


### PR DESCRIPTION
Ruby 2.4 deprecated Fixnum & Bignum by unifying them into Integer (see https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/). This means the MD5 digests for the integers in our tests have a class of Integer under 2.4.0 and later instead of Fixnum from earlier releases which means we need to update the digests specifically for Ruby >= 2.4.0.  This PR does just that.

I didn't go the route of modifying Linguist::MD5.hexdigest as any mention of `Fixnum` or `Bignum` results in a deprecation warning which gets annoying fast 💨.

/cc @github/data-engineering 