### PR TITLE
script: Add build-grammars-tarball

### DIFF
--- a/script/build-grammars-tarball
+++ b/script/build-grammars-tarball
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")/.."
+rm -rf ./linguist-grammars
+./script/grammar-compiler compile -o linguist-grammars || true
+tar -zcvf linguist-grammars.tar.gz linguist-grammars
+
+


### PR DESCRIPTION
This is a very simple scripts that packages the compiled grammars so we can push a tarball for them with each Linguist release. That should make updating grammars in the website much more straightforward.

cc @github/linguist