### PR TITLE
Change Haskell's colour to use official branding

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1767,7 +1767,7 @@ Harbour:
   language_id: 156
 Haskell:
   type: programming
-  color: "#29b544"
+  color: "#5e5086"
   extensions:
   - ".hs"
   - ".hsc"


### PR DESCRIPTION
Resolves github/linguist#3727.

Quoting @adius:
> The Haskell community has obviously settled with purple (check out https://haskell.org, https://haskell-lang.org, https://reddit.com/r/haskell, ...). `rgb(94,80,134)` to be precise.

He's right, and now that I think about it, I'm not entirely sure where the colour green came from. Everything in the language's branding uses either purple or dark blue, so that's obviously much more representative of the language than, well, `rgb(41,181,68)`.

/cc @lildude Reckon we could squeeze this under the door for Linguist [`v5.1.0`](https://github.com/github/linguist/pull/3725)?

**EDIT:** Additional rationale to justify this particular shade of purple: it's the same colour used by the [central lambda in Haskell's logo](https://www.haskell.org/static/img/haskell-logo.svg), arguably the image's most prominent element.