### PR TITLE
compiler: Allow loading grammars from `syntaxes` folder

### DIFF
--- a/tools/grammars/compiler/loader.go
+++ b/tools/grammars/compiler/loader.go
@@ -122,7 +122,7 @@ func isValidGrammar(path string, info os.FileInfo) bool {
 	case ".tmlanguage", ".yaml-tmlanguage":
 		return true
 	case ".cson", ".json":
-		return strings.HasSuffix(dir, "/grammars")
+		return strings.HasSuffix(dir, "/grammars") || strings.HasSuffix(dir, "/syntaxes")
 	default:
 		return false
 	}


### PR DESCRIPTION
The standard location for Atom grammars is the `/grammars` folder, but I guess we can support this too.

cc @lildude 