### PR TITLE
Register "cpanfile" as a Perl filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3217,6 +3217,8 @@ Perl:
   - ".pod"
   - ".psgi"
   - ".t"
+  filenames:
+  - cpanfile
   interpreters:
   - perl
   language_id: 282

--- a/samples/Perl/filenames/cpanfile
+++ b/samples/Perl/filenames/cpanfile
@@ -1,0 +1,11 @@
+requires 'perl', '5.008001';
+
+requires 'JSON';
+requires 'Path::Class', 0.26;
+requires 'WebService::Dropbox', 2.06;
+requires 'DateTime::Format::Strptime';
+requires 'Encode::Locale';
+
+if ($^O eq 'darwin') {
+	requires 'Encode::UTF8Mac';
+}


### PR DESCRIPTION
This is a [manifest file](http://search.cpan.org/~miyagawa/Module-CPANfile-1.1002/lib/cpanfile.pod) used for describing the dependencies list of a CPAN module. Very similar (and inspired by) Ruby's [Gemfile](http://bundler.io/v1.3/man/gemfile.5.html) format.

**In-the-wild usage:** [~10,782 results](https://github.com/search?q=filename%3Acpanfile+NOT+nothack&type=Code), no discrepancies. Distributed across 2273 repositories by 852 users (based on a [subsample](https://github.com/Alhadis/Linguist-Silo/blob/misc/cpanfile.log) of 2,587 results).

**Origin of sample file:** [`s-aska/dropbox-api-command`](https://github.com/s-aska/dropbox-api-command/blob/035f3d41d41027a8d382c1e3cb1c7af231acee7c/cpanfile), released under the [MIT license](https://github.com/s-aska/dropbox-api-command/blob/035f3d41d41027a8d382c1e3cb1c7af231acee7c/LICENSE).