### PR TITLE
Fix Perl 5 and 6 disambiguation bug

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -358,10 +358,10 @@ module Linguist
     end
 
     disambiguate ".pm" do |data|
-      if /^\s*(?:use\s+v6\s*;|(?:\bmy\s+)?class|module)\b/.match(data)
-        Language["Perl 6"]
-      elsif /\buse\s+(?:strict\b|v?5\.)/.match(data)
+      if /\buse\s+(?:strict\b|v?5\.)/.match(data)
         Language["Perl"]
+      elsif /^\s*(?:use\s+v6\s*;|(?:\bmy\s+)?class|module)\b/.match(data)
+        Language["Perl 6"]
       elsif /^\s*\/\* XPM \*\//.match(data)
         Language["XPM"]
       end

--- a/test/fixtures/Perl/Module.pm
+++ b/test/fixtures/Perl/Module.pm
@@ -1,0 +1,8 @@
+use 5.006;
+use strict;
+
+=head1
+
+module
+
+=cut


### PR DESCRIPTION
Perl 5 code containing `class` or `module` was incorrectly interpret as Perl 6, as described in #3637.

This fixes the issue and adds a test which would cause a failure without the change to `heuristics.rb`.