### PR TITLE
Update escape_utils requirement to >= 1.1, < 1.3

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.executables = ['linguist', 'git-linguist']
 
   s.add_dependency 'charlock_holmes', '~> 0.7.5'
-  s.add_dependency 'escape_utils',    '>= 1.1', '< 1.3'
+  s.add_dependency 'escape_utils',    '>= 1.1', '< 2.0'
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '>= 0.25.1'
 

--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.executables = ['linguist', 'git-linguist']
 
   s.add_dependency 'charlock_holmes', '~> 0.7.5'
-  s.add_dependency 'escape_utils',    '~> 1.1.0'
+  s.add_dependency 'escape_utils',    '>= 1.1', '< 1.3'
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '>= 0.25.1'
 


### PR DESCRIPTION
Updates requirements on [escape_utils](https://github.com/brianmario/escape_utils) to permit the latest version.

Generated on my fork using [Dependabot](https://dependabot.com), if you want to automate this stuff for the future.