### PR TITLE
Add .nims and .nimble files to Nim

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2930,6 +2930,8 @@ Nim:
   extensions:
   - ".nim"
   - ".nimrod"
+  - ".nims"
+  - ".nimble"
   ace_mode: text
   tm_scope: source.nim
   language_id: 249

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2929,9 +2929,9 @@ Nim:
   color: "#37775b"
   extensions:
   - ".nim"
+  - ".nimble"
   - ".nimrod"
   - ".nims"
-  - ".nimble"
   ace_mode: text
   tm_scope: source.nim
   language_id: 249


### PR DESCRIPTION
Add .nims (NimScript) and .nimble ([Nimble](https://github.com/nim-lang/nimble) package descriptor) file extensions to the Nim highlighter.

## Description
NimScript is a subset of Nim used for performing additional tasks while building packages, and Nimble package descriptors are also a subset that give information about a Nimble package. Since both file types are based on Nim, this pull request would highlight the files in the way regular Nim is highlighted.