### PR TITLE
Make Matlab's Color More Appropriate

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2614,7 +2614,7 @@ Mathematica:
   language_id: 224
 Matlab:
   type: programming
-  color: "#bb92ac"
+  color: "#e16737"
   aliases:
   - octave
   extensions:


### PR DESCRIPTION
Purple is not an affiliated color of Matlab or Mathworks. Change the color to better reflect the color theme of the Matlab sofware and logo.