### PR TITLE
Allow classifier to run on symlinks as usual

### DIFF
--- a/lib/linguist/classifier.rb
+++ b/lib/linguist/classifier.rb
@@ -18,8 +18,6 @@ module Linguist
     #
     # Returns an Array of Language objects, most probable first.
     def self.call(blob, possible_languages)
-      return [] if blob.symlink?
-
       language_names = possible_languages.map(&:name)
       classify(Samples.cache, blob.data[0...CLASSIFIER_CONSIDER_BYTES], language_names).map do |name, _|
         Language[name] # Return the actual Language objects

--- a/lib/linguist/file_blob.rb
+++ b/lib/linguist/file_blob.rb
@@ -27,7 +27,7 @@ module Linguist
     end
 
     def symlink?
-      return @symlink if !@symlink.nil?
+      return @symlink if defined? @symlink
       @symlink = (File.symlink?(@fullpath) rescue false)
     end
 

--- a/samples/Markdown/symlink.md
+++ b/samples/Markdown/symlink.md
@@ -1,0 +1,1 @@
+README.mdown

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -13,8 +13,9 @@ class TestHeuristics < Minitest::Test
   end
 
   def all_fixtures(language_name, file="*")
-    Dir.glob("#{samples_path}/#{language_name}/#{file}") -
-      ["#{samples_path}/#{language_name}/filenames"]
+    fixs = Dir.glob("#{samples_path}/#{language_name}/#{file}") -
+           ["#{samples_path}/#{language_name}/filenames"]
+    fixs.reject { |f| File.symlink?(f) }
   end
 
   def test_no_match

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -14,7 +14,7 @@ class TestHeuristics < Minitest::Test
 
   def all_fixtures(language_name, file="*")
     fixs = Dir.glob("#{samples_path}/#{language_name}/#{file}") -
-           ["#{samples_path}/#{language_name}/filenames"]
+             ["#{samples_path}/#{language_name}/filenames"]
     fixs.reject { |f| File.symlink?(f) }
   end
 
@@ -22,6 +22,10 @@ class TestHeuristics < Minitest::Test
     language = []
     results = Heuristics.call(file_blob("JavaScript/namespace.js"), language)
     assert_equal [], results
+  end
+
+  def test_symlink_empty
+    assert_equal [], Heuristics.call(file_blob("Markdown/symlink.md"), [Language["Markdown"]])
   end
 
   def assert_heuristics(hash)

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -473,4 +473,10 @@ class TestLanguage < Minitest::Test
     assert_nil Language.find_by_name(',')
     assert_nil Language.find_by_alias(',')
   end
+
+  def test_detect_prefers_markdown_for_md
+    blob = Linguist::FileBlob.new(File.join(samples_path, "Markdown/symlink.md"))
+    match = Linguist.detect(blob)
+    assert_equal Language["Markdown"], match
+  end
 end


### PR DESCRIPTION
When deciding between "GCC Machine Description" and "Markdown" for `.md`, and a symlink is involved, we always choose "GCC Machine Description".

In general, if we've gotten to the end of all strategies and we're choosing between these two — i.e. we've deemed it to be "equal probability" that it's either one or the other — _however_ we've determined this, we should choose Markdown as the more likely of the two.

/cc @lildude Definitely open to other ways of doing this.