### PR TITLE
Add Carthage/Build to generated list so it doesn't show in PR diffs

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -53,6 +53,7 @@ module Linguist
     def generated?
       xcode_file? ||
       cocoapods? ||
+      carthage_build? ||
       generated_net_designer_file? ||
       generated_net_specflow_feature_file? ||
       composer_lock? ||
@@ -101,6 +102,13 @@ module Linguist
     # Returns true or false.
     def cocoapods?
       !!name.match(/(^Pods|\/Pods)\//)
+    end
+
+    # Internal: Is the blob part of Carthage/Build/, which contains dependencies not meant for humans in pull requests.
+    #
+    # Returns true or false.
+    def carthage_build?
+      !!name.match(/(^|\/)Carthage\/Build\//)
     end
 
     # Internal: Is the blob minified files?

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -192,6 +192,13 @@ class TestFileBlob < Minitest::Test
     assert sample_blob('Pods/blah').generated?
     assert !sample_blob('My-Pods/blah').generated?
 
+    # Carthage
+    assert sample_blob('Carthage/Build/blah').generated?
+    assert !sample_blob('Carthage/blah').generated?
+    assert !sample_blob('Carthage/Checkout/blah').generated?
+    assert !sample_blob('My-Carthage/Build/blah').generated?
+    assert !sample_blob('My-Carthage/Build/blah').generated?
+
     # Gemfile.lock is NOT generated
     assert !sample_blob("Gemfile.lock").generated?
 

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -52,6 +52,14 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data("Dummy/Pods/ObjCDependency/foo.h")
     generated_sample_without_loading_data("Dummy/Pods/ObjCDependency/foo.m")
 
+    # Carthage
+    generated_sample_without_loading_data("Carthage/Build/.Dependency.version")
+    generated_sample_without_loading_data("Carthage/Build/iOS/Dependency.framework")
+    generated_sample_without_loading_data("Carthage/Build/Mac/Dependency.framework")
+    generated_sample_without_loading_data("src/Carthage/Build/.Dependency.version")
+    generated_sample_without_loading_data("src/Carthage/Build/iOS/Dependency.framework")
+    generated_sample_without_loading_data("src/Carthage/Build/Mac/Dependency.framework")
+
     # Go-specific vendored paths
     generated_sample_without_loading_data("go/vendor/github.com/foo.go")
     generated_sample_without_loading_data("go/vendor/golang.org/src/foo.c")


### PR DESCRIPTION
This is equivalent to #3865, but for [`Carthage`](https://github.com/Carthage/Carthage).

## What ?

This PR adds the `Carthage/Build` folder to `generated.rb` to blacklist it and its contents from PR diffs, etc.

## Why ?

While many developers [don't commit their `Carthage/Build` folder](https://github.com/Carthage/Carthage#using-submodules-for-dependencies), there are many developers and companies who do, due to the following reasons:

- Quicker build times in CI/CD (this is the top reason, usually)
- Ability for new developers to build immediately after cloning
- Many companies prefer keeping dependencies cloned to protect themselves from the day a project is "gone"

The problem for pushing PRs that contain changes to dependencies is that they create an impossible-to-follow PR, as well as the fact the actual files changed by the developer don't get diffs as there are too many files.

This is an example from my own repo:
<img width="992" alt="screen shot 2017-11-28 at 8 58 31 am" src="https://user-images.githubusercontent.com/685609/33332907-565bec02-d41a-11e7-8211-5189e7661ae2.png">

The actual code changes there were less than 20 lines, while the diff was very hard to read due to the binary changes in `Carthage/Build`.

_Note, I chose to not add `Carthage/Checkout` because the only time people will chose to commit that is if they're using submodules, in which case I believe it's useful to see hash changes in the diffs._ 