### PR TITLE
Changed Carthage vendor regex to allow folder in any subdirectory

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -240,7 +240,7 @@
 - \.imageset/
 
 # Carthage
-- ^Carthage/
+- (^|/)Carthage/
 
 # Sparkle
 - (^|/)Sparkle/

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -492,6 +492,9 @@ class TestFileBlob < Minitest::Test
 
     # Carthage
     assert sample_blob('Carthage/blah').vendored?
+    assert sample_blob('iOS/Carthage/blah').vendored?
+    assert !sample_blob('My-Carthage/blah').vendored?
+    assert !sample_blob('iOS/My-Carthage/blah').vendored?
 
     # Html5shiv
     assert sample_blob("Scripts/html5shiv.js").vendored?


### PR DESCRIPTION
In monorepro projects, it's not uncommon for `Carthage` to not be in the root directory.