### PR TITLE
Add nearley language definition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -866,3 +866,6 @@
 [submodule "vendor/grammars/language-reason"]
 	path = vendor/grammars/language-reason
 	url = https://github.com/reasonml-editor/language-reason
+[submodule "vendor/grammars/sublime-nearley"]
+	path = vendor/grammars/sublime-nearley
+	url = https://github.com/Hardmath123/sublime-nearley

--- a/grammars.yml
+++ b/grammars.yml
@@ -644,6 +644,8 @@ vendor/grammars/sublime-golo:
 - source.golo
 vendor/grammars/sublime-mask:
 - source.mask
+vendor/grammars/sublime-nearley:
+- source.ne
 vendor/grammars/sublime-netlinx:
 - source.netlinx
 - source.netlinx.erb

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2789,6 +2789,15 @@ NSIS:
   codemirror_mode: nsis
   codemirror_mime_type: text/x-nsis
   language_id: 242
+Nearley:
+  type: programming
+  ace_mode: text
+  color: "#990000"
+  extensions:
+  - ".ne"
+  - ".nearley"
+  tm_scope: source.ne
+  language_id: 521429430
 Nemerle:
   type: programming
   color: "#3d3c6e"

--- a/samples/Nearley/nearley-language-bootstrapped.ne
+++ b/samples/Nearley/nearley-language-bootstrapped.ne
@@ -1,0 +1,106 @@
+# nearley grammar
+@builtin "string.ne"
+
+@{%
+
+function insensitive(sl) {
+    var s = sl.literal;
+    result = [];
+    for (var i=0; i<s.length; i++) {
+        var c = s.charAt(i);
+        if (c.toUpperCase() !== c || c.toLowerCase() !== c) {
+            result.push(new RegExp("[" + c.toLowerCase() + c.toUpperCase() + "]"));
+        } else {
+            result.push({literal: c});
+        }
+    }
+    return {subexpression: [{tokens: result, postprocess: function(d) {return d.join(""); }}]};
+}
+
+%}
+
+final -> whit? prog whit?  {% function(d) { return d[1]; } %}
+
+prog -> prod  {% function(d) { return [d[0]]; } %}
+      | prod whit prog  {% function(d) { return [d[0]].concat(d[2]); } %}
+
+prod -> word whit? ("-"|"="):+ ">" whit? expression+  {% function(d) { return {name: d[0], rules: d[5]}; } %}
+      | word "[" wordlist "]" whit? ("-"|"="):+ ">" whit? expression+ {% function(d) {return {macro: d[0], args: d[2], exprs: d[8]}} %}
+      | "@" whit? js  {% function(d) { return {body: d[2]}; } %}
+      | "@" word whit word  {% function(d) { return {config: d[1], value: d[3]}; } %}
+      | "@include"  whit? string {% function(d) {return {include: d[2].literal, builtin: false}} %}
+      | "@builtin"  whit? string {% function(d) {return {include: d[2].literal, builtin: true }} %}
+
+expression+ -> completeexpression
+             | expression+ whit? "|" whit? completeexpression  {% function(d) { return d[0].concat([d[4]]); } %}
+
+expressionlist -> completeexpression
+             | expressionlist whit? "," whit? completeexpression {% function(d) { return d[0].concat([d[4]]); } %}
+
+wordlist -> word
+            | wordlist whit? "," whit? word {% function(d) { return d[0].concat([d[4]]); } %}
+
+completeexpression -> expr  {% function(d) { return {tokens: d[0]}; } %}
+                    | expr whit? js  {% function(d) { return {tokens: d[0], postprocess: d[2]}; } %}
+
+expr_member ->
+      word {% id %}
+    | "$" word {% function(d) {return {mixin: d[1]}} %}
+    | word "[" expressionlist "]" {% function(d) {return {macrocall: d[0], args: d[2]}} %} 
+    | string "i":? {% function(d) { if (d[1]) {return insensitive(d[0]); } else {return d[0]; } } %}
+    | "%" word {% function(d) {return {token: d[1]}} %}
+    | charclass {% id %}
+    | "(" whit? expression+ whit? ")" {% function(d) {return {'subexpression': d[2]} ;} %}
+    | expr_member whit? ebnf_modifier {% function(d) {return {'ebnf': d[0], 'modifier': d[2]}; } %}
+
+ebnf_modifier -> ":+" {% id %} | ":*" {% id %} | ":?" {% id %}
+
+expr -> expr_member
+      | expr whit expr_member  {% function(d){ return d[0].concat([d[2]]); } %}
+
+word -> [\w\?\+]  {% function(d){ return d[0]; } %}
+      | word [\w\?\+]  {% function(d){ return d[0]+d[1]; } %}
+
+string -> dqstring {% function(d) {return { literal: d[0] }; } %}
+#string -> "\"" charset "\""  {% function(d) { return { literal: d[1].join("") }; } %}
+#
+#charset -> null
+#         | charset char  {% function(d) { return d[0].concat([d[1]]); } %}
+#
+#char -> [^\\"]  {% function(d) { return d[0]; } %}
+#      | "\\" .  {% function(d) { return JSON.parse("\""+"\\"+d[1]+"\""); } %}
+
+charclass -> "."  {% function(d) { return new RegExp("."); } %}
+           | "[" charclassmembers "]"  {% function(d) { return new RegExp("[" + d[1].join('') + "]"); } %}
+
+charclassmembers -> null
+                  | charclassmembers charclassmember  {% function(d) { return d[0].concat([d[1]]); } %}
+
+charclassmember -> [^\\\]]  {% function(d) { return d[0]; } %}
+                 | "\\" .  {% function(d) { return d[0] + d[1]; } %}
+
+js -> "{" "%" jscode "%" "}"  {% function(d) { return d[2]; } %}
+
+jscode -> null  {% function() {return "";} %}
+        | jscode [^%]  {% function(d) {return d[0] + d[1];} %}
+        | jscode "%" [^}] {% function(d) {return d[0] + d[1] + d[2]; } %}
+
+# Whitespace with a comment
+whit -> whitraw
+      | whitraw? comment whit?
+
+# Optional whitespace with a comment
+whit? -> null
+       | whit
+
+# Literally a string of whitespace
+whitraw -> [\s]
+         | whitraw [\s]
+
+# A string of whitespace OR the empty string
+whitraw? -> null
+          | whitraw
+
+comment -> "#" commentchars "\n"
+commentchars -> null
+              | commentchars [^\n]

--- a/vendor/licenses/grammar/sublime-nearley.txt
+++ b/vendor/licenses/grammar/sublime-nearley.txt
@@ -1,0 +1,29 @@
+---
+type: grammar
+name: sublime-nearley
+license: unlicense
+---
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>


### PR DESCRIPTION
Hi everyone! I added a language definition for the [nearley parser generator](http://github.com/Hardmath123/nearley). In particular, I

- [x] Added the definition in languages.yml; the extension does not conflict with any other language
- [x] Picked a distinct-enough color
- [x] Added a grammar (.tmLanguage), which is Unlicensed
- [x] Added a large sample `.ne` file
- [x] Added a language ID using the script
- [x] Ran the tests; all pass on my machine

Here is a [search result](https://github.com/search?utf8=✓&q=extension%3Ane+NOT+nothack&type=Code) showing around 4.9k nearley files "in the wild". In addition, the [nearley homepage](https://nearley.js.org) explicitly curates 50 nearley-based projects, all hosted on Github.

Please let me know if there's anything else I need to do. Thanks for your time!

(I'm going to CC the other nearley maintainer, @tjvr.)

EDIT: I also accepted the CLA for github/linguist.