### PR TITLE
Added C regex to prevent ambiguity in header file

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -76,8 +76,8 @@ module Linguist
 
     # Common heuristics
     CRegex = Regexp.union(
-        /^(char|double|short|int|long|float|unsigned|void)*\w\s*\w\s*\(\s*void\s*\)/,
-        /^(\w|\s|\*)*restrict/,
+        /^(char|double|short|int|long|float|unsigned|void)\w+\s*\(\s*void\s*\)/,
+        /\([\s\w\*]+restrict\s+/,
         /^(char|short|int|long|float|unsigned)\s+\w+\s*\[\]\s*;/
       )
     CPlusPlusRegex = Regexp.union(

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -75,6 +75,7 @@ module Linguist
     end
 
     # Common heuristics
+    CRegex = /^\s*#\s*include <(stdlib|stdio|stdarg|stdbool|stdint|stddef|setjmp|errno)\.h>/
     CPlusPlusRegex = Regexp.union(
         /^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>/,
         /^\s*template\s*</,
@@ -231,7 +232,9 @@ module Linguist
     end
 
     disambiguate ".h" do |data|
-      if ObjectiveCRegex.match(data)
+      if CRegex.match(data)
+        Language["C"]
+      elsif ObjectiveCRegex.match(data)
         Language["Objective-C"]
       elsif CPlusPlusRegex.match(data)
         Language["C++"]

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -76,9 +76,9 @@ module Linguist
 
     # Common heuristics
     CRegex = Regexp.union(
-        /^(char|double|short|int|long|float|unsigned|void)\w+\s*\(\s*void\s*\)/,
+        /\b(char|double|short|int|long|float|unsigned|void)\s+\w+\s*\(\s*void\s*\)/,
         /\([\s\w\*]+restrict\s+/,
-        /^(char|short|int|long|float|unsigned)\s+\w+\s*\[\]\s*;/
+        /\b(char|short|int|long|float|unsigned)\s+\w+\s*\[\]\s*;/
       )
     CPlusPlusRegex = Regexp.union(
         /^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>/,

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -78,7 +78,7 @@ module Linguist
     CRegex = Regexp.union(
         /^(char|double|short|int|long|float|unsigned|void)*\w\s*\w\s*\(\s*void\s*\)/,
         /^(\w|\s|\*)*restrict/,
-        /^(char|short|int|long|float|unsigned)*\s+\w+\s*\[\]\s*;/
+        /^(char|short|int|long|float|unsigned)\s+\w+\s*\[\]\s*;/
       )
     CPlusPlusRegex = Regexp.union(
         /^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>/,

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -75,7 +75,11 @@ module Linguist
     end
 
     # Common heuristics
-    CRegex = /^\s*#\s*include <(stdlib|stdio|stdarg|stdbool|stdint|stddef|setjmp|errno)\.h>/
+    CRegex = Regexp.union(
+        /^(char|double|short|int|long|float|unsigned|void)*\w\s*\w\s*\(\s*void\s*\)/,
+        /^(\w|\s|\*)*restrict/,
+        /^(char|short|int|long|float|unsigned)*\s+\w+\s*\[\]\s*;/
+      )
     CPlusPlusRegex = Regexp.union(
         /^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>/,
         /^\s*template\s*</,

--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -77,7 +77,7 @@ module Linguist
     # Common heuristics
     CRegex = Regexp.union(
         /\b(char|double|short|int|long|float|unsigned|void)\s+\w+\s*\(\s*void\s*\)/,
-        /\([\s\w\*]+restrict\s+/,
+        /\([\sa-zA-Z0-9\*]+restrict\s+/,
         /\b(char|short|int|long|float|unsigned)\s+\w+\s*\[\]\s*;/
       )
     CPlusPlusRegex = Regexp.union(
@@ -236,12 +236,12 @@ module Linguist
     end
 
     disambiguate ".h" do |data|
-      if CRegex.match(data)
-        Language["C"]
-      elsif ObjectiveCRegex.match(data)
+      if ObjectiveCRegex.match(data)
         Language["Objective-C"]
       elsif CPlusPlusRegex.match(data)
         Language["C++"]
+      elsif CRegex.match(data)
+        Language["C"]
       end
     end
 


### PR DESCRIPTION
Adding a C regex for disambiguation of `.h` files

## Description

Basically, my C header file is getting incorrectly classified as Objective-C. While overrides can fix this, it would be good to have a regex detecting C-only standard header includes. 

https://github.com/jweinst1/DataBlock/blob/master/src/DataBlock.h

That is the url to the incorrectly categorized file.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s): https://github.com/jweinst1/DataBlock/blob/master/src/DataBlock.h
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
