### PR TITLE
Update URL for HTTP grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -412,9 +412,6 @@
 [submodule "vendor/grammars/sublime-bsv"]
 	path = vendor/grammars/sublime-bsv
 	url = https://github.com/thotypous/sublime-bsv
-[submodule "vendor/grammars/Sublime-HTTP"]
-	path = vendor/grammars/Sublime-HTTP
-	url = https://github.com/httpspec/sublime-highlighting
 [submodule "vendor/grammars/sass-textmate-bundle"]
 	path = vendor/grammars/sass-textmate-bundle
 	url = https://github.com/nathos/sass-textmate-bundle
@@ -895,3 +892,6 @@
 [submodule "vendor/grammars/JSyntax"]
 	path = vendor/grammars/JSyntax
 	url = https://github.com/tikkanz/JSyntax
+[submodule "vendor/grammars/Sublime-HTTP"]
+	path = vendor/grammars/Sublime-HTTP
+	url = https://github.com/samsalisbury/Sublime-HTTP

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -160,7 +160,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **HTML+EEX:** [elixir-lang/elixir-tmbundle](https://github.com/elixir-lang/elixir-tmbundle)
 - **HTML+ERB:** [atom/language-ruby](https://github.com/atom/language-ruby)
 - **HTML+PHP:** [textmate/php.tmbundle](https://github.com/textmate/php.tmbundle)
-- **HTTP:** [httpspec/sublime-highlighting](https://github.com/httpspec/sublime-highlighting)
+- **HTTP:** [samsalisbury/Sublime-HTTP](https://github.com/samsalisbury/Sublime-HTTP)
 - **IDL:** [mgalloy/idl.tmbundle](https://github.com/mgalloy/idl.tmbundle)
 - **Idris:** [idris-hackers/idris-sublime](https://github.com/idris-hackers/idris-sublime)
 - **Inform 7:** [erkyrath/language-inform7](https://github.com/erkyrath/language-inform7)


### PR DESCRIPTION
The HTTP grammar has been moved to a new location, from https://github.com/httpspec/sublime-highlighting to https://github.com/samsalisbury/Sublime-HTTP.