### PR TITLE
Tests for Ruby 2.4 must pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ rvm:
   - 2.3.3
   - 2.4.0
 
-matrix:
-  allow_failures:
-  - rvm: 2.4.0
-
 notifications:
   disabled: true
 


### PR DESCRIPTION
I couldn't track down why these were disabled in the first place, but tests for Ruby 2.4.0 now work!