### PR TITLE
Byebug requires Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ git:
 
 cache: bundler
 dist: precise
+
+bundler_args: --without debug

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 gemspec :name => "github-linguist"
-gem 'byebug' if RUBY_VERSION >= '2.0'
+
+group :debug do
+  gem 'byebug' if RUBY_VERSION >= '2.2'
+end


### PR DESCRIPTION
The minimum Ruby version required for byebug is now 2.2.0 thanks to https://github.com/deivid-rodriguez/byebug/pull/337. This requirement change has led to our 2.1 builds failing with:

```
Gem::InstallError: byebug requires Ruby version >= 2.2.0.
Using github-linguist 5.2.0 from source at .
An error occurred while installing byebug (9.1.0), and Bundler cannot continue.
Make sure that `gem install byebug -v '9.1.0'` succeeds before bundling.
The command "eval bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} " failed 3 times.
The command "bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}" failed and exited with 5 during .
Your build has been stopped.
```

Rather than locking us to a particular version of byebug, I've bumped the minimum Ruby version to 2.2.0 and I've also defined a `:debug` group and excluded it in the Travis build so byebug is not installed during testing as it's not needed during testing.

One less gem means a slightly quicker build too 😄

/cc @github/data-engineering