### PR TITLE
compiler: Do not load TreeSitter grammars

### DIFF
--- a/tools/grammars/compiler/loader.go
+++ b/tools/grammars/compiler/loader.go
@@ -108,6 +108,11 @@ func isValidGrammar(path string, info os.FileInfo) bool {
 		return false
 	}
 
+	// Tree-Sitter grammars are not supported
+	if strings.HasPrefix(filepath.Base(path), "tree-sitter-") {
+		return false
+	}
+
 	dir := filepath.Dir(path)
 	ext := filepath.Ext(path)
 


### PR DESCRIPTION
These grammars are not TextMate-compatible. Skip them!

cc @lildude 