### PR TITLE
Make Language methods more resilient to non-String input

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -109,7 +109,7 @@ module Linguist
     #
     # Returns the Language or nil if none was found.
     def self.find_by_name(name)
-      return nil if name.to_s.empty?
+      return nil if !name.is_a?(String) || name.to_s.empty?
       name && (@name_index[name.downcase] || @name_index[name.split(',').first.downcase])
     end
 
@@ -124,7 +124,7 @@ module Linguist
     #
     # Returns the Language or nil if none was found.
     def self.find_by_alias(name)
-      return nil if name.to_s.empty?
+      return nil if !name.is_a?(String) || name.to_s.empty?
       name && (@alias_index[name.downcase] || @alias_index[name.split(',').first.downcase])
     end
 
@@ -214,7 +214,7 @@ module Linguist
     #
     # Returns the Language or nil if none was found.
     def self.[](name)
-      return nil if name.to_s.empty?
+      return nil if !name.is_a?(String) || name.to_s.empty?
 
       lang = @index[name.downcase]
       return lang if lang

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -270,6 +270,12 @@ class TestLanguage < Minitest::Test
     assert_nil Language[""]
   end
 
+  def test_does_not_blow_up_with_non_string_lookup
+    assert_nil Language.find_by_alias(true)
+    assert_nil Language.find_by_name(true)
+    assert_nil Language[true]
+  end
+
   def test_name
     assert_equal 'Perl',   Language['Perl'].name
     assert_equal 'Python', Language['Python'].name


### PR DESCRIPTION
The erroring test in 3e594a58ed70c278b0a5aa299dea45c18f40e531 shows the exception that we're seeing when using Linguist on GitHub.com and GitHub Enterprise when calls like `Language.find_by_alias(true)` end up being made:

```
  1) Error:
TestLanguage#test_does_not_blow_up_with_non_string_lookup:
NoMethodError: undefined method `downcase' for true:TrueClass
    /home/travis/build/github/linguist/lib/linguist/language.rb:128:in `find_by_alias'
    /home/travis/build/github/linguist/test/test_language.rb:274:in `test_does_not_blow_up_with_non_string_lookup'
```

Instead of raising an error, this handles non-String input so that `nil` is returned instead.

The problem can be recreated by creating a `.gitattributes` file that sets `linguist-language` to `true`, rather than a `String`.

So like this:

```
*.rb linguist-language
```

Rather than using the documented instructions like this:

```
*.rb linguist-language=Ruby
```

From the docs for the _Set_ state at https://git-scm.com/docs/gitattributes:

> The path has the attribute with special value "true"; this is specified by listing only the name of the attribute in the attribute list.