### PR TITLE
WIP Experiment: Lets see if we can finally get JSX working properly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -739,9 +739,6 @@
 [submodule "vendor/grammars/language-emacs-lisp"]
 	path = vendor/grammars/language-emacs-lisp
 	url = https://github.com/Alhadis/language-emacs-lisp
-[submodule "vendor/grammars/language-babel"]
-	path = vendor/grammars/language-babel
-	url = https://github.com/github-linguist/language-babel
 [submodule "vendor/CodeMirror"]
 	path = vendor/CodeMirror
 	url = https://github.com/codemirror/CodeMirror
@@ -898,3 +895,6 @@
 [submodule "vendor/grammars/atom-language-nextflow"]
 	path = vendor/grammars/atom-language-nextflow
 	url = https://github.com/nextflow-io/atom-language-nextflow
+[submodule "vendor/grammars/language-babel"]
+	path = vendor/grammars/language-babel
+	url = https://github.com/lildude/language-babel

--- a/.gitmodules
+++ b/.gitmodules
@@ -898,3 +898,4 @@
 [submodule "vendor/grammars/language-babel"]
 	path = vendor/grammars/language-babel
 	url = https://github.com/lildude/language-babel
+	branch = make-pcre-friendly

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -181,7 +181,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **JSON5:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **JSONiq:** [wcandillon/language-jsoniq](https://github.com/wcandillon/language-jsoniq)
 - **JSONLD:** [atom/language-javascript](https://github.com/atom/language-javascript)
-- **JSX:** [github-linguist/language-babel](https://github.com/github-linguist/language-babel)
+- **JSX:** [lildude/language-babel](https://github.com/lildude/language-babel)
 - **Julia:** [JuliaEditorSupport/atom-language-julia](https://github.com/JuliaEditorSupport/atom-language-julia)
 - **Jupyter Notebook:** [textmate/json.tmbundle](https://github.com/textmate/json.tmbundle)
 - **KiCad Layout:** [Alhadis/language-pcb](https://github.com/Alhadis/language-pcb)


### PR DESCRIPTION
This is an experiment I'm starting to see what it would take to finally get the JSX syntax highlighting issues sorted out.

For the most part we're held back by the fact the upstream grammar introduced changes that include oniguruma-only regexes and GitHub.com (and Lightshow) need PCRE-friendly grammars.

This PR pulls in the work I'm doing in a PR against my own fork at https://github.com/lildude/language-babel/pull/1 in which I document the changes I've made whilst at the same time trying to automate the changes and opens up the dialogue channel where. If things are simple enough, we _might_ be able to convince the upstream author to accept a PR to switch to PCRE-friendly regexes, but if not, the automation should allow me to add the script to our fork so we can update automatically with each update. It'd be a PITA, but we'll see.

@pchaigno @Alhadis I'd really appreciate your comments, thoughts and findings. I'm not a grammar expert so am flying by the seat of my 👖  for the most part 😄 . I'll slowly work on my fork as and when I spot issues that cause us problems.  Feel free to comment in this PR or https://github.com/lildude/language-babel/pull/1

/ref https://github.com/github/linguist/issues/3044 https://github.com/github/linguist/issues/3775 