### PR TITLE
Add .clang-tidy filename for YAML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5050,6 +5050,7 @@ YAML:
   - ".yml.mysql"
   filenames:
   - ".clang-format"
+  - ".clang-tidy"
   ace_mode: yaml
   codemirror_mode: yaml
   codemirror_mime_type: text/x-yaml

--- a/samples/YAML/filenames/.clang-tidy
+++ b/samples/YAML/filenames/.clang-tidy
@@ -1,0 +1,30 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            linguist-user
+CheckOptions:
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+


### PR DESCRIPTION
`.clang-tidy` is the filename used for clang-tidy's configuration file. clang-tidy is a clang-based C++ "linter" tool. For more info, see: https://clang.llvm.org/extra/clang-tidy/

It has [over a thousand site-wide uses](https://github.com/search?utf8=%E2%9C%93&q=filename%3A.clang-tidy+NOT+nothack&type=Code&ref=searchresults).