### PR TITLE
Whitelist injectionSelector in grammars

### DIFF
--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -27,4 +27,5 @@ var KnownFields = map[string]bool{
 	"foldingEndMarker":   true,
 	"limitLineLength":    true,
 	"hideFromUser":       true,
+	"injectionSelector":  true,
 }


### PR DESCRIPTION
`injectionSelector` is an (undocumented?) key for Atom. See cdibbs/language-jison#17 for details.

/cc @vmg