### PR TITLE
Added a new extension for solidity language

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -119,6 +119,7 @@ vendor/grammars/SublimeClarion:
 - source.clarion
 vendor/grammars/SublimeEthereum:
 - source.solidity
+- source.sol
 vendor/grammars/SublimeGDB/:
 - source.disasm
 - source.gdb


### PR DESCRIPTION
Usually, solidity files has a '.solidity' extension. But me and over the 70% blockchain programmers using Solidity as main smart contracts langugage use '.sol' extension as well. So this string allow toh ighlite a .sol files. Cheers :)