### PR TITLE
Update gemspec to use charlock_holmes 0.7.5

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*'] + Dir['grammars/*'] + ['LICENSE']
   s.executables = ['linguist', 'git-linguist']
 
-  s.add_dependency 'charlock_holmes', '~> 0.7.3'
+  s.add_dependency 'charlock_holmes', '~> 0.7.5'
   s.add_dependency 'escape_utils',    '~> 1.1.0'
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '>= 0.25.1'


### PR DESCRIPTION
As pointed out in https://github.com/github/linguist/issues/3777 the charlock_holmes dependency of Linguist can't be installed on macOS 10.12.6 due to https://github.com/brianmario/charlock_holmes/issues/117

This PR fixes that problem by updating our dependency to charlock_holmes 0.7.5. This is the latest release and also the release used on GitHub.com

Fixes https://github.com/github/linguist/issues/3777

/cc @github/data-engineering for FYI