### PR TITLE
Grammar compiler invocation fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ end
 
 task :build_gem => :samples do
   rm_rf "grammars"
-  sh "script/convert-grammars"
+  sh "script/grammar-compiler compile -o grammars"
   languages = YAML.load_file("lib/linguist/languages.yml")
   File.write("lib/linguist/languages.json", Yajl.dump(languages))
   `gem build github-linguist.gemspec`

--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ end
 
 task :build_gem => :samples do
   rm_rf "grammars"
-  sh "script/grammar-compiler compile -o grammars"
+  sh "script/grammar-compiler compile -o grammars || true"
   languages = YAML.load_file("lib/linguist/languages.yml")
   File.write("lib/linguist/languages.json", Yajl.dump(languages))
   `gem build github-linguist.gemspec`


### PR DESCRIPTION
Fix our `build_gem` call. Add `|| true` because right now there are broken grammars which would block a new gem deploy.

/cc @vmg @lildude 