### PR TITLE
Add .hsig extensions for Haskell highlightning

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1824,6 +1824,7 @@ Haskell:
   extensions:
   - ".hs"
   - ".hsc"
+  - ".hsig"
   interpreters:
   - runhaskell
   ace_mode: haskell


### PR DESCRIPTION
Since version 8.2.1 GHC supports declaration of so called signatures which also use Haskell syntax.