### PR TITLE
Do not traverse symlinks in heuristics

### DIFF
--- a/lib/linguist/blob.rb
+++ b/lib/linguist/blob.rb
@@ -11,11 +11,13 @@ module Linguist
     #
     # path    - A path String (does not necessarily exists on the file system).
     # content - Content of the file.
+    # symlink - Whether the file is a symlink.
     #
     # Returns a Blob.
-    def initialize(path, content)
+    def initialize(path, content, symlink: false)
       @path = path
       @content = content
+      @symlink = symlink
     end
 
     # Public: Filename
@@ -68,6 +70,13 @@ module Linguist
       segments.map.with_index do |segment, index|
         "." + segments[index..-1].join(".")
       end
+    end
+
+    # Public: Is this a symlink?
+    #
+    # Returns true or false.
+    def symlink?
+      @symlink
     end
   end
 end

--- a/lib/linguist/classifier.rb
+++ b/lib/linguist/classifier.rb
@@ -18,6 +18,8 @@ module Linguist
     #
     # Returns an Array of Language objects, most probable first.
     def self.call(blob, possible_languages)
+      return [] if blob.symlink?
+
       language_names = possible_languages.map(&:name)
       classify(Samples.cache, blob.data[0...CLASSIFIER_CONSIDER_BYTES], language_names).map do |name, _|
         Language[name] # Return the actual Language objects

--- a/lib/linguist/file_blob.rb
+++ b/lib/linguist/file_blob.rb
@@ -26,6 +26,11 @@ module Linguist
       @mode ||= File.stat(@fullpath).mode.to_s(8)
     end
 
+    def symlink?
+      return @symlink if !@symlink.nil?
+      @symlink = (File.symlink?(@fullpath) rescue false)
+    end
+
     # Public: Read file contents.
     #
     # Returns a String.

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -16,6 +16,8 @@ module Linguist
     #
     # Returns an Array of languages, or empty if none matched or were inconclusive.
     def self.call(blob, candidates)
+      return [] if blob.symlink?
+
       data = blob.data[0...HEURISTICS_CONSIDER_BYTES]
 
       @heuristics.each do |heuristic|

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -80,6 +80,11 @@ module Linguist
       @size
     end
 
+    def symlink?
+      # We don't create LazyBlobs for symlinks.
+      false
+    end
+
     def cleanup!
       @data.clear if @data
     end

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -11,6 +11,8 @@ module Linguist
     # Returns an Array with one Language if the blob has a shebang with a valid
     # interpreter, or empty if there is no shebang.
     def self.call(blob, _ = nil)
+      return [] if blob.symlink?
+
       Language.find_by_interpreter interpreter(blob.data)
     end
 

--- a/lib/linguist/strategy/modeline.rb
+++ b/lib/linguist/strategy/modeline.rb
@@ -109,6 +109,8 @@ module Linguist
       # Returns an Array with one Language if the blob has a Vim or Emacs modeline
       # that matches a Language name or alias. Returns an empty array if no match.
       def self.call(blob, _ = nil)
+        return [] if blob.symlink?
+
         header = blob.first_lines(SEARCH_SCOPE).join("\n")
         footer = blob.last_lines(SEARCH_SCOPE).join("\n")
         Array(Language.find_by_alias(modeline(header + footer)))


### PR DESCRIPTION
This is part of what should be a correct fix for https://github.com/github/markup/pull/1133. Changes are required in `markup` itself and dotcom to pass the symlink info through from the repository.