### PR TITLE
perl6 alias for Perl 6

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3362,6 +3362,8 @@ Perl 6:
   - Rexfile
   interpreters:
   - perl6
+  aliases:
+  - perl6
   tm_scope: source.perl6fe
   ace_mode: perl
   codemirror_mode: perl


### PR DESCRIPTION
As reported in #3976, many repository rely on `perl6` as a Markdown
key for code snippet highlighting. The new Perl 6 name breaks this
behavior as it requires `perl-6` as the Markdown key.