### PR TITLE
Handle repo cleanup race more elegantly

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -117,36 +117,33 @@ def git_linguist(args)
   end
 
   parser.parse!(args)
+  git_dir = `git rev-parse --git-dir`.strip
+  raise "git-linguist must be run in a Git repository" unless $?.success?
+  wrapper = GitLinguist.new(git_dir, commit, incremental)
 
-  begin
-    git_dir = `git rev-parse --git-dir`.strip
-    raise "git-linguist must be run in a Git repository" unless $?.success?
-    wrapper = GitLinguist.new(git_dir, commit, incremental)
-
-    case args.pop
-    when "stats"
-      wrapper.linguist do |linguist|
-        puts JSON.dump(linguist.languages)
-      end
-    when "breakdown"
-      wrapper.linguist do |linguist|
-        puts JSON.dump(linguist.breakdown_by_file)
-      end
-    when "dump-cache"
-      puts JSON.dump(wrapper.load_language_stats)
-    when "clear"
-      wrapper.clear_language_stats
-    when "disable"
-      wrapper.disable_language_stats
-    else
-      $stderr.print(parser.help)
-      exit 1
+  case args.pop
+  when "stats"
+    wrapper.linguist do |linguist|
+      puts JSON.dump(linguist.languages)
     end
-  rescue Exception => e
-    $stderr.puts e.message
-    $stderr.puts e.backtrace
+  when "breakdown"
+    wrapper.linguist do |linguist|
+      puts JSON.dump(linguist.breakdown_by_file)
+    end
+  when "dump-cache"
+    puts JSON.dump(wrapper.load_language_stats)
+  when "clear"
+    wrapper.clear_language_stats
+  when "disable"
+    wrapper.disable_language_stats
+  else
+    $stderr.print(parser.help)
     exit 1
   end
+rescue Exception => e
+  $stderr.puts e.message
+  $stderr.puts e.backtrace
+  exit 1
 end
 
 git_linguist(ARGV)

--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -119,7 +119,10 @@ def git_linguist(args)
   parser.parse!(args)
 
   git_dir = `git rev-parse --git-dir`.strip
-  raise "git-linguist must be run in a Git repository" unless $?.success?
+  unless $?.success?
+    $stderr.puts "git-linguist must be run in a Git repository"
+    exit 1
+  end
   wrapper = GitLinguist.new(git_dir, commit, incremental)
 
   case args.pop

--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -118,30 +118,33 @@ def git_linguist(args)
 
   parser.parse!(args)
 
-  git_dir = `git rev-parse --git-dir`.strip
-  unless $?.success?
-    $stderr.puts "git-linguist must be run in a Git repository"
-    exit 1
-  end
-  wrapper = GitLinguist.new(git_dir, commit, incremental)
+  begin
+    git_dir = `git rev-parse --git-dir`.strip
+    raise "git-linguist must be run in a Git repository" unless $?.success?
+    wrapper = GitLinguist.new(git_dir, commit, incremental)
 
-  case args.pop
-  when "stats"
-    wrapper.linguist do |linguist|
-      puts JSON.dump(linguist.languages)
+    case args.pop
+    when "stats"
+      wrapper.linguist do |linguist|
+        puts JSON.dump(linguist.languages)
+      end
+    when "breakdown"
+      wrapper.linguist do |linguist|
+        puts JSON.dump(linguist.breakdown_by_file)
+      end
+    when "dump-cache"
+      puts JSON.dump(wrapper.load_language_stats)
+    when "clear"
+      wrapper.clear_language_stats
+    when "disable"
+      wrapper.disable_language_stats
+    else
+      $stderr.print(parser.help)
+      exit 1
     end
-  when "breakdown"
-    wrapper.linguist do |linguist|
-      puts JSON.dump(linguist.breakdown_by_file)
-    end
-  when "dump-cache"
-    puts JSON.dump(wrapper.load_language_stats)
-  when "clear"
-    wrapper.clear_language_stats
-  when "disable"
-    wrapper.disable_language_stats
-  else
-    $stderr.print(parser.help)
+  rescue Exception => e
+    $stderr.puts e.message
+    $stderr.puts e.backtrace
     exit 1
   end
 end

--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -119,7 +119,7 @@ def git_linguist(args)
   parser.parse!(args)
 
   git_dir = `git rev-parse --git-dir`.strip
-  raise "git-linguist must be run in a Git repository (#{Dir.pwd})" unless $?.success?
+  raise "git-linguist must be run in a Git repository" unless $?.success?
   wrapper = GitLinguist.new(git_dir, commit, incremental)
 
   case args.pop


### PR DESCRIPTION
Due to recent changes in the way repositories are cleaned up after deletion on GitHub.com, we can find ourselves in a race where the queued linguist job runs moments after the repository cleanup job has removed the repo from disk resulting in Linguist attempting to run on a non-existent directory.

This leads to the following exception:

```
git-linguist failed: fatal: Unable to read current working directory: No such file or directory
/data/github/releases/deploy-b/vendor/gems/2.4.3/ruby/2.4.0/gems/github-linguist-5.3.3/bin/git-linguist:122:in `pwd': No such file or directory - getcwd (Errno::ENOENT)
	from /data/github/releases/deploy-b/vendor/gems/2.4.3/ruby/2.4.0/gems/github-linguist-5.3.3/bin/git-linguist:122:in `git_linguist'
	from /data/github/releases/deploy-b/vendor/gems/2.4.3/ruby/2.4.0/gems/github-linguist-5.3.3/bin/git-linguist:146:in `<top (required)>'
	from /data/github/releases/deploy-b/bin/git-linguist:8:in `load'
	from /data/github/releases/deploy-b/bin/git-linguist:8:in `<main>'
```

Yes, ideally the job should be removed before it's run, but until then, this PR goes towards addressing this by a) not attempting to print the current directory in the event it goes missing, and b) printing the error to STDERR instead of raising another exception.

The lack of the directory in the error message reduces user-friendliness ever-so-slightly, but the removal of the exception improves it vastly.

Previously when run on a non-repo directory:

```
$ ~/github/linguist/bin/git-linguist stats
fatal: Not a git repository (or any of the parent directories): .git
/Users/lildude/github/linguist/bin/git-linguist:123:in `git_linguist': git-linguist must be run in a Git repository (/Users/lildude/Downloads/trash/foo.XX) (RuntimeError)
	from /Users/lildude/github/linguist/bin/git-linguist:150:in `<main>'
$
```

Now...

```
$ ~/github/linguist/bin/git-linguist
fatal: Not a git repository (or any of the parent directories): .git
git-linguist must be run in a Git repository
$
```

I did think of keeping the directory in the message and catching `Errno::ENOENT` but that would still have left a pretty 🤢  user-experience for peeps running on the CLI and would then have led to a RuntimeError we'd need to catch to keep our internal monitoring happy.  I like to think this approach is a happy compromise.

/cc @carlosmn & https://github.com/github/github/issues/81249