### PR TITLE
Add WDL language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -877,3 +877,6 @@
 [submodule "vendor/grammars/TypeScript-TmLanguage"]
 	path = vendor/grammars/TypeScript-TmLanguage
 	url = https://github.com/Microsoft/TypeScript-TmLanguage
+[submodule "vendor/grammars/wdl-sublime-syntax-highlighter"]
+	path = vendor/grammars/wdl-sublime-syntax-highlighter
+	url = https://github.com/broadinstitute/wdl-sublime-syntax-highlighter

--- a/grammars.yml
+++ b/grammars.yml
@@ -715,6 +715,8 @@ vendor/grammars/vhdl:
 - source.vhdl
 vendor/grammars/vue-syntax-highlight:
 - text.html.vue
+vendor/grammars/wdl-sublime-syntax-highlighter:
+- source.wdl
 vendor/grammars/xc.tmbundle:
 - source.xc
 vendor/grammars/xml.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5202,6 +5202,7 @@ wdl:
   extensions:
   - ".wdl"
   tm_scope: source.wdl
+  ace_mode: text
   language_id: 374521672
 wisp:
   type: programming

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5196,6 +5196,13 @@ reStructuredText:
   codemirror_mode: rst
   codemirror_mime_type: text/x-rst
   language_id: 419
+wdl:
+  type: programming
+  color: "#42f1f4"
+  extensions:
+  - ".wdl"
+  tm_scope: source.wdl
+  language_id: 374521672
 wisp:
   type: programming
   ace_mode: clojure

--- a/samples/wdl/hello.wdl
+++ b/samples/wdl/hello.wdl
@@ -1,0 +1,21 @@
+# Sample originally from https://github.com/broadinstitute/centaur
+
+task hello {
+  String addressee
+  command {
+    echo "Hello ${addressee}!"
+  }
+  output {
+    String salutation = read_string(stdout())
+  }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+  }
+}
+
+workflow wf_hello {
+  call hello
+  output {
+     hello.salutation
+  }
+}

--- a/samples/wdl/ifs_in_scatters.wdl
+++ b/samples/wdl/ifs_in_scatters.wdl
@@ -1,0 +1,44 @@
+# Sample originally from https://github.com/broadinstitute/centaur
+
+task validate_int {
+  Int i
+  command {
+    echo $(( ${i} % 2 ))
+  }
+  output {
+    Boolean validation = read_int(stdout()) == 1
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}
+
+task mirror {
+  Int i
+  command {
+    echo ${i}
+  }
+  output {
+    Int out = read_int(stdout())
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}
+
+workflow ifs_in_scatters {
+  Array[Int] numbers = range(5)
+
+  scatter (n in numbers) {
+
+    call validate_int { input: i = n }
+    if (validate_int.validation) {
+      Int incremented = n + 1
+      call mirror { input: i = incremented }
+    }
+  }
+
+  output {
+    Array[Int?] mirrors = mirror.out
+  }
+}

--- a/samples/wdl/passingfiles.wdl
+++ b/samples/wdl/passingfiles.wdl
@@ -1,0 +1,42 @@
+# Sample originally from https://github.com/broadinstitute/centaur
+
+##
+# Check that we can:
+# - Create a file from a task and feed it into subsequent commands.
+# - Create a file output by interpolating a file name
+# - Use engine functions on an interpolated file name
+##
+
+task mkFile {
+  command { 
+    echo "small file contents" > out.txt
+  }
+  output { File out = "out.txt" }
+  runtime { docker: "ubuntu:latest" }
+}
+
+task consumeFile {
+  File in_file
+  String out_name
+
+  command {
+    cat ${in_file} > ${out_name}
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+  output {
+    File out_interpolation = "${out_name}"
+    String contents = read_string("${out_name}")
+    String contentsAlt = read_string(out_interpolation)
+  }
+}
+
+workflow filepassing {
+  call mkFile
+  call consumeFile {input: in_file=mkFile.out, out_name = "myFileName.abc.txt" }
+  output {
+      consumeFile.contents
+      consumeFile.contentsAlt
+  }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -381,6 +381,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Vue:** [vuejs/vue-syntax-highlight](https://github.com/vuejs/vue-syntax-highlight)
 - **Wavefront Material:** [Alhadis/language-wavefront](https://github.com/Alhadis/language-wavefront)
 - **Wavefront Object:** [Alhadis/language-wavefront](https://github.com/Alhadis/language-wavefront)
+- **wdl:** [broadinstitute/wdl-sublime-syntax-highlighter](https://github.com/broadinstitute/wdl-sublime-syntax-highlighter)
 - **Web Ontology Language:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)
 - **WebAssembly:** [Alhadis/language-webassembly](https://github.com/Alhadis/language-webassembly)
 - **WebIDL:** [andik/IDL-Syntax](https://github.com/andik/IDL-Syntax)

--- a/vendor/licenses/grammar/wdl-sublime-syntax-highlighter.txt
+++ b/vendor/licenses/grammar/wdl-sublime-syntax-highlighter.txt
@@ -1,0 +1,34 @@
+---
+type: grammar
+name: wdl-sublime-syntax-highlighter
+license: bsd-3-clause
+---
+BSD 3-Clause License
+
+Copyright (c) 2017, Broad Institute
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This is adding language support for the [Workflow Description Language](https://github.com/openwdl/wdl).

Current public usages, as requested: [WDL Usages](https://github.com/search?utf8=%E2%9C%93&q=extension%3Awdl+NOT+nothack&type=Code) 

If I managed to do everything correctly, this should be based on our [sublime highlighter](https://github.com/broadinstitute/wdl-sublime-syntax-highlighter). 

WDL has full development support in [JetBrains IDEs](https://github.com/broadinstitute/winstanley) and multiple [high-scale](https://github.com/broadinstitute/cromwell) [execution](https://dnastack.com/#/) [engines](https://github.com/dnanexus-rnd/dxWDL).

Thanks!