### PR TITLE
Add BUILD.bazel to Python filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3592,6 +3592,7 @@ Python:
   - ".gclient"
   - BUCK
   - BUILD
+  - BUILD.bazel
   - SConscript
   - SConstruct
   - Snakefile


### PR DESCRIPTION
BUILD.bazel and BUILD are used by Bazel, and both are valid filenames. BUILD.bazel is used in favor of BUILD if it exists.

https://stackoverflow.com/a/43205770/521209