### PR TITLE
Track the Vue grammar's master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -544,6 +544,7 @@
 [submodule "vendor/grammars/vue-syntax-highlight"]
 	path = vendor/grammars/vue-syntax-highlight
 	url = https://github.com/vuejs/vue-syntax-highlight
+	branch = master
 [submodule "vendor/grammars/st2-zonefile"]
 	path = vendor/grammars/st2-zonefile
 	url = https://github.com/sixty4k/st2-zonefile


### PR DESCRIPTION
## Description

I was caught napping with the most recent update of the submodules which I included in v6.0.0 in that I completely missed that Vue has switched from TextMate compatible grammar to Sublime Text compatible.

As a result we pulled in but didn't convert their grammar and now Vue files aren't highlighted on GitHub.com.

Their [README](https://github.com/vuejs/vue-syntax-highlight/blob/5c2b5afbb3e71c87aca1eda626edbb4506571072/README.md) kindly points out this change:

> Note: The master branch hosts the tmLanguage based implementation that is distributed to Sublime Text build < 3153. It is also used to power GitHub's syntax highlight of *.vue files in linguist.
> 
> For a newer implementation of the syntax that is distributed to build >=3153, See the new branch.

... but the news didn't get to us before I performed the update.

This PR locks the Vue grammar to the master branch.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

This is the first grammar we're actively tracking a specific branch. We may need to do this in future if more peeps switch from TextMate to SublimeText as their default syntax.  

Elm is another that has done it and caught me 💤 and is what is causing the tests for this PR to fail but will be resolved once https://github.com/github/linguist/pull/4007 has been merged.

Tests show the correct SHA is being checked out for Vue with this change now:

```
Cloning into 'vendor/grammars/vue-syntax-highlight'...
Submodule path 'vendor/grammars/vue-syntax-highlight': checked out '5f24639e8858c0b4f34e0c80d89041b6869e10b6'
```

