### PR TITLE
Correct Arduino's Color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2499,7 +2499,7 @@ M4Sugar:
   language_id: 216
 MAXScript:
   type: programming
-  color: "#00a6a6"
+  color: "#016b6b"
   extensions:
   - ".ms"
   - ".mcr"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -281,7 +281,7 @@ Arc:
   language_id: 20
 Arduino:
   type: programming
-  color: "#bd79d1"
+  color: "#00979d"
   extensions:
   - ".ino"
   tm_scope: source.c++


### PR DESCRIPTION
Change arduino's purple color representation to it's signature blue.