### PR TITLE
shell: add more extensions and interpreters

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4122,7 +4122,12 @@ Shell:
   - PKGBUILD
   - gradlew
   interpreters:
+  - ash
   - bash
+  - dash
+  - ksh
+  - mksh
+  - pdksh
   - rc
   - sh
   - zsh

--- a/test/fixtures/Shell/ash-env
+++ b/test/fixtures/Shell/ash-env
@@ -1,0 +1,2 @@
+#!/usr/bin/env ash
+echo "ash"

--- a/test/fixtures/Shell/dash-env
+++ b/test/fixtures/Shell/dash-env
@@ -1,0 +1,2 @@
+#!/usr/bin/env dash
+echo "dash"

--- a/test/fixtures/Shell/ksh-env
+++ b/test/fixtures/Shell/ksh-env
@@ -1,0 +1,2 @@
+#!/usr/bin/env ksh
+echo "ksh"

--- a/test/fixtures/Shell/mksh
+++ b/test/fixtures/Shell/mksh
@@ -1,0 +1,2 @@
+#!/bin/mksh
+echo "mksh"

--- a/test/fixtures/Shell/pdksh-env
+++ b/test/fixtures/Shell/pdksh-env
@@ -1,0 +1,2 @@
+#!/usr/bin/env pdksh
+echo "pdksh"


### PR DESCRIPTION
* ash: only interpreter, extension is more commonly used for
  Kingdom of Loathing scripting, e.g. github.com/twistedmage/assorted-kol-scripts

* dash: only interpreter, extension is more commonly used for
  dashboarding-related stuff

* ksh: extension was already present

* mksh

* pdksh