### PR TITLE
Add notes about gitattributes usage (see #4050)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,7 @@ $ cat .gitattributes
 *.rb linguist-language=Java
 ```
 
-Note that, when using Linguist locally, `.gitattributes` must be committed again each time it is modified for Linguist to take it into account. Also note that you might need to use wildcards to match files deeper than top-level ones.
-
-```
+```console
 $ cat .gitattributes
 build/* linguist-vendored     # will match build/* but not dist/build/*
 **/build/* linguist-vendored  # will match build/* and dist/build/*

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ cat .gitattributes
 *.rb linguist-language=Java
 ```
 
-Note that, when using Linguist locally, `.gitattributes` must be committed again each time it is modified for Linguist to take it into account. Also note that Linguist requires that you match files and not directories in `.gitattributes`. You might need to use wildcards to match files deeper than top-level ones.
+Note that, when using Linguist locally, `.gitattributes` must be committed again each time it is modified for Linguist to take it into account. Also note that you might need to use wildcards to match files deeper than top-level ones.
 
 ```
 $ cat .gitattributes

--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ $ cat .gitattributes
 *.rb linguist-language=Java
 ```
 
-Note that, when using Linguist locally, `.gitattributes` must be committed again each time it is modified for Linguist to take it into account. Also note that `.gitattributes` patterns are not equivalent to `.gitignore` ones. You may need to use wildcards to match files in subdirectories:
+Note that, when using Linguist locally, `.gitattributes` must be committed again each time it is modified for Linguist to take it into account. Also note that Linguist requires that you match files and not directories in `.gitattributes`. You might need to use wildcards to match files deeper than top-level ones.
 
-```$ cat .gitattributes
-**/build/* linguist-vendored
+```
+$ cat .gitattributes
+build/* linguist-vendored     # will match build/* but not dist/build/*
+**/build/* linguist-vendored  # will match build/* and dist/build/*
 ```
 
 #### Vendored code

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ $ cat .gitattributes
 *.rb linguist-language=Java
 ```
 
+Note that, when using Linguist locally, `.gitattributes` must be committed again each time it is modified for Linguist to take it into account. Also note that `.gitattributes` patterns are not equivalent to `.gitignore` ones. You may need to use wildcards to match files in subdirectories:
+
+```$ cat .gitattributes
+**/build/* linguist-vendored
+```
+
 #### Vendored code
 
 Checking code you didn't write, such as JavaScript libraries, into your git repo is a common practice, but this often inflates your project's language stats and may even cause your project to be labeled as another language. By default, Linguist treats all of the paths defined in [`vendor.yml`](/lib/linguist/vendor.yml) as vendored and therefore doesn't include them in the language statistics for a repository.


### PR DESCRIPTION
`.gitattributes` must be committed again after each modification.

Also a `licenses/*` pattern won't match the `licenses` sub-sub-directory's files, we need to use `**/licenses/*`.

But it's confusing me a lot because [Git documentation itself](https://www.git-scm.com/docs/gitattributes) says the patterns in `.gitignore` and `.gitattributes` will match the files the same way:

> The rules how the pattern matches paths are the same as in .gitignore files; see gitignore.

Did I miss something here?
