### PR TITLE
tokenizer: capture non-ASCII identifiers

### DIFF
--- a/lib/linguist/tokenizer.rb
+++ b/lib/linguist/tokenizer.rb
@@ -107,7 +107,7 @@ module Linguist
           tokens << token
 
         # Regular token
-        elsif token = s.scan(/[\w\.@#\/\*]+/)
+        elsif token = s.scan(/[[[:alnum:]]_\.@#\/\*]+/)
           tokens << token
 
         # Common operators

--- a/test/test_tokenizer.rb
+++ b/test/test_tokenizer.rb
@@ -113,4 +113,8 @@ class TestTokenizer < Minitest::Test
     assert_equal %w(module Foo end), tokenize(:"Ruby/foo.rb")
     assert_equal %w(task default do puts end), tokenize(:"Ruby/filenames/Rakefile")
   end
+
+  def test_utf8_tokens
+    assert_equal %w(Функция الكون), tokenize(:"Функция الكون".to_s)
+  end
 end


### PR DESCRIPTION
`\w` captures only ASCII letters and numbers. Changed to [[:alnum:]]
to capture any Unicode letter and digit. This makes the tokenizer
work properly on non-English based langiages (e.g. 1C Enterprise).