### PR TITLE
Distinction between Component Pascal language and Pascal language and…

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -781,9 +781,6 @@ Component Pascal:
   - ".cp"
   - ".cps"
   tm_scope: source.pascal
-  aliases:
-  - delphi
-  - objectpascal
   ace_mode: pascal
   codemirror_mode: pascal
   codemirror_mime_type: text/x-pascal
@@ -3199,12 +3196,19 @@ Parrot Internal Representation:
 Pascal:
   type: programming
   color: "#E3F171"
+  aliases:
+  - delphi
+  - objectpascal
   extensions:
   - ".pas"
   - ".dfm"
   - ".dpr"
+  - ".dproj"
+  - ".dpk"
   - ".inc"
   - ".lpr"
+  - ".lpk"
+  - ".lpi"
   - ".pascal"
   - ".pp"
   interpreters:


### PR DESCRIPTION
Change "delphi" and "objectpascal" aliases from the "Component Pascal" language to the "Pascal" language because [Component Pascal language](https://en.wikipedia.org/wiki/Component_Pascal) has no relation to Pascal language and their dialects.

[Pascal language](https://en.wikipedia.org/wiki/Pascal_(programming_language)) is the main language of dialects like "Object Pascal", "Oxygene" and "Delphi".

Delphi is a registered product of [Embarcadero Technologies](https://www.embarcadero.com/products/delphi).