### PR TITLE
replace non-UTF-8 characters before tokenizing

### DIFF
--- a/lib/linguist/tokenizer.rb
+++ b/lib/linguist/tokenizer.rb
@@ -13,6 +13,7 @@ module Linguist
     #
     # Returns Array of token Strings.
     def self.tokenize(data)
+      data = data.encode('UTF-8', 'UTF-8', :invalid => :replace)
       new.extract_tokens(data)
     end
 

--- a/samples/GLSL/scene.gs
+++ b/samples/GLSL/scene.gs
@@ -1,0 +1,13 @@
+#version 330 core
+
+layout(points) in ;
+layout(points, max_vertices = 1) out;
+
+// 直通的几何着色器 原样输出
+void main()
+{
+	gl_Position = gl_in[0].gl_Position;
+	gl_PointSize = gl_in[0].gl_PointSize;
+	EmitVertex();
+	EndPrimitive();
+}


### PR DESCRIPTION
This prevents later encoding errors in the tokenizer
whenever a file with non-UTF-8 characters reaches the
classifier.

Added GLSL sample with non-UTF-8 characters. Extracted
from wangdingqiao/noteForOpenGL, licensed unther the MIT
license. See:
https://github.com/wangdingqiao/noteForOpenGL/blob/40c014ca23ebdb9a33da86278ba232594c1b9f1e/geometryShader/geometryShader1/scene.gs