### PR TITLE
Added required file extension for Modula-2 and sample files.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2665,6 +2665,7 @@ Modelica:
 Modula-2:
   type: programming
   extensions:
+  - ".def"
   - ".mod"
   tm_scope: source.modula2
   ace_mode: text

--- a/samples/Modula-2/Newline.def
+++ b/samples/Modula-2/Newline.def
@@ -1,0 +1,18 @@
+(*!m2iso*) (* Copyright (c) 2017 Modula-2 Software Foundation *)
+
+DEFINITION MODULE Newline;
+
+(* Newline mode management *)
+
+TYPE Mode = ( LF, CR, CRLF );
+
+
+PROCEDURE SetMode ( mode : Mode );
+(* Sets the default newline mode. *)
+
+
+PROCEDURE mode ( ) : Mode;
+(* Returns the default newline mode. *)
+
+
+END Newline.

--- a/samples/Modula-2/Newline.def
+++ b/samples/Modula-2/Newline.def
@@ -16,3 +16,7 @@ PROCEDURE mode ( ) : Mode;
 
 
 END Newline.
+
+(* License Exception:
+   This file has been relicensed to the Linguist project under MIT license
+   terms for use with Linguist. For other uses the LGPL 2.1 license applies. *)

--- a/samples/Modula-2/Newline.mod
+++ b/samples/Modula-2/Newline.mod
@@ -26,3 +26,7 @@ END mode;
 BEGIN
   defaultMode := LF
 END Newline.
+
+(* License Exception:
+   This file has been relicensed to the Linguist project under MIT license
+   terms for use with Linguist. For other uses the LGPL 2.1 license applies. *)

--- a/samples/Modula-2/Newline.mod
+++ b/samples/Modula-2/Newline.mod
@@ -1,0 +1,28 @@
+(*!m2iso*) (* Copyright (c) 2017 Modula-2 Software Foundation *)
+
+IMPLEMENTATION MODULE Newline;
+
+(* Newline mode management *)
+
+VAR defaultMode : Mode;
+
+
+PROCEDURE SetMode ( mode : Mode );
+(* Sets the default newline mode. *)
+
+BEGIN
+  defaultMode := mode
+END SetMode;
+
+
+PROCEDURE mode ( ) : Mode;
+(* Returns the default newline mode. *)
+
+BEGIN
+  RETURN defaultMode;
+END mode;
+
+
+BEGIN
+  defaultMode := LF
+END Newline.


### PR DESCRIPTION
Modula-2 libraries consist of a definition module (file extension .def) and an implementation module (file extension .mod). This is comparable to .h and .c files in C and C++. Linguist not recognising .def, but .mod alone for Modula-2 would be like not recognising .c for C and C++. This patch adds (1) an entry to recognise ".def" as Modula-2 to languages.yml and (2) a def/mod sample file pair in the samples/modula-2 directory.