### PR TITLE
Don't count VCL as Perl for statistics.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4689,7 +4689,6 @@ UrWeb:
   ace_mode: text
   language_id: 383
 VCL:
-  group: Perl
   type: programming
   extensions:
   - ".vcl"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4690,6 +4690,7 @@ UrWeb:
   language_id: 383
 VCL:
   type: programming
+  color: "#0298c3"
   extensions:
   - ".vcl"
   tm_scope: source.varnish.vcl


### PR DESCRIPTION
While the Varnish-specific language was apparently inspired by C and Perl, there's no reason to group it as Perl for repo statistics.  Also re-adding the VCL `color` definition.