### PR TITLE
compiler: Add error output to the compiler

### DIFF
--- a/script/add-grammar
+++ b/script/add-grammar
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require "optparse"
+require "open3"
 
 ROOT = File.expand_path("../../", __FILE__)
 
@@ -42,6 +43,17 @@ def log(msg)
   puts msg if $verbose
 end
 
+def command(*args)
+  log "$ #{args.join(' ')}"
+  output, status = Open3.capture2e(*args)
+  if !status.success?
+    output.each_line do |line|
+      log "  > #{line}"
+    end
+    warn "Command failed. Aborting."
+    exit 1
+  end
+end
 
 usage = """Usage:
   #{$0} [-v|--verbose] [--replace grammar] url
@@ -51,12 +63,12 @@ Examples:
 """
 
 $replace = nil
-$verbose = false
+$verbose = true
 
 OptionParser.new do |opts|
   opts.banner = usage
-  opts.on("-v", "--verbose", "Print verbose feedback to STDOUT") do
-    $verbose = true
+  opts.on("-q", "--quiet", "Do not print output unless there's a failure") do
+    $verbose = false
   end
   opts.on("-rSUBMODULE", "--replace=SUBMODDULE", "Replace an existing grammar submodule.") do |name|
     $replace = name
@@ -82,23 +94,22 @@ Dir.chdir(ROOT)
 
 if repo_old
   log "Deregistering: #{repo_old}"
-  `git submodule deinit #{repo_old}`
-  `git rm -rf #{repo_old}`
-  `script/grammar-compiler -update`
+  command('git', 'submodule', 'deinit', repo_old)
+  command('git', 'rm', '-rf', repo_old)
+  command('script/grammar-compiler', 'update', '-f')
 end
 
 log "Registering new submodule: #{repo_new}"
-`git submodule add -f #{https} #{repo_new}`
-exit 1 if $?.exitstatus > 0
-`script/grammar-compiler -add #{repo_new}`
+command('git', 'submodule', 'add', '-f', https, repo_new)
+command('script/grammar-compiler', 'add', repo_new)
 
 log "Confirming license"
 if repo_old
-  `script/licensed`
+  command('script/licensed')
 else
-  `script/licensed --module "#{repo_new}"`
+  command('script/licensed', '--module', repo_new)
 end
 
 log "Updating grammar documentation in vendor/README.md"
-`bundle exec rake samples`
-`script/list-grammars`
+command('bundle', 'exec', 'rake', 'samples')
+command('script/list-grammars')

--- a/script/grammar-compiler
+++ b/script/grammar-compiler
@@ -9,4 +9,4 @@ mkdir -p grammars
 exec docker run --rm \
     -u $(id -u $USER):$(id -g $USER) \
     -v $PWD:/src/linguist \
-    -w /src/linguist -ti $image "$@"
+    -w /src/linguist $image "$@"

--- a/tools/grammars/Gopkg.lock
+++ b/tools/grammars/Gopkg.lock
@@ -26,6 +26,12 @@
   revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
 
 [[projects]]
+  name = "github.com/urfave/cli"
+  packages = ["."]
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
+
+[[projects]]
   name = "gopkg.in/cheggaaa/pb.v1"
   packages = ["."]
   revision = "657164d0228d6bebe316fdf725c69f131a50fb10"
@@ -40,6 +46,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "eb10157687c05a542025c119a5280abe429e29141bde70dd437d48668f181861"
+  inputs-digest = "ba2e3150d728692b49e3e2d652b6ea23db82777c340e0c432cd4af6f0eef9f55"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tools/grammars/Gopkg.toml
+++ b/tools/grammars/Gopkg.toml
@@ -17,3 +17,7 @@
 [[constraint]]
   name = "gopkg.in/cheggaaa/pb.v1"
   version = "1.0.18"
+
+[[constraint]]
+  name = "github.com/urfave/cli"
+  version = "1.20.0"

--- a/tools/grammars/cmd/grammar-compiler/main.go
+++ b/tools/grammars/cmd/grammar-compiler/main.go
@@ -1,80 +1,120 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/github/linguist/tools/grammars/compiler"
+	"github.com/urfave/cli"
 )
 
-var linguistRoot = flag.String("linguist", "", "path to Linguist installation")
-var protoOut = flag.String("proto", "", "dump Protobuf library")
-var jsonOut = flag.String("json", "", "dump JSON output")
-var addGrammar = flag.String("add", "", "add a new grammar source")
-var updateList = flag.Bool("update", false, "update grammars.yml instead of verifying its contents")
-var report = flag.String("report", "", "write report to file")
+func cwd() string {
+	cwd, _ := os.Getwd()
+	return cwd
+}
 
-func fatal(err error) {
-	fmt.Fprintf(os.Stderr, "FATAL: %s\n", err)
-	os.Exit(1)
+func wrap(err error) error {
+	return cli.NewExitError(err, 255)
 }
 
 func main() {
-	flag.Parse()
+	app := cli.NewApp()
+	app.Name = "Linguist Grammars Compiler"
+	app.Usage = "Compile user-submitted grammars and check them for errors"
 
-	if _, err := exec.LookPath("csonc"); err != nil {
-		fatal(err)
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "linguist-path",
+			Value: cwd(),
+			Usage: "path to Linguist root",
+		},
 	}
 
-	if *linguistRoot == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			fatal(err)
-		}
-		*linguistRoot = cwd
+	app.Commands = []cli.Command{
+		{
+			Name:  "add",
+			Usage: "add a new grammar source",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "force, f",
+					Usage: "ignore compilation errors",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				conv, err := compiler.NewConverter(c.String("linguist-path"))
+				if err != nil {
+					return wrap(err)
+				}
+				if err := conv.AddGrammar(c.Args().First()); err != nil {
+					if !c.Bool("force") {
+						return wrap(err)
+					}
+				}
+				if err := conv.WriteGrammarList(); err != nil {
+					return wrap(err)
+				}
+				return nil
+			},
+		},
+		{
+			Name:  "update",
+			Usage: "update grammars.yml with the contents of the grammars library",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "force, f",
+					Usage: "write grammars.yml even if grammars fail to compile",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				conv, err := compiler.NewConverter(c.String("linguist-path"))
+				if err != nil {
+					return wrap(err)
+				}
+				if err := conv.ConvertGrammars(true); err != nil {
+					return wrap(err)
+				}
+				if err := conv.Report(); err != nil {
+					if !c.Bool("force") {
+						return wrap(err)
+					}
+				}
+				if err := conv.WriteGrammarList(); err != nil {
+					return wrap(err)
+				}
+				return nil
+			},
+		},
+		{
+			Name:  "compile",
+			Usage: "convert the grammars from the library",
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "proto-out, P"},
+				cli.StringFlag{Name: "out, o"},
+			},
+			Action: func(c *cli.Context) error {
+				conv, err := compiler.NewConverter(c.String("linguist-path"))
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				if err := conv.ConvertGrammars(false); err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				if out := c.String("proto-out"); out != "" {
+					if err := conv.WriteProto(out); err != nil {
+						return cli.NewExitError(err, 1)
+					}
+				}
+				if out := c.String("out"); out != "" {
+					if err := conv.WriteJSON(out); err != nil {
+						return cli.NewExitError(err, 1)
+					}
+				}
+				if err := conv.Report(); err != nil {
+					return wrap(err)
+				}
+				return nil
+			},
+		},
 	}
 
-	conv, err := compiler.NewConverter(*linguistRoot)
-	if err != nil {
-		fatal(err)
-	}
-
-	if *addGrammar != "" {
-		if err := conv.AddGrammar(*addGrammar); err != nil {
-			fatal(err)
-		}
-	}
-
-	if err := conv.ConvertGrammars(*updateList); err != nil {
-		fatal(err)
-	}
-
-	if err := conv.WriteGrammarList(); err != nil {
-		fatal(err)
-	}
-
-	if *protoOut != "" {
-		if err := conv.WriteProto(*protoOut); err != nil {
-			fatal(err)
-		}
-	}
-
-	if *jsonOut != "" {
-		if err := conv.WriteJSON(*jsonOut); err != nil {
-			fatal(err)
-		}
-	}
-
-	if *report == "" {
-		conv.Report(os.Stderr)
-	} else {
-		f, err := os.Create(*report)
-		if err != nil {
-			fatal(err)
-		}
-		conv.Report(f)
-		f.Close()
-	}
+	app.Run(os.Args)
 }

--- a/tools/grammars/compiler/loader.go
+++ b/tools/grammars/compiler/loader.go
@@ -81,7 +81,7 @@ func (repo *Repository) CompareScopes(scopes []string) {
 	}
 }
 
-func (repo *Repository) FixRules(knownScopes map[string]*Repository) {
+func (repo *Repository) FixRules(knownScopes map[string]bool) {
 	for _, file := range repo.Files {
 		w := walker{
 			File:    file,

--- a/tools/grammars/compiler/walker.go
+++ b/tools/grammars/compiler/walker.go
@@ -19,7 +19,7 @@ func (w *walker) checkInclude(rule *grammar.Rule) {
 	}
 
 	include = strings.Split(include, "#")[0]
-	_, ok := w.Known[include]
+	ok := w.Known[include]
 	if !ok {
 		if !w.Missing[include] {
 			w.Missing[include] = true
@@ -73,7 +73,7 @@ func (w *walker) walk(rule *grammar.Rule) {
 
 type walker struct {
 	File    *LoadedFile
-	Known   map[string]*Repository
+	Known   map[string]bool
 	Missing map[string]bool
 	Errors  []error
 }


### PR DESCRIPTION
The `add-grammars` script is not particularly robust. It uses backticks to spawn a lot of different commands, which means that if any of the commands fails, or returns an error message, this is disregarded.

This commit fixes the issue by refactoring the script a little bit. In my machine:

```
~/src/gopath/src/github.com/github/linguist vmg/compiler-err .$ script/add-grammar --replace language-babel https://github.com/gandm/language-babel
Deregistering: vendor/grammars/language-babel
$ git submodule deinit vendor/grammars/language-babel
$ git rm -rf vendor/grammars/language-babel
$ script/grammar-compiler update -f
Registering new submodule: vendor/grammars/language-babel
$ git submodule add -f https://github.com/gandm/language-babel vendor/grammars/language-babel
$ script/grammar-compiler add vendor/grammars/language-babel
  > The new grammar repository `vendor/grammars/language-babel` (from https://github.com/gandm/language-babel) contains 14 errors:
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(^|:|;|=|(?<=:|;|=))\s*+(\((?=((`...": subpattern name expected (at offset 52))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(?<=^|{|,)\s*+(('|\")([^"']*)(\k`...": subpattern name expected (at offset 33))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(^\s*+(?=([$\w]*\s*+\??\s*+(:|=(`...": nothing to repeat (at offset 73))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(?<!:)\s*+(\bstatic\b)?\s*+(\bas`...": subpattern name expected (at offset 78))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(?:^|;)\s*+(\bstatic\b)?\s*+(\ba`...": subpattern name expected (at offset 422))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(?<=^|{|,)\s*+(\b[_$a-zA-Z][$\w]`...": subpattern name expected (at offset 281))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(?<=^|{|,)\s*+(\b[_$a-zA-Z][$\w]`...": subpattern name expected (at offset 271))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(?<=^|{|,)\s*+(('|\")([^"']*)(\k`...": subpattern name expected (at offset 33))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`(?<=^|{|,)\s*+(('|\")([^"']*)(\k`...": subpattern name expected (at offset 33))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`\s*+((("|').*?(?<=[^\\])\k<-1>)|`...": subpattern name expected (at offset 27))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`\s*+(\basync\b)?\s*+(?=(<(?:(?>[`...": subpattern name expected (at offset 240))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`\s*+(\b[_$a-zA-Z][$\w]*)\s*+(=)\`...": subpattern name expected (at offset 271))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`\s*+(\b[A-Z][$\w]*)?(\.)(prototy`...": subpattern name expected (at offset 304))
  >     - Invalid regex in grammar: `source.js.jsx` (in `grammars/Babel Language.json`) contains a malformed regex (regex "`\s*+(\b_?[A-Z][$\w]*)?(\.)([_$a-`...": subpattern name expected (at offset 291))
  > 
  > failed to compile the given grammar
Command failed. Aborting.
```

I've also added a proper CLI interface to the compiler:

```
~/src/gopath/src/github.com/github/linguist vmg/compiler-err 1:$ ./script/grammar-compiler 
NAME:
   Linguist Grammars Compiler - Compile user-submitted grammars and check them for errors

USAGE:
   grammar-compiler [global options] command [command options] [arguments...]

VERSION:
   0.0.0

COMMANDS:
     add      add a new grammar source
     update   update grammars.yml with the contents of the grammars library
     compile  convert the grammars from the library
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --linguist-path value  path to Linguist root (default: "/src/linguist")
   --help, -h             show help
   --version, -v          print the version
```

You can now do fancier stuff like skipping errors and things.

cc @lildude 