### PR TITLE
fix classifier tests

### DIFF
--- a/test/test_classifier.rb
+++ b/test/test_classifier.rb
@@ -47,7 +47,10 @@ class TestClassifier < Minitest::Test
     Samples.each do |sample|
       language  = Linguist::Language.find_by_name(sample[:language])
       languages = Language.find_by_filename(sample[:path]).map(&:name)
-      next unless languages.length > 1
+      next if languages.length == 1
+
+      languages = Language.find_by_extension(sample[:path]).map(&:name)
+      next if languages.length <= 1
 
       results = Classifier.classify(Samples.cache, File.read(sample[:path]), languages)
       assert_equal language.name, results.first[0], "#{sample[:path]}\n#{results.inspect}"


### PR DESCRIPTION
test_classify_ambiguous_languages was not running any test, since
it was looking only for languages that are ambiguous on
filename for known filenames (rather than ambiguous for filename
or extension).

Note that test time and assertions.
Before:
  Finished in 0.149294s, 40.1892 runs/s, 46.8874 assertions/s.
After:
  Finished in 3.043109s, 1.9717 runs/s, 224.7702 assertions/s.