### PR TITLE
Add syntax for Zig

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -889,6 +889,9 @@
 [submodule "vendor/grammars/sublime-varnish"]
 	path = vendor/grammars/sublime-varnish
 	url = https://github.com/brandonwamboldt/sublime-varnish
+[submodule "vendor/grammars/sublime-zig-language"]
+	path = vendor/grammars/sublime-zig-language
+	url = https://github.com/ziglang/sublime-zig-language
 [submodule "vendor/grammars/sublime_cobol"]
 	path = vendor/grammars/sublime_cobol
 	url = https://bitbucket.org/bitlang/sublime_cobol

--- a/grammars.yml
+++ b/grammars.yml
@@ -726,6 +726,8 @@ vendor/grammars/sublime-text-ox:
 - source.ox
 vendor/grammars/sublime-varnish:
 - source.varnish.vcl
+vendor/grammars/sublime-zig-language:
+- source.zig
 vendor/grammars/sublime_cobol:
 - source.acucobol
 - source.cobol

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5489,6 +5489,14 @@ Zephir:
   tm_scope: source.php.zephir
   ace_mode: php
   language_id: 410
+Zig:
+  type: programming
+  color: "#ec915c"
+  extensions:
+  - ".zig"
+  tm_scope: source.zig
+  ace_mode: text
+  language_id: 646424281
 Zimpl:
   type: programming
   extensions:

--- a/samples/Zig/cat.zig
+++ b/samples/Zig/cat.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+const io = std.io;
+const mem = std.mem;
+const os = std.os;
+const warn = std.debug.warn;
+const allocator = std.debug.global_allocator;
+
+pub fn main() !void {
+    var args_it = os.args();
+    const exe = try unwrapArg(args_it.next(allocator).?);
+    var catted_anything = false;
+    var stdout_file = try io.getStdOut();
+
+    while (args_it.next(allocator)) |arg_or_err| {
+        const arg = try unwrapArg(arg_or_err);
+        if (mem.eql(u8, arg, "-")) {
+            catted_anything = true;
+            var stdin_file = try io.getStdIn();
+            try cat_file(&stdout_file, &stdin_file);
+        } else if (arg[0] == '-') {
+            return usage(exe);
+        } else {
+            var file = os.File.openRead(arg) catch |err| {
+                warn("Unable to open file: {}\n", @errorName(err));
+                return err;
+            };
+            defer file.close();
+
+            catted_anything = true;
+            try cat_file(&stdout_file, &file);
+        }
+    }
+    if (!catted_anything) {
+        var stdin_file = try io.getStdIn();
+        try cat_file(&stdout_file, &stdin_file);
+    }
+}
+
+fn usage(exe: []const u8) !void {
+    warn("Usage: {} [FILE]...\n", exe);
+    return error.Invalid;
+}
+
+fn cat_file(stdout: *os.File, file: *os.File) !void {
+    var buf: [1024 * 4]u8 = undefined;
+
+    while (true) {
+        const bytes_read = file.read(buf[0..]) catch |err| {
+            warn("Unable to read from stream: {}\n", @errorName(err));
+            return err;
+        };
+
+        if (bytes_read == 0) {
+            break;
+        }
+
+        stdout.write(buf[0..bytes_read]) catch |err| {
+            warn("Unable to write to stdout: {}\n", @errorName(err));
+            return err;
+        };
+    }
+}
+
+fn unwrapArg(arg: anyerror![]u8) ![]u8 {
+    return arg catch |err| {
+        warn("Unable to parse command line: {}\n", err);
+        return err;
+    };
+}

--- a/samples/Zig/guess_number.zig
+++ b/samples/Zig/guess_number.zig
@@ -1,0 +1,48 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const io = std.io;
+const fmt = std.fmt;
+const os = std.os;
+
+pub fn main() !void {
+    var stdout_file = try io.getStdOut();
+    const stdout = &stdout_file.outStream().stream;
+
+    try stdout.print("Welcome to the Guess Number Game in Zig.\n");
+
+    var seed_bytes: [@sizeOf(u64)]u8 = undefined;
+    os.getRandomBytes(seed_bytes[0..]) catch |err| {
+        std.debug.warn("unable to seed random number generator: {}", err);
+        return err;
+    };
+    const seed = std.mem.readIntNative(u64, &seed_bytes);
+    var prng = std.rand.DefaultPrng.init(seed);
+
+    const answer = prng.random.range(u8, 0, 100) + 1;
+
+    while (true) {
+        try stdout.print("\nGuess a number between 1 and 100: ");
+        var line_buf: [20]u8 = undefined;
+
+        const line = io.readLineSlice(line_buf[0..]) catch |err| switch (err) {
+            error.OutOfMemory => {
+                try stdout.print("Input too long.\n");
+                continue;
+            },
+            else => return err,
+        };
+
+        const guess = fmt.parseUnsigned(u8, line, 10) catch {
+            try stdout.print("Invalid number.\n");
+            continue;
+        };
+        if (guess > answer) {
+            try stdout.print("Guess lower.\n");
+        } else if (guess < answer) {
+            try stdout.print("Guess higher.\n");
+        } else {
+            try stdout.print("You win!\n");
+            return;
+        }
+    }
+}

--- a/samples/Zig/hello.zig
+++ b/samples/Zig/hello.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+
+pub fn main() !void {
+    // If this program is run without stdout attached, exit with an error.
+    var stdout_file = try std.io.getStdOut();
+    // If this program encounters pipe failure when printing to stdout, exit
+    // with an error.
+    try stdout_file.write("Hello, world!\n");
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -434,3 +434,4 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **YARA:** [blacktop/language-yara](https://github.com/blacktop/language-yara)
 - **YASnippet:** [Alhadis/language-emacs-lisp](https://github.com/Alhadis/language-emacs-lisp)
 - **Zephir:** [phalcon/zephir-sublime](https://github.com/phalcon/zephir-sublime)
+- **Zig:** [ziglang/sublime-zig-language](https://github.com/ziglang/sublime-zig-language)

--- a/vendor/licenses/grammar/sublime-zig-language.txt
+++ b/vendor/licenses/grammar/sublime-zig-language.txt
@@ -1,7 +1,7 @@
 ---
 type: grammar
 name: sublime-zig-language
-version: 29b9a012613da924bafd68de1f9a3f27ceccf126
+version: 88fa0b243da89bda765dc40b15e632f444d9d125
 license: mit
 ---
 The MIT License (Expat)

--- a/vendor/licenses/grammar/sublime-zig-language.txt
+++ b/vendor/licenses/grammar/sublime-zig-language.txt
@@ -1,0 +1,27 @@
+---
+type: grammar
+name: sublime-zig-language
+version: 29b9a012613da924bafd68de1f9a3f27ceccf126
+license: mit
+---
+The MIT License (Expat)
+
+Copyright (c) 2018 Jeff Fowler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Hi! I'd like to add syntax support for the [Zig programming Language](http://ziglang.org/).

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?utf8=%E2%9C%93&q=import+extension%3Azig&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): from the [Zig source tree](https://github.com/zig-lang/zig/tree/ad3e2a5da07fbfe02e0152eb3fc408a7bcf36e3c/example)
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

Closes zig-lang/zig#138
Closes zig-lang/sublime-zig-language#1

Please let me know and thank you!