### PR TITLE
Treat "python3" as an alias for "python"

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3632,6 +3632,7 @@ Python:
   - python3
   aliases:
   - rusthon
+  - python3
   language_id: 303
 Python console:
   type: programming


### PR DESCRIPTION
Pygments has separate highlighters for "python" (meaning python 2) and "python3" (meaning python 3). As a result, there are lots of files out there (especially ReSTructured text) that contain code blocks whose language is explicitly given as "python3". Currently these are unrecognized by linguist. Instead, we should use our python highlighter for them (which works for both python 2 and python 3).

References:
  http://pygments.org/docs/lexers/#pygments.lexers.python.Python3Lexer
  https://github.com/github/markup/issues/1019
  https://github.com/python-trio/async_generator/pull/12
