### PR TITLE
Add color for LFE language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2248,7 +2248,6 @@ LFE:
   color: "#4C3023"
   extensions:
   - ".lfe"
-  group: Erlang
   tm_scope: source.lisp
   ace_mode: lisp
   codemirror_mode: commonlisp

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2245,7 +2245,7 @@ Kotlin:
   language_id: 189
 LFE:
   type: programming
-  color: "#7F2119"
+  color: "#4C3023"
   extensions:
   - ".lfe"
   group: Erlang

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2245,6 +2245,7 @@ Kotlin:
   language_id: 189
 LFE:
   type: programming
+  color: "#7F2119"
   extensions:
   - ".lfe"
   group: Erlang


### PR DESCRIPTION
LFE language had no color to display in the status bar! 
LFE, I guess shouldn't be grouped. `group: Erlang` should be removed. The language is different in its own aspect as Elixir is different to Erlang. LFE contains many language designs as of CL, Scheme, Erlang. So, it wouldn't be justified to group it as LFE. 