### PR TITLE
Added ".monkey2" extension to Monkey Programming Language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2740,6 +2740,7 @@ Monkey:
   type: programming
   extensions:
   - ".monkey"
+  - ".monkey2"
   ace_mode: text
   tm_scope: source.monkey
   language_id: 236


### PR DESCRIPTION
The latest Monkey Programming Language extension is ".monkey2", so I added it to this list. The language description is available at "http://monkeycoder.co.nz". Thanks!