### PR TITLE
Add some linguist-detectable attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@ Rakefile linguist-generated
 test/fixtures/* linguist-vendored=false
 README.md linguist-documentation=false
 samples/Arduino/* linguist-documentation
+samples/Markdown/*.md linguist-detectable=true
+samples/HTML/*.html linguist-detectable=false


### PR DESCRIPTION
This allows to test a use-case where markdown should be reported
in the language stats (e.g because the main purpose of the repo is to
hold prose in markdown format) while HTML should be excluded from the
language stats (e.g because it's example output).