### PR TITLE
Added .lzz files to the C++ langauge

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -501,6 +501,7 @@ C++:
   - ".re"
   - ".tcc"
   - ".tpp"
+  - ".lzz"
   language_id: 43
 C-ObjDump:
   type: data

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -498,10 +498,10 @@ C++:
   - ".inc"
   - ".inl"
   - ".ipp"
+  - ".lzz"
   - ".re"
   - ".tcc"
   - ".tpp"
-  - ".lzz"
   language_id: 43
 C-ObjDump:
   type: data


### PR DESCRIPTION
Files ending in `.lzz` are used by [lazycplusplus](http://www.lazycplusplus.com/index.html) to generate header files for you while developing in C++.