### PR TITLE
Add Cocoapods to generated list so it doesn't show in PR diffs

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -100,7 +100,7 @@ module Linguist
     #
     # Returns true or false.
     def cocoapods?
-      !!name.match(/Pods\//)
+      !!name.match(/(^Pods|\/Pods)\//)
     end
 
     # Internal: Is the blob minified files?

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -52,6 +52,7 @@ module Linguist
     # Return true or false
     def generated?
       xcode_file? ||
+      cocoapods? ||
       generated_net_designer_file? ||
       generated_net_specflow_feature_file? ||
       composer_lock? ||
@@ -93,6 +94,13 @@ module Linguist
     # Returns true of false.
     def xcode_file?
       ['.nib', '.xcworkspacedata', '.xcuserstate'].include?(extname)
+    end
+
+    # Internal: Is the blob part of Pods/, which contains dependencies not meant for humans in pull requests.
+    #
+    # Returns true or false.
+    def cocoapods?
+      !!name.match(/Pods\//)
     end
 
     # Internal: Is the blob minified files?

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -232,9 +232,6 @@
 # Carthage
 - ^Carthage/
 
-# Cocoapods
-- ^Pods/
-
 # Sparkle
 - (^|/)Sparkle/
 

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -491,9 +491,6 @@ class TestFileBlob < Minitest::Test
     # Carthage
     assert sample_blob('Carthage/blah').vendored?
 
-    # Cocoapods
-    assert sample_blob('Pods/blah').vendored?
-
     # Html5shiv
     assert sample_blob("Scripts/html5shiv.js").vendored?
     assert sample_blob("Scripts/html5shiv.min.js").vendored?

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -188,6 +188,10 @@ class TestFileBlob < Minitest::Test
     assert fixture_blob("Binary/MainMenu.nib").generated?
     assert !sample_blob("XML/project.pbxproj").generated?
 
+    # Cocoapods
+    assert sample_blob('Pods/blah').generated?
+    assert !sample_blob('My-Pods/blah').generated?
+
     # Gemfile.lock is NOT generated
     assert !sample_blob("Gemfile.lock").generated?
 

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -42,6 +42,12 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data("Dummy/foo.xcworkspacedata")
     generated_sample_without_loading_data("Dummy/foo.xcuserstate")
 
+    # Cocoapods
+    generated_sample_without_loading_data("Dummy/Pods/Pods.xcodeproj")
+    generated_sample_without_loading_data("Dummy/Pods/SwiftDependency/foo.swift")
+    generated_sample_without_loading_data("Dummy/Pods/ObjCDependency/foo.h")
+    generated_sample_without_loading_data("Dummy/Pods/ObjCDependency/foo.m")
+
     # Go-specific vendored paths
     generated_sample_without_loading_data("go/vendor/github.com/foo.go")
     generated_sample_without_loading_data("go/vendor/golang.org/src/foo.c")

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -43,6 +43,10 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data("Dummy/foo.xcuserstate")
 
     # Cocoapods
+    generated_sample_without_loading_data("Pods/Pods.xcodeproj")
+    generated_sample_without_loading_data("Pods/SwiftDependency/foo.swift")
+    generated_sample_without_loading_data("Pods/ObjCDependency/foo.h")
+    generated_sample_without_loading_data("Pods/ObjCDependency/foo.m")
     generated_sample_without_loading_data("Dummy/Pods/Pods.xcodeproj")
     generated_sample_without_loading_data("Dummy/Pods/SwiftDependency/foo.swift")
     generated_sample_without_loading_data("Dummy/Pods/ObjCDependency/foo.h")


### PR DESCRIPTION
## What ?

This PR adds the `Pods` folder to `generated.rb` to blacklist it and its contents from PR diffs, etc.

## Why ?

While many developers don't commit their `Pods` folder, there are many developers and companies who do, due to the following reasons:

1. Quicker build times in CI/CD _(this is the top reason, usually)_
2. Ability for new developers to build immediately after cloning
3. Many companies prefer keeping dependencies cloned to protect themselves from the day a project is "gone"

The problem for pushing PRs that contain changes to dependencies is that they create an impossible-to-follow PR, as well as the fact the _actual files_ changed by the developer don't get diffs as there are too many files. 

Here's just a single example but we, as well as many other companies and devs I know, have this issue:
![e1d96f3f-c3ac-40a3-a1ee-35603375e735](https://user-images.githubusercontent.com/605076/31669130-e22facfc-b35c-11e7-81f6-b99a47799b65.png)

I would appreciate your consideration of merging this change, for the sanity of iOS developers :neckbeard: 