### PR TITLE
Set color for Idris language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1921,6 +1921,7 @@ IRC log:
   language_id: 164
 Idris:
   type: programming
+  color: "#b30000"
   extensions:
   - ".idr"
   - ".lidr"


### PR DESCRIPTION
Idris is probably [big enough](https://github.com/search?l=Idris&q=idris&type=Repositories&utf8=%E2%9C%93) now to earn is its own color.

Medium red color (`#b30000`) taken from language logo:

![](https://www.idris-lang.org/logo/logo-small.png)