### PR TITLE
Linguist should understand JSX in .js files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1975,6 +1975,7 @@ JSX:
   type: programming
   group: JavaScript
   extensions:
+  - ".js"
   - ".jsx"
   tm_scope: source.js.jsx
   ace_mode: javascript

--- a/samples/JSX/sample.js
+++ b/samples/JSX/sample.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const React = require('react')
+
+module.exports = React.createClass({
+  render: function() {
+    let {feeds, log} = this.props;
+
+    log.info(feeds);
+    return <div className="feed-list">
+      <h3>News Feed's</h3>
+      <ul>
+        {feeds.map(function(feed) {
+          return <li key={feed.name} className={feed.fetched ? 'loaded' : 'loading'}>
+            {feed.data && feed.data.length > 0 ?
+              <span>{feed.name} <span className='light'>({feed.data.length})</span></span>
+              : 'feed.name' }
+          </li>
+        })}
+      </ul>
+    </div>;
+  }
+});


### PR DESCRIPTION
[Search for `.js`](https://github.com/search?utf8=%E2%9C%93&q=extension%3Ajs+NOT+nothack&type=Code) / [Search for `.jsx`](https://github.com/search?utf8=%E2%9C%93&q=extension%3Ajsx+NOT+nothack&type=Code)

[Search for `.js` with "return \<div>"](https://github.com/search?utf8=%E2%9C%93&q=extension%3Ajs+return+%3Cdiv%3E&type=Code) (the `<` characters are ignored, but you can see that many people uses JSX in `.js` files by opening a few pages).

Please, let me know what I can do to help getting this PR merged at some point.

Refs #3144 