### PR TITLE
Unvendor tools/

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -19,9 +19,7 @@
 - (^|/)dist/
 
 # C deps
-#  https://github.com/joyent/node
 - ^deps/
-- ^tools/
 - (^|/)configure$
 - (^|/)config.guess$
 - (^|/)config.sub$

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -313,8 +313,6 @@ class TestFileBlob < Minitest::Test
     assert sample_blob("deps/http_parser/http_parser.c").vendored?
     assert sample_blob("deps/v8/src/v8.h").vendored?
 
-    assert sample_blob("tools/something/else.c").vendored?
-
     # Chart.js
     assert sample_blob("some/vendored/path/Chart.js").vendored?
     assert !sample_blob("some/vendored/path/chart.js").vendored?


### PR DESCRIPTION
As pointed out in the discussion in https://github.com/github/linguist/issues/3911, `tools/` is more commonly used for non-vendored code than vendored code.  Those that use this for vendored code, as the minority, should be using an override to mark this directory as vendored rather than the other way round.

This PR removed `tools/` from consideration for vendoring.

Fixes https://github.com/github/linguist/issues/3911