### PR TITLE
Update vendor.yml: skeleton.css

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -72,6 +72,9 @@
 # Normalize.css
 - (^|/)normalize\.(css|less|scss|styl)$
 
+# Skeleton.css
+- (^|/)skeleton\.(css|less|scss|styl)$
+
 # Bourbon css
 - (^|/)[Bb]ourbon/.*\.(css|less|scss|styl)$
 


### PR DESCRIPTION
[Skeleton](http://getskeleton.com/) is the younger, slimmer cousin to bootstrap.  Figured it should be excluded as well.  

