### PR TITLE
Node.js ES2015 modules do not have JavaScript syntax highlighting.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2077,6 +2077,7 @@ JavaScript:
   - ".jsfl"
   - ".jsm"
   - ".jss"
+  - ".mjs"
   - ".njs"
   - ".pac"
   - ".sjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,169 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "coffee-script": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.0.tgz",
+      "integrity": "sha1-dJLLvD8DYcxdiGWv9yN1Uv8z4fc="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "cson-parser": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.0.9.tgz",
+      "integrity": "sha1-t5/BuCp3V0NoDw7/uL+tMRNNrHQ=",
+      "requires": {
+        "coffee-script": "1.9.0"
+      }
+    },
+    "fs-plus": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
+      "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
+      "requires": {
+        "async": "1.5.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1",
+        "underscore-plus": "1.6.6"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.4.0.tgz",
+      "integrity": "sha1-y47Dfy/jqphky2eidSUOfhliCiU=",
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "season": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/season/-/season-5.4.1.tgz",
+      "integrity": "sha1-S9baYVKn8tbwixQzzi2SBmmFPQ0=",
+      "requires": {
+        "cson-parser": "1.0.9",
+        "fs-plus": "2.10.1",
+        "optimist": "0.4.0"
+      }
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "underscore-plus": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
+      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "requires": {
+        "underscore": "1.6.0"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/samples/JavaScript/module.mjs
+++ b/samples/JavaScript/module.mjs
@@ -1,0 +1,11 @@
+import { bar } from './foo.js';
+
+export const BAZ = 'me';
+
+export function RocketLauncher() {
+  return true;
+}
+
+export default {
+  message: 'spaaaaaace',
+};


### PR DESCRIPTION
The Node.js project has settled on the `.mjs` extension to identify
ES2015 modules. This extension is not being highlighted in projects that
use linguist.

## Reference

https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#32-determining-if-source-is-an-es-module

## Usage on GitHub

https://github.com/search?utf8=%E2%9C%93&q=extension%3Amjs+NOT+nothack&type=Code