### PR TITLE
Bump escape_utils to ~> 1.2.0

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.extensions = ['ext/linguist/extconf.rb']
 
   s.add_dependency 'charlock_holmes', '~> 0.7.5'
-  s.add_dependency 'escape_utils',    '~> 1.1.0'
+  s.add_dependency 'escape_utils',    '~> 1.2.0'
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '>= 0.25.1'
 


### PR DESCRIPTION
There are very few changes between 1.1.x and 1.2.x, and I can't see any that would indicate this would break anything on GitHub.com. It does however fix https://github.com/github/linguist/issues/3797 and https://github.com/github/linguist/issues/3649 thus allowing peeps to install Linguist on Windows using rubyinstaller2.

/cc @brianmario cos of these wise words from https://github.com/oneclick/rubyinstaller2/issues/73#issuecomment-325385907

> 👋 It looks like you got the charlock_holmes issue was resolved, and the issue with escape_utils was fixed in 1.2.0. How hard would it be to bump that dependency?

I'll bump escape_utils on GitHub.com at the same time as I bump Linguist when it includes this fix.