### PR TITLE
Improve running from cloned repo docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,11 @@ For development you are going to want to checkout out the source. To get it, clo
     cd linguist/
     script/bootstrap
 
-If you are going to run Linguist from the cloned repository directory, you will need to generate the code samples first:
+To run Linguist from the cloned repository directory, you will need to generate the code samples first:
 
     bundle exec rake samples
+
+If you are not running the tests below, re-run this command every time you modify any of the [samples][samples].
 
 To run Linguist from the cloned repository directory:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,14 @@ For development you are going to want to checkout out the source. To get it, clo
     cd linguist/
     script/bootstrap
 
+If you are going to run Linguist from the cloned repository directory, you will need to generate the code samples first:
+
+    bundle exec rake samples
+
+To run Linguist from the cloned repository directory:
+
+    bundle exec bin/linguist --breakdown
+
 To run the tests:
 
     bundle exec rake test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,13 +67,13 @@ For development you are going to want to checkout out the source. To get it, clo
     cd linguist/
     script/bootstrap
 
-To run Linguist from the cloned repository directory, you will need to generate the code samples first:
+To run Linguist from the cloned repository, you will need to generate the code samples first:
 
     bundle exec rake samples
 
-If you are not running the tests below, re-run this command every time you modify any of the [samples][samples].
+Run this command each time a [samples][samples] has been modified.
 
-To run Linguist from the cloned repository directory:
+To run Linguist from the cloned repository:
 
     bundle exec bin/linguist --breakdown
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ To run Linguist from the cloned repository, you will need to generate the code s
 
     bundle exec rake samples
 
-Run this command each time a [samples][samples] has been modified.
+Run this command each time a [sample][samples] has been modified.
 
 To run Linguist from the cloned repository:
 


### PR DESCRIPTION
As pointed out in https://github.com/github/linguist/issues/3663, it's not clear that you need to generate the `samples.json` file before you can run Linguist from the cloned repo. This is probably missed by most who run straight into running the tests as the Rake task updates the samples for you.

This PR adds the missing step and advises that this needs to be rerun every time there is a change to any of the samples if the tests aren't being run.

Fixes https://github.com/github/linguist/issues/3663