### PR TITLE
compiler: Prefer specific grammar formats

### DIFF
--- a/tools/grammars/Dockerfile
+++ b/tools/grammars/Dockerfile
@@ -1,16 +1,13 @@
 FROM golang:1.9.2
 
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y curl gnupg
+WORKDIR /go/src/github.com/github/linguist/tools/grammars
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g season
-
-RUN apt-get install -y cmake
-RUN cd /tmp && git clone https://github.com/vmg/pcre
-RUN mkdir -p /tmp/pcre/build && cd /tmp/pcre/build && \
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+	apt-get update && \
+	apt-get install -y nodejs cmake && \
+	npm install -g season && \
+	cd /tmp && git clone https://github.com/vmg/pcre && \
+	mkdir -p /tmp/pcre/build && cd /tmp/pcre/build && \
 	cmake .. \
 		-DPCRE_SUPPORT_JIT=ON \
 		-DPCRE_SUPPORT_UTF=ON \
@@ -22,14 +19,12 @@ RUN mkdir -p /tmp/pcre/build && cd /tmp/pcre/build && \
 		-DPCRE_BUILD_PCREGREP=OFF \
 		-DPCRE_BUILD_TESTS=OFF \
 		-G "Unix Makefiles" && \
-    make && make install
-RUN rm -rf /tmp/pcre
+    make && make install && \
+	rm -rf /tmp/pcre && \
+	cd /go && go get -u github.com/golang/dep/cmd/dep && \
+	rm -rf /var/lib/apt/lists/*
 
-RUN go get -u github.com/golang/dep/cmd/dep
-WORKDIR /go/src/github.com/github/linguist/tools/grammars
 COPY . .
-
-RUN dep ensure
-RUN go install ./cmd/grammar-compiler
+RUN dep ensure && go install ./cmd/grammar-compiler
 
 ENTRYPOINT ["grammar-compiler"]

--- a/tools/grammars/compiler/loader_fs.go
+++ b/tools/grammars/compiler/loader_fs.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -14,14 +15,43 @@ type fsLoader struct {
 	abspath string
 }
 
+var preferredGrammars = map[string]int{
+	".tmlanguage":      0,
+	".cson":            1,
+	".json":            1,
+	".plist":           2,
+	".yaml-tmlanguage": 3,
+}
+
+func findPreferredExtension(ext []string) string {
+	if len(ext) > 1 {
+		sort.Slice(ext, func(i, j int) bool {
+			a := strings.ToLower(ext[i])
+			b := strings.ToLower(ext[j])
+			return preferredGrammars[a] < preferredGrammars[b]
+		})
+	}
+	return ext[0]
+}
+
 func (l *fsLoader) findGrammars() (files []string, err error) {
+	grammars := make(map[string][]string)
+
 	err = filepath.Walk(l.abspath,
 		func(path string, info os.FileInfo, err error) error {
 			if err == nil && isValidGrammar(path, info) {
-				files = append(files, path)
+				ext := filepath.Ext(path)
+				base := path[0 : len(path)-len(ext)]
+				grammars[base] = append(grammars[base], ext)
 			}
 			return nil
 		})
+
+	for base, ext := range grammars {
+		pref := findPreferredExtension(ext)
+		files = append(files, base+pref)
+	}
+
 	return
 }
 


### PR DESCRIPTION
The compiler was implemented with the assumption that if a repository has several files with the same name but different extension, they're all equivalent grammars (just with a different format) and any of them can be used as the compiled grammar.

This is not the case in some repositories like TypeScript or Vue, where the `.YAML-tmLanguage` file is actually a template to generate the final `.tmLanguage`.

Fix this by having a list of preferred extensions.

cc @lildude 