### PR TITLE
Whitelist hideFromUser key in grammars

### DIFF
--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -26,4 +26,5 @@ var KnownFields = map[string]bool{
 	"foldingStartMarker": true,
 	"foldingEndMarker":   true,
 	"limitLineLength":    true,
+	"hideFromUser":       true,
 }


### PR DESCRIPTION
`hideFromUser` is an undocumented key from TextMate used to hide
some grammars from the user.

/cc @vmg 