### PR TITLE
Slight improvement  to .pro Prolog heuristic to avoid false positives

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -379,7 +379,7 @@ module Linguist
     end
 
     disambiguate ".pro" do |data|
-      if /^[^#]+:-/.match(data)
+      if /^[^\[#]+:-/.match(data)
         Language["Prolog"]
       elsif data.include?("last_client=")
         Language["INI"]


### PR DESCRIPTION
The `[a:-b]` syntax for index selection in arrays is valid in IDL and
matches the heuristic for Prolog. Update the Prolog heuristic to
exclude `[`.

See [EllenWasbo/getSiemensQC](https://github.com/EllenWasbo/getSiemensQC/blob/23228fb690fab1860a68f8e3cfd2d85e34ab5f8e/readctcons.pro#L96) for an example of such syntax.