### PR TITLE
Add NCSA to license whitelist

### DIFF
--- a/vendor/licenses/config.yml
+++ b/vendor/licenses/config.yml
@@ -2,10 +2,11 @@ whitelist:
   - apache-2.0
   - bsd-2-clause
   - bsd-3-clause
-  - permissive
-  - mit
   - isc
+  - mit
   - mpl-2.0
+  - ncsa
+  - permissive
   - unlicense
   - wtfpl
   - zlib


### PR DESCRIPTION
See https://github.com/github/linguist/pull/3689#issuecomment-313593201:

> @ayberkt __wrote:__ *"The examples are currently under the [UIUC/NCSA](https://opensource.org/licenses/NCSA) license. If you could whitelist this we would prefer that but if that's not possible, we can release these sample programs under one of the whitelisted licenses (in another repo maybe)."*

@mlinksva gave the official go-ahead to whitelist NCSA, as it's an acceptably permissive license.

I also took the liberty of alphabetising our whitelist, since I couldn't figure out which line to add it on... :\

SPDX identifier [sourced from here](https://spdx.org/licenses/NCSA.html).