### PR TITLE
Added syntax definition for Fantom language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -854,3 +854,6 @@
 [submodule "vendor/grammars/language-webassembly"]
 	path = vendor/grammars/language-webassembly
 	url = https://github.com/Alhadis/language-webassembly
+[submodule "vendor/grammars/sublime-fantom"]
+	path = vendor/grammars/sublime-fantom
+	url = https://github.com/mgiannini/sublime-fantom

--- a/.gitmodules
+++ b/.gitmodules
@@ -856,4 +856,4 @@
 	url = https://github.com/Alhadis/language-webassembly
 [submodule "vendor/grammars/sublime-fantom"]
 	path = vendor/grammars/sublime-fantom
-	url = https://github.com/mgiannini/sublime-fantom
+	url = https://github.com/rkoeninger/sublime-fantom

--- a/README.md
+++ b/README.md
@@ -139,4 +139,3 @@ The language grammars included in this gem are covered by their repositories'
 respective licenses. `grammars.yml` specifies the repository for each grammar.
 
 All other files are covered by the MIT license, see `LICENSE`.
-

--- a/README.md
+++ b/README.md
@@ -139,3 +139,4 @@ The language grammars included in this gem are covered by their repositories'
 respective licenses. `grammars.yml` specifies the repository for each grammar.
 
 All other files are covered by the MIT license, see `LICENSE`.
+

--- a/grammars.yml
+++ b/grammars.yml
@@ -624,6 +624,8 @@ vendor/grammars/sublime-cirru:
 - source.cirru
 vendor/grammars/sublime-clips:
 - source.clips
+vendor/grammars/sublime-fantom:
+- source.fan
 vendor/grammars/sublime-glsl:
 - source.essl
 - source.glsl

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1231,10 +1231,10 @@ Fancy:
   language_id: 109
 Fantom:
   type: programming
-  color: "#dbded5"
+  color: "#14253c"
   extensions:
   - ".fan"
-  tm_scope: none
+  tm_scope: source.fan
   ace_mode: text
   language_id: 110
 Filebench WML:

--- a/samples/Fantom/sample1.fan
+++ b/samples/Fantom/sample1.fan
@@ -1,0 +1,97 @@
+/*
+ * Author: Robert Koeninger
+ * License: WTFPL (http://www.wtfpl.net/)
+ */
+
+class Spelling {
+
+  ** Load sample text and offer corrections for input
+  static Void main(Str[] args) {
+    text := File.os("big.txt").readAllStr
+    counts := Str:Int[:] { def = 0 }
+    text.split.each |word| { counts[word] += 1 }
+    args.each |arg| { echo(correction(counts, arg)) }
+  }
+
+  static const Range letters := Range.makeInclusive(97, 122)
+
+  ** Most probable spelling correction for `word`.
+  static Str correction(Str:Int counts, Str word) {
+    candidates(counts, word).max |x, y| { counts[x] <=> counts[y] }
+  }
+
+  ** Generate possible spelling corrections for `word`.
+  static Str[] candidates(Str:Int counts, Str word) {
+    result := known(counts, Str[word])
+    if (result.size > 0) return result
+
+    result = known(counts, edits1(word))
+    if (result.size > 0) return result
+
+    result = known(counts, edits2(word))
+    if (result.size > 0) return result
+
+    return Str[word]
+  }
+
+  ** The subset of `words` that appear in the map of `counts`.
+  static Str[] known(Str:Int counts, Str[] words) {
+    words.findAll |word, i| { counts[word] > 0 }.unique
+  }
+
+  ** All edits that are one edit away from `word`.
+  static Str[] edits1(Str word) {
+    edits := Str[,]
+
+    for (i := 0; i < word.size; ++i) {
+      edits.add(delete(word, i))
+
+      if (i < word.size - 2) {
+        edits.add(transpose(word, i))
+      }
+
+      edits.addAll(replace(word, i))
+      edits.addAll(insert(word, i))
+    }
+
+    edits = edits.unique
+    edits.remove(word)
+    return edits
+  }
+
+  ** Word with `i`th letter removed.
+  static Str delete(Str word, Int i) {
+    left := word.getRange(Range.makeExclusive(0, i))
+    right := word.getRange(Range.makeExclusive(i + 1, word.size))
+    return left + right
+  }
+
+  ** Word with `i`th and `i+1`st letter swapped.
+  static Str transpose(Str word, Int i) {
+    left := word.getRange(Range.makeExclusive(0, i))
+    right := word.getRange(Range.makeExclusive(i, word.size))
+    first := right.get(0).toChar
+    second := right.get(1).toChar
+    rest := right.getRange(Range.makeExclusive(2, right.size))
+    return left + second + first + rest
+  }
+
+  ** Word with `i`th letter replaced with every other letter.
+  static Str[] replace(Str word, Int i) {
+    left := word.getRange(Range.makeExclusive(0, i))
+    right := word.getRange(Range.makeExclusive(i + 1, word.size))
+    return letters.map |ch| { left + ch.toChar + right }
+  }
+
+  ** Word with each letter inserted at `i`.
+  static Str[] insert(Str word, Int i) {
+    left := word.getRange(Range.makeExclusive(0, i))
+    right := word.getRange(Range.makeExclusive(i, word.size))
+    return letters.map |ch| { left + ch.toChar + right }
+  }
+
+  ** All edits that are two edits away from `word`.
+  static Str[] edits2(Str word) {
+    (Str[])(edits1(word).map |w| { edits1(w) }.flatten)
+  }
+}

--- a/samples/Fantom/sample2.fan
+++ b/samples/Fantom/sample2.fan
@@ -1,0 +1,50 @@
+/*
+ * Author: Robert Koeninger
+ * License: WTFPL (http://www.wtfpl.net/)
+ */
+
+mixin Expr
+{
+  abstract Obj? eval()
+}
+
+class Constant : Expr
+{
+  Obj? value
+
+  new make(Obj? value) { this.value = value }
+  override Obj? eval() { value }
+}
+
+enum class Op
+{
+  plus,
+  minus
+}
+
+class Infix : Expr
+{
+  Op op
+  Expr left
+  Expr right
+
+  new make(Op op, Expr left, Expr right)
+  {
+    this.op = op
+    this.left = left
+    this.right = right
+  }
+
+  override Obj? eval()
+  {
+    switch (op)
+    {
+      case Op.plus:
+        return (Int)left.eval() + (Int)right.eval()
+      case Op.minus:
+        return (Int)left.eval() - (Int)right.eval()
+      default:
+        throw Err("undefined Op")
+    }
+  }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -107,7 +107,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **F#:** [fsprojects/atom-fsharp](https://github.com/fsprojects/atom-fsharp)
 - **Factor:** [slavapestov/factor](https://github.com/slavapestov/factor)
 - **Fancy:** [fancy-lang/fancy-tmbundle](https://github.com/fancy-lang/fancy-tmbundle)
-- **Fantom** [mgiannini/sublime-fantom](https://github.com/mgiannini/sublime-fantom)
+- **Fantom** [rkoeninger/sublime-fantom](https://github.com/rkoeninger/sublime-fantom)
 - **fish:** [l15n/fish-tmbundle](https://github.com/l15n/fish-tmbundle)
 - **Forth:** [textmate/forth.tmbundle](https://github.com/textmate/forth.tmbundle)
 - **Fortran:** [textmate/fortran.tmbundle](https://github.com/textmate/fortran.tmbundle)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -107,6 +107,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **F#:** [fsprojects/atom-fsharp](https://github.com/fsprojects/atom-fsharp)
 - **Factor:** [slavapestov/factor](https://github.com/slavapestov/factor)
 - **Fancy:** [fancy-lang/fancy-tmbundle](https://github.com/fancy-lang/fancy-tmbundle)
+- **Fantom** [mgiannini/sublime-fantom](https://github.com/mgiannini/sublime-fantom)
 - **fish:** [l15n/fish-tmbundle](https://github.com/l15n/fish-tmbundle)
 - **Forth:** [textmate/forth.tmbundle](https://github.com/textmate/forth.tmbundle)
 - **Fortran:** [textmate/fortran.tmbundle](https://github.com/textmate/fortran.tmbundle)

--- a/vendor/licenses/grammar/sublime-fantom.txt
+++ b/vendor/licenses/grammar/sublime-fantom.txt
@@ -1,0 +1,29 @@
+---
+type: grammar
+name: sublime-fantom
+license: mit
+---
+License
+------------
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Matthew Giannini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
[Fantom](http://fantom.org) was a pre-existing language in linguist.

Added [rkoeninger/sublime-fantom](https://github.com/rkoeninger/sublime-fantom) as a submodule
Added license for `sublime-fantom`
Specified `tm_scope` for Fantom
Provided better color for Fantom derived from official logo