### PR TITLE
Update mac os requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install the gem:
 
 Linguist uses the [`charlock_holmes`](https://github.com/brianmario/charlock_holmes) character encoding detection library which in turn uses [ICU](http://site.icu-project.org/), and the libgit2 bindings for Ruby provided by [`rugged`](https://github.com/libgit2/rugged). These components have their own dependencies - `icu4c`, and `cmake` and `pkg-config` respectively - which you may need to install before you can install Linguist.
 
-For example, on macOS with [Homebrew](http://brew.sh/): `brew install cmake pkg-config icu4c` and on Ubuntu: `apt-get install cmake pkg-config libicu-dev`.
+For example, on macOS with [Homebrew](http://brew.sh/): `brew install ruby cmake pkg-config icu4c` and on Ubuntu: `apt-get install cmake pkg-config libicu-dev`.
 
 ### Application usage
 


### PR DESCRIPTION
Add homebrew ruby formulae to fix github-linguist install error
When running `gem install github-linguist`