### PR TITLE
Change Type Language type to markup

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4514,7 +4514,7 @@ Twig:
   codemirror_mime_type: text/x-twig
   language_id: 377
 Type Language:
-  type: data
+  type: markup
   aliases:
   - tl
   extensions:


### PR DESCRIPTION
I looked at Protobuf and it has `type: markup` but initially I thought that this type should be used for HTML-like languages only and not RPC languages like Protobuf.

(markup type is very misleading at first)