### PR TITLE
languages: add *.BUILD support for Bazel (Python)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3592,6 +3592,7 @@ Python:
   color: "#3572A5"
   extensions:
   - ".py"
+  - ".BUILD"
   - ".bzl"
   - ".cgi"
   - ".fcgi"
@@ -3609,7 +3610,6 @@ Python:
   - ".tac"
   - ".wsgi"
   - ".xpy"
-  - ".BUILD"
   filenames:
   - ".gclient"
   - BUCK

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3609,6 +3609,7 @@ Python:
   - ".tac"
   - ".wsgi"
   - ".xpy"
+  - ".BUILD"
   filenames:
   - ".gclient"
   - BUCK

--- a/samples/Python/sqlite.BUILD
+++ b/samples/Python/sqlite.BUILD
@@ -1,0 +1,16 @@
+# Description:
+#   Sqlite3 library. Provides utilities for interacting
+#   with sqlite3 databases.
+
+licenses(["unencumbered"])  # Public Domain
+
+# exports_files(["LICENSE"])
+
+cc_library(
+    name = "sqlite",
+    srcs = ["sqlite3.c"],
+    hdrs = ["sqlite3.h"],
+    includes = ["."],
+    linkopts = ["-lm"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Many projects compiled with [Bazel](https://bazel.build) utilizes not only BUILD file but also *.BUILD files. They should be parsed as [Python](https://docs.bazel.build/versions/master/build-ref.html#core_build_language).

See examples:
* https://github.com/tensorflow/tensorflow/tree/master/third_party
* https://github.com/google/protobuf
* https://github.com/bazelbuild/rules_closure/tree/master/closure/templates