### PR TITLE
Add Ballerina language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -875,3 +875,6 @@
 [submodule "vendor/grammars/squirrel-language"]
 	path = vendor/grammars/squirrel-language
 	url = https://github.com/mathewmariani/squirrel-language
+[submodule "vendor/grammars/plugin-vscode"]
+	path = vendor/grammars/plugin-vscode
+	url = https://github.com/ballerinalang/plugin-vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -875,6 +875,6 @@
 [submodule "vendor/grammars/squirrel-language"]
 	path = vendor/grammars/squirrel-language
 	url = https://github.com/mathewmariani/squirrel-language
-[submodule "vendor/grammars/plugin-vscode"]
-	path = vendor/grammars/plugin-vscode
+[submodule "vendor/grammars/language-ballerina"]
+	path = vendor/grammars/language-ballerina
 	url = https://github.com/ballerinalang/plugin-vscode

--- a/grammars.yml
+++ b/grammars.yml
@@ -352,6 +352,8 @@ vendor/grammars/language-asn1:
 vendor/grammars/language-babel:
 - source.js.jsx
 - source.regexp.babel
+vendor/grammars/language-ballerina:
+- source.ballerina
 vendor/grammars/language-batchfile:
 - source.batchfile
 vendor/grammars/language-blade:
@@ -572,8 +574,6 @@ vendor/grammars/pig-latin:
 - source.pig_latin
 vendor/grammars/pike-textmate:
 - source.pike
-vendor/grammars/plugin-vscode:
-- source.bal
 vendor/grammars/postscript.tmbundle:
 - source.postscript
 vendor/grammars/powershell:

--- a/grammars.yml
+++ b/grammars.yml
@@ -572,6 +572,8 @@ vendor/grammars/pig-latin:
 - source.pig_latin
 vendor/grammars/pike-textmate:
 - source.pike
+vendor/grammars/plugin-vscode:
+- source.bal
 vendor/grammars/postscript.tmbundle:
 - source.postscript
 vendor/grammars/powershell:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -354,6 +354,16 @@ Awk:
   - nawk
   ace_mode: text
   language_id: 28
+Ballerina:
+  type: programming
+  aliases:
+  - ballerinalang
+  extensions:
+  - ".bal"
+  tm_scope: source.bal
+  ace_mode: text
+  color: "#FF7900"
+  language_id: 720859680
 Batchfile:
   type: programming
   aliases:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -356,11 +356,9 @@ Awk:
   language_id: 28
 Ballerina:
   type: programming
-  aliases:
-  - ballerinalang
   extensions:
   - ".bal"
-  tm_scope: source.bal
+  tm_scope: source.ballerina
   ace_mode: text
   color: "#FF5000"
   language_id: 720859680

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -362,7 +362,7 @@ Ballerina:
   - ".bal"
   tm_scope: source.bal
   ace_mode: text
-  color: "#FF7900"
+  color: "#FF5000"
   language_id: 720859680
 Batchfile:
   type: programming

--- a/samples/Ballerina/hello-world-service.bal
+++ b/samples/Ballerina/hello-world-service.bal
@@ -1,0 +1,16 @@
+import ballerina.lang.messages;
+import ballerina.net.http;
+import ballerina.doc;
+
+@doc:Description {value:"By default Ballerina assumes that the service is to be exposed via HTTP/1.1 using the system default port and that all requests coming to the HTTP server will be delivered to this service."}
+service<http> helloWorld {
+    @doc:Description {value:"All resources are invoked with an argument of type message, the built-in reference type representing a network invocation."}
+    resource sayHello (message m) {
+        // Creates an empty message.
+        message response = {};
+        // A util method that can be used to set string payload.
+        messages:setStringPayload(response, "Hello, World!");
+        // Reply keyword sends the response back to the client.
+        reply response;
+    }
+}

--- a/samples/Ballerina/hello-world.bal
+++ b/samples/Ballerina/hello-world.bal
@@ -1,0 +1,6 @@
+import ballerina.lang.system;
+
+function main (string[] args) {
+    system:println("Hello, World!");
+}
+

--- a/samples/Ballerina/json.bal
+++ b/samples/Ballerina/json.bal
@@ -1,0 +1,31 @@
+import ballerina.lang.system;
+
+function main (string[] args) {
+    // JSON string value.
+    json j1 = "Apple";
+    system:println(j1);
+
+    // JSON number value.
+    json j2 = 5.36;
+    system:println(j2);
+
+    // JSON true value.
+    json j3 = true;
+    system:println(j3);
+
+    // JSON false value.
+    json j4 = false;
+    system:println(j4);
+
+    // JSON null value.
+    json j5 = null;
+
+    //JSON Objects.
+    json j6 = {name:"apple", color:"red", price:j2};
+    system:println(j6);
+
+    //JSON Arrays. They are arrays of any JSON value.
+    json j7 = [1, false, null, "foo",
+               {first:"John", last:"Pala"}];
+    system:println(j7);
+}

--- a/samples/Ballerina/var.bal
+++ b/samples/Ballerina/var.bal
@@ -1,0 +1,28 @@
+import ballerina.lang.system;
+
+function divideBy10 (int d) (int, int) {
+    return d / 10, d % 10;
+}
+
+function main (string[] args) {
+    //Here the variable type is inferred type from the initial value. This is same as "int k = 5";
+    var k = 5;
+    system:println(10 + k);
+
+    //Here the type of the 'strVar' is 'string'.
+    var strVar = "Hello!";
+    system:println(strVar);
+
+    //Multiple assignment with 'var' allows you to define the variable then and there.
+    //Variable type is inferred from the right-hand side.
+    var q, r = divideBy10(6);
+    system:println("06/10: " + "quotient=" + q + " " +
+                   "remainder=" + r);
+
+    //To ignore a particular return value in a multiple assignment statement, use '_'.
+    var q1, _ = divideBy10(57);
+    system:println("57/10: " + "quotient=" + q1);
+
+    var _, r1 = divideBy10(9);
+    system:println("09/10: " + "remainder=" + r1);
+}

--- a/samples/Ballerina/xml.bal
+++ b/samples/Ballerina/xml.bal
@@ -1,0 +1,26 @@
+import ballerina.lang.system;
+
+function main (string[] args) {
+
+	// XML element. Can only have one root element.
+    xml x1 = xml `<book>The Lost World</book>`;
+    system:println(x1);
+
+    // XML text
+    xml x2 = xml `Hello, world!`;
+    system:println(x2);
+
+    // XML comment
+    xml x3 = xml `<!--I am a comment-->`;
+    system:println(x3);
+
+    // XML processing instruction
+    xml x4 = xml `<?target data?>`;
+    system:println(x4);
+
+    // Multiple XML items can be combined to form a sequence of XML. The resulting sequence is again an XML on its own.
+    xml x5 = x1 + x2 + x3 + x4;
+    system:println("\nResulting XML sequence:");
+    system:println(x5);
+
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -33,6 +33,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **AutoHotkey:** [ahkscript/SublimeAutoHotkey](https://github.com/ahkscript/SublimeAutoHotkey)
 - **AutoIt:** [AutoIt/SublimeAutoItScript](https://github.com/AutoIt/SublimeAutoItScript)
 - **Awk:** [github-linguist/awk-sublime](https://github.com/github-linguist/awk-sublime)
+- **Ballerina:** [ballerinalang/plugin-vscode](https://github.com/ballerinalang/plugin-vscode)
 - **Batchfile:** [mmims/language-batchfile](https://github.com/mmims/language-batchfile)
 - **Befunge:** [johanasplund/sublime-befunge](https://github.com/johanasplund/sublime-befunge)
 - **Bison:** [textmate/bison.tmbundle](https://github.com/textmate/bison.tmbundle)

--- a/vendor/licenses/grammar/language-ballerina.txt
+++ b/vendor/licenses/grammar/language-ballerina.txt
@@ -1,6 +1,6 @@
 ---
 type: grammar
-name: plugin-vscode
+name: language-ballerina
 license: apache-2.0
 ---
                                  Apache License

--- a/vendor/licenses/grammar/plugin-vscode.txt
+++ b/vendor/licenses/grammar/plugin-vscode.txt
@@ -1,0 +1,206 @@
+---
+type: grammar
+name: plugin-vscode
+license: apache-2.0
+---
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Hi all,

This PR adds [Ballerina](https://github.com/ballerinalang/ballerina) language to the linguist. Ballerina is a general purpose, concurrent and strongly typed programming language with both textual and graphical syntaxes, optimized for integration.

I have,
1) Added Ballerina language to `languages.yml`. Extension(.bal) does not have any conflicts.
2) Added grammar which has Apache 2 licence.
3) Added some samples.
4) Generated `language_id` for Ballerina.
5) Ran the tests locally and all tests passed without any issue.

You can find the search results for Ballerina usage [here](https://github.com/search?o=desc&q=extension%3Abal+NOT+nothack&s=indexed&type=Code&utf8=%E2%9C%93).

Please let me know if I have missed something.

Thanks.