### PR TITLE
Add script to alphabetise submodule list

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,216 +1,204 @@
-[submodule "vendor/grammars/go-tmbundle"]
-	path = vendor/grammars/go-tmbundle
-	url = https://github.com/AlanQuatermain/go-tmbundle
-[submodule "vendor/grammars/PHP-Twig.tmbundle"]
-	path = vendor/grammars/PHP-Twig.tmbundle
-	url = https://github.com/Anomareh/PHP-Twig.tmbundle
-[submodule "vendor/grammars/sublime-cirru"]
-	path = vendor/grammars/sublime-cirru
-	url = https://github.com/Cirru/sublime-cirru
-[submodule "vendor/grammars/SublimeBrainfuck"]
-	path = vendor/grammars/SublimeBrainfuck
-	url = https://github.com/Drako/SublimeBrainfuck
-[submodule "vendor/grammars/awk-sublime"]
-	path = vendor/grammars/awk-sublime
-	url = https://github.com/github-linguist/awk-sublime
-[submodule "vendor/grammars/Sublime-SQF-Language"]
-	path = vendor/grammars/Sublime-SQF-Language
-	url = https://github.com/JonBons/Sublime-SQF-Language
-[submodule "vendor/grammars/SCSS.tmbundle"]
-	path = vendor/grammars/SCSS.tmbundle
-	url = https://github.com/MarioRicalde/SCSS.tmbundle
-[submodule "vendor/grammars/Sublime-REBOL"]
-	path = vendor/grammars/Sublime-REBOL
-	url = https://github.com/Oldes/Sublime-REBOL
-[submodule "vendor/grammars/language-viml"]
-	path = vendor/grammars/language-viml
-	url = https://github.com/Alhadis/language-viml
+[submodule "vendor/CodeMirror"]
+	path = vendor/CodeMirror
+	url = https://github.com/codemirror/CodeMirror
+[submodule "vendor/grammars/ABNF.tmbundle"]
+	path = vendor/grammars/ABNF.tmbundle
+	url = https://github.com/sanssecours/ABNF.tmbundle
+[submodule "vendor/grammars/Agda.tmbundle"]
+	path = vendor/grammars/Agda.tmbundle
+	url = https://github.com/mokus0/Agda.tmbundle
+[submodule "vendor/grammars/Alloy.tmbundle"]
+	path = vendor/grammars/Alloy.tmbundle
+	url = https://github.com/macekond/Alloy.tmbundle
+[submodule "vendor/grammars/AutoHotkey"]
+	path = vendor/grammars/AutoHotkey
+	url = https://github.com/ahkscript/SublimeAutoHotkey
+[submodule "vendor/grammars/BrightScript.tmbundle"]
+	path = vendor/grammars/BrightScript.tmbundle
+	url = https://github.com/cmink/BrightScript.tmbundle
 [submodule "vendor/grammars/ColdFusion"]
 	path = vendor/grammars/ColdFusion
 	url = https://github.com/SublimeText/ColdFusion
+[submodule "vendor/grammars/Docker.tmbundle"]
+	path = vendor/grammars/Docker.tmbundle
+	url = https://github.com/asbjornenge/Docker.tmbundle
+[submodule "vendor/grammars/EBNF.tmbundle"]
+	path = vendor/grammars/EBNF.tmbundle
+	url = https://github.com/sanssecours/EBNF.tmbundle
+[submodule "vendor/grammars/Elm"]
+	path = vendor/grammars/Elm
+	url = https://github.com/elm-community/Elm.tmLanguage
+[submodule "vendor/grammars/FreeMarker.tmbundle"]
+	path = vendor/grammars/FreeMarker.tmbundle
+	url = https://github.com/freemarker/FreeMarker.tmbundle
+[submodule "vendor/grammars/G-Code"]
+	path = vendor/grammars/G-Code
+	url = https://github.com/robotmaster/sublime-text-syntax-highlighting
+[submodule "vendor/grammars/Handlebars"]
+	path = vendor/grammars/Handlebars
+	url = https://github.com/daaain/Handlebars
+[submodule "vendor/grammars/IDL-Syntax"]
+	path = vendor/grammars/IDL-Syntax
+	url = https://github.com/andik/IDL-Syntax
+[submodule "vendor/grammars/Isabelle.tmbundle"]
+	path = vendor/grammars/Isabelle.tmbundle
+	url = https://github.com/lsf37/Isabelle.tmbundle
+[submodule "vendor/grammars/JSyntax"]
+	path = vendor/grammars/JSyntax
+	url = https://github.com/tikkanz/JSyntax
+[submodule "vendor/grammars/Lean.tmbundle"]
+	path = vendor/grammars/Lean.tmbundle
+	url = https://github.com/leanprover/Lean.tmbundle
+[submodule "vendor/grammars/LiveScript.tmbundle"]
+	path = vendor/grammars/LiveScript.tmbundle
+	url = https://github.com/paulmillr/LiveScript.tmbundle
+[submodule "vendor/grammars/MATLAB-Language-grammar"]
+	path = vendor/grammars/MATLAB-Language-grammar
+	url = https://github.com/mathworks/MATLAB-Language-grammar
+[submodule "vendor/grammars/MQL5-sublime"]
+	path = vendor/grammars/MQL5-sublime
+	url = https://github.com/mqsoft/MQL5-sublime
+[submodule "vendor/grammars/MagicPython"]
+	path = vendor/grammars/MagicPython
+	url = https://github.com/MagicStack/MagicPython
+[submodule "vendor/grammars/Modelica"]
+	path = vendor/grammars/Modelica
+	url = https://github.com/BorisChumichev/modelicaSublimeTextPackage
 [submodule "vendor/grammars/NSIS"]
 	path = vendor/grammars/NSIS
 	url = https://github.com/github-linguist/NSIS
 [submodule "vendor/grammars/NimLime"]
 	path = vendor/grammars/NimLime
 	url = https://github.com/Varriount/NimLime
-[submodule "vendor/grammars/gradle.tmbundle"]
-	path = vendor/grammars/gradle.tmbundle
-	url = https://github.com/alkemist/gradle.tmbundle
-[submodule "vendor/grammars/Sublime-Loom"]
-	path = vendor/grammars/Sublime-Loom
-	url = https://github.com/ambethia/Sublime-Loom
-[submodule "vendor/grammars/VBDotNetSyntax"]
-	path = vendor/grammars/VBDotNetSyntax
-	url = https://github.com/angryant0007/VBDotNetSyntax
-[submodule "vendor/grammars/cool-tmbundle"]
-	path = vendor/grammars/cool-tmbundle
-	url = https://github.com/anunayk/cool-tmbundle
-[submodule "vendor/grammars/Docker.tmbundle"]
-	path = vendor/grammars/Docker.tmbundle
-	url = https://github.com/asbjornenge/Docker.tmbundle
-[submodule "vendor/grammars/jasmin-sublime"]
-	path = vendor/grammars/jasmin-sublime
-	url = https://github.com/atmarksharp/jasmin-sublime
-[submodule "vendor/grammars/language-clojure"]
-	path = vendor/grammars/language-clojure
-	url = https://github.com/atom/language-clojure
-[submodule "vendor/grammars/language-coffee-script"]
-	path = vendor/grammars/language-coffee-script
-	url = https://github.com/atom/language-coffee-script
-[submodule "vendor/grammars/language-csharp"]
-	path = vendor/grammars/language-csharp
-	url = https://github.com/atom/language-csharp
-[submodule "vendor/grammars/language-gfm"]
-	path = vendor/grammars/language-gfm
-	url = https://github.com/atom/language-gfm
-[submodule "vendor/grammars/language-javascript"]
-	path = vendor/grammars/language-javascript
-	url = https://github.com/atom/language-javascript
-[submodule "vendor/grammars/language-shellscript"]
-	path = vendor/grammars/language-shellscript
-	url = https://github.com/atom/language-shellscript
-[submodule "vendor/grammars/language-supercollider"]
-	path = vendor/grammars/language-supercollider
-	url = https://github.com/supercollider/language-supercollider
-[submodule "vendor/grammars/language-yaml"]
-	path = vendor/grammars/language-yaml
-	url = https://github.com/atom/language-yaml
-[submodule "vendor/grammars/Sublime-Lasso"]
-	path = vendor/grammars/Sublime-Lasso
-	url = https://github.com/bfad/Sublime-Lasso
-[submodule "vendor/grammars/chapel-tmbundle"]
-	path = vendor/grammars/chapel-tmbundle
-	url = https://github.com/chapel-lang/chapel-tmbundle
-[submodule "vendor/grammars/sublime-nginx"]
-	path = vendor/grammars/sublime-nginx
-	url = https://github.com/brandonwamboldt/sublime-nginx
-[submodule "vendor/grammars/bro-sublime"]
-	path = vendor/grammars/bro-sublime
-	url = https://github.com/bro/bro-sublime
-[submodule "vendor/grammars/sublime-MuPAD"]
-	path = vendor/grammars/sublime-MuPAD
-	url = https://github.com/ccreutzig/sublime-MuPAD
-[submodule "vendor/grammars/haxe-sublime-bundle"]
-	path = vendor/grammars/haxe-sublime-bundle
-	url = https://github.com/clemos/haxe-sublime-bundle
-[submodule "vendor/grammars/cucumber-tmbundle"]
-	path = vendor/grammars/cucumber-tmbundle
-	url = https://github.com/cucumber/cucumber-tmbundle
-[submodule "vendor/grammars/powershell"]
-	path = vendor/grammars/powershell
-	url = https://github.com/SublimeText/PowerShell
-[submodule "vendor/grammars/jade-tmbundle"]
-	path = vendor/grammars/jade-tmbundle
-	url = https://github.com/davidrios/jade-tmbundle
-[submodule "vendor/grammars/elixir-tmbundle"]
-	path = vendor/grammars/elixir-tmbundle
-	url = https://github.com/elixir-lang/elixir-tmbundle
-[submodule "vendor/grammars/sublime-glsl"]
-	path = vendor/grammars/sublime-glsl
-	url = https://github.com/euler0/sublime-glsl
-[submodule "vendor/grammars/fancy-tmbundle"]
-	path = vendor/grammars/fancy-tmbundle
-	url = https://github.com/fancy-lang/fancy-tmbundle
-[submodule "vendor/grammars/sublimetext-cuda-cpp"]
-	path = vendor/grammars/sublimetext-cuda-cpp
-	url = https://github.com/harrism/sublimetext-cuda-cpp
-[submodule "vendor/grammars/pike-textmate"]
-	path = vendor/grammars/pike-textmate
-	url = https://github.com/hww3/pike-textmate
-[submodule "vendor/grammars/ceylon-sublimetext"]
-	path = vendor/grammars/ceylon-sublimetext
-	url = https://github.com/jeancharles-roger/ceylon-sublimetext
-[submodule "vendor/grammars/Sublime-Text-2-OpenEdge-ABL"]
-	path = vendor/grammars/Sublime-Text-2-OpenEdge-ABL
-	url = https://github.com/jfairbank/Sublime-Text-2-OpenEdge-ABL
-[submodule "vendor/grammars/sublime-befunge"]
-	path = vendor/grammars/sublime-befunge
-	url = https://github.com/johanasplund/sublime-befunge
+[submodule "vendor/grammars/PHP-Twig.tmbundle"]
+	path = vendor/grammars/PHP-Twig.tmbundle
+	url = https://github.com/Anomareh/PHP-Twig.tmbundle
+[submodule "vendor/grammars/PogoScript.tmbundle"]
+	path = vendor/grammars/PogoScript.tmbundle
+	url = https://github.com/featurist/PogoScript.tmbundle
 [submodule "vendor/grammars/RDoc.tmbundle"]
 	path = vendor/grammars/RDoc.tmbundle
 	url = https://github.com/joshaven/RDoc.tmbundle
-[submodule "vendor/grammars/Textmate-Gosu-Bundle"]
-	path = vendor/grammars/Textmate-Gosu-Bundle
-	url = https://github.com/jpcamara/Textmate-Gosu-Bundle
-[submodule "vendor/grammars/fish-tmbundle"]
-	path = vendor/grammars/fish-tmbundle
-	url = https://github.com/l15n/fish-tmbundle
-[submodule "vendor/grammars/moonscript-tmbundle"]
-	path = vendor/grammars/moonscript-tmbundle
-	url = https://github.com/leafo/moonscript-tmbundle
-[submodule "vendor/grammars/Isabelle.tmbundle"]
-	path = vendor/grammars/Isabelle.tmbundle
-	url = https://github.com/lsf37/Isabelle.tmbundle
-[submodule "vendor/grammars/Alloy.tmbundle"]
-	path = vendor/grammars/Alloy.tmbundle
-	url = https://github.com/macekond/Alloy.tmbundle
-[submodule "vendor/grammars/opa.tmbundle"]
-	path = vendor/grammars/opa.tmbundle
-	url = https://github.com/mads379/opa.tmbundle
-[submodule "vendor/grammars/vscode-scala-syntax"]
-	path = vendor/grammars/vscode-scala-syntax
-	url = https://github.com/scala/vscode-scala-syntax
-[submodule "vendor/grammars/scala.tmbundle"]
-	path = vendor/grammars/scala.tmbundle
-	url = https://github.com/mads379/scala.tmbundle
-[submodule "vendor/grammars/mako-tmbundle"]
-	path = vendor/grammars/mako-tmbundle
-	url = https://github.com/marconi/mako-tmbundle
-[submodule "vendor/grammars/gnuplot-tmbundle"]
-	path = vendor/grammars/gnuplot-tmbundle
-	url = https://github.com/mattfoster/gnuplot-tmbundle
-[submodule "vendor/grammars/idl.tmbundle"]
-	path = vendor/grammars/idl.tmbundle
-	url = https://github.com/mgalloy/idl.tmbundle
-[submodule "vendor/grammars/protobuf-tmbundle"]
-	path = vendor/grammars/protobuf-tmbundle
-	url = https://github.com/michaeledgar/protobuf-tmbundle
-[submodule "vendor/grammars/Sublime-Coq"]
-	path = vendor/grammars/Sublime-Coq
-	url = https://github.com/mkolosick/Sublime-Coq
-[submodule "vendor/grammars/Agda.tmbundle"]
-	path = vendor/grammars/Agda.tmbundle
-	url = https://github.com/mokus0/Agda.tmbundle
-[submodule "vendor/grammars/ooc.tmbundle"]
-	path = vendor/grammars/ooc.tmbundle
-	url = https://github.com/nilium/ooc.tmbundle
-[submodule "vendor/grammars/LiveScript.tmbundle"]
-	path = vendor/grammars/LiveScript.tmbundle
-	url = https://github.com/paulmillr/LiveScript.tmbundle
-[submodule "vendor/grammars/sublime-tea"]
-	path = vendor/grammars/sublime-tea
-	url = https://github.com/pferruggiaro/sublime-tea
-[submodule "vendor/grammars/abap.tmbundle"]
-	path = vendor/grammars/abap.tmbundle
-	url = https://github.com/pvl/abap.tmbundle
-[submodule "vendor/grammars/mercury-tmlanguage"]
-	path = vendor/grammars/mercury-tmlanguage
-	url = https://github.com/sebgod/mercury-tmlanguage
-[submodule "vendor/grammars/mathematica-tmbundle"]
-	path = vendor/grammars/mathematica-tmbundle
-	url = https://github.com/shadanan/mathematica-tmbundle
-[submodule "vendor/grammars/sublime-robot-plugin"]
-	path = vendor/grammars/sublime-robot-plugin
-	url = https://github.com/shellderp/sublime-robot-plugin
-[submodule "vendor/grammars/Sublime-QML"]
-	path = vendor/grammars/Sublime-QML
-	url = https://github.com/skozlovf/Sublime-QML
+[submodule "vendor/grammars/Racket"]
+	path = vendor/grammars/Racket
+	url = https://github.com/soegaard/racket-highlight-for-github
+[submodule "vendor/grammars/SCSS.tmbundle"]
+	path = vendor/grammars/SCSS.tmbundle
+	url = https://github.com/MarioRicalde/SCSS.tmbundle
+[submodule "vendor/grammars/SMT.tmbundle"]
+	path = vendor/grammars/SMT.tmbundle
+	url = https://github.com/SRI-CSL/SMT.tmbundle.git
+[submodule "vendor/grammars/Scalate.tmbundle"]
+	path = vendor/grammars/Scalate.tmbundle
+	url = https://github.com/scalate/Scalate.tmbundle
 [submodule "vendor/grammars/Slash.tmbundle"]
 	path = vendor/grammars/Slash.tmbundle
 	url = https://github.com/slash-lang/Slash.tmbundle
-[submodule "vendor/grammars/factor"]
-	path = vendor/grammars/factor
-	url = https://github.com/slavapestov/factor
-[submodule "vendor/grammars/ruby-slim.tmbundle"]
-	path = vendor/grammars/ruby-slim.tmbundle
-	url = https://github.com/slim-template/ruby-slim.tmbundle
+[submodule "vendor/grammars/Stata.tmbundle"]
+	path = vendor/grammars/Stata.tmbundle
+	url = https://github.com/pschumm/Stata.tmbundle
+[submodule "vendor/grammars/Stylus"]
+	path = vendor/grammars/Stylus
+	url = https://github.com/billymoon/Stylus
+[submodule "vendor/grammars/Sublime-Coq"]
+	path = vendor/grammars/Sublime-Coq
+	url = https://github.com/mkolosick/Sublime-Coq
+[submodule "vendor/grammars/Sublime-HTTP"]
+	path = vendor/grammars/Sublime-HTTP
+	url = https://github.com/samsalisbury/Sublime-HTTP
+[submodule "vendor/grammars/Sublime-Lasso"]
+	path = vendor/grammars/Sublime-Lasso
+	url = https://github.com/bfad/Sublime-Lasso
+[submodule "vendor/grammars/Sublime-Loom"]
+	path = vendor/grammars/Sublime-Loom
+	url = https://github.com/ambethia/Sublime-Loom
+[submodule "vendor/grammars/Sublime-Modula-2"]
+	path = vendor/grammars/Sublime-Modula-2
+	url = https://github.com/harogaston/Sublime-Modula-2
+[submodule "vendor/grammars/Sublime-Nit"]
+	path = vendor/grammars/Sublime-Nit
+	url = https://github.com/R4PaSs/Sublime-Nit
+[submodule "vendor/grammars/Sublime-Pep8"]
+	path = vendor/grammars/Sublime-Pep8
+	url = https://github.com/R4PaSs/Sublime-Pep8
+[submodule "vendor/grammars/Sublime-QML"]
+	path = vendor/grammars/Sublime-QML
+	url = https://github.com/skozlovf/Sublime-QML
+[submodule "vendor/grammars/Sublime-REBOL"]
+	path = vendor/grammars/Sublime-REBOL
+	url = https://github.com/Oldes/Sublime-REBOL
+[submodule "vendor/grammars/Sublime-Red"]
+	path = vendor/grammars/Sublime-Red
+	url = https://github.com/Oldes/Sublime-Red
+[submodule "vendor/grammars/Sublime-SQF-Language"]
+	path = vendor/grammars/Sublime-SQF-Language
+	url = https://github.com/JonBons/Sublime-SQF-Language
+[submodule "vendor/grammars/Sublime-Text-2-OpenEdge-ABL"]
+	path = vendor/grammars/Sublime-Text-2-OpenEdge-ABL
+	url = https://github.com/jfairbank/Sublime-Text-2-OpenEdge-ABL
+[submodule "vendor/grammars/SublimeBrainfuck"]
+	path = vendor/grammars/SublimeBrainfuck
+	url = https://github.com/Drako/SublimeBrainfuck
+[submodule "vendor/grammars/SublimeClarion"]
+	path = vendor/grammars/SublimeClarion
+	url = https://github.com/fushnisoft/SublimeClarion
+[submodule "vendor/grammars/SublimeEthereum"]
+	path = vendor/grammars/SublimeEthereum
+	url = https://github.com/davidhq/SublimeEthereum.git
+[submodule "vendor/grammars/SublimeGDB"]
+	path = vendor/grammars/SublimeGDB
+	url = https://github.com/quarnster/SublimeGDB
+[submodule "vendor/grammars/SublimePapyrus"]
+	path = vendor/grammars/SublimePapyrus
+	url = https://github.com/Kapiainen/SublimePapyrus
+[submodule "vendor/grammars/SublimePuppet"]
+	path = vendor/grammars/SublimePuppet
+	url = https://github.com/russCloak/SublimePuppet
 [submodule "vendor/grammars/SublimeXtend"]
 	path = vendor/grammars/SublimeXtend
 	url = https://github.com/staltz/SublimeXtend
+[submodule "vendor/grammars/Syntax-highlighting-for-PostCSS"]
+	path = vendor/grammars/Syntax-highlighting-for-PostCSS
+	url = https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS
+[submodule "vendor/grammars/TLA"]
+	path = vendor/grammars/TLA
+	url = https://github.com/agentultra/TLAGrammar
+[submodule "vendor/grammars/TXL"]
+	path = vendor/grammars/TXL
+	url = https://github.com/MikeHoffert/Sublime-Text-TXL-syntax
+[submodule "vendor/grammars/Terraform.tmLanguage"]
+	path = vendor/grammars/Terraform.tmLanguage
+	url = https://github.com/alexlouden/Terraform.tmLanguage
+[submodule "vendor/grammars/Textmate-Gosu-Bundle"]
+	path = vendor/grammars/Textmate-Gosu-Bundle
+	url = https://github.com/jpcamara/Textmate-Gosu-Bundle
+[submodule "vendor/grammars/TypeScript-TmLanguage"]
+	path = vendor/grammars/TypeScript-TmLanguage
+	url = https://github.com/Microsoft/TypeScript-TmLanguage
+[submodule "vendor/grammars/UrWeb-Language-Definition"]
+	path = vendor/grammars/UrWeb-Language-Definition
+	url = https://github.com/gwalborn/UrWeb-Language-Definition.git
+[submodule "vendor/grammars/VBDotNetSyntax"]
+	path = vendor/grammars/VBDotNetSyntax
+	url = https://github.com/angryant0007/VBDotNetSyntax
 [submodule "vendor/grammars/Vala-TMBundle"]
 	path = vendor/grammars/Vala-TMBundle
 	url = https://github.com/technosophos/Vala-TMBundle
+[submodule "vendor/grammars/X10"]
+	path = vendor/grammars/X10
+	url = https://github.com/x10-lang/x10-highlighting
+[submodule "vendor/grammars/abap.tmbundle"]
+	path = vendor/grammars/abap.tmbundle
+	url = https://github.com/pvl/abap.tmbundle
+[submodule "vendor/grammars/actionscript3-tmbundle"]
+	path = vendor/grammars/actionscript3-tmbundle
+	url = https://github.com/simongregory/actionscript3-tmbundle
+[submodule "vendor/grammars/ada.tmbundle"]
+	path = vendor/grammars/ada.tmbundle
+	url = https://github.com/textmate/ada.tmbundle
+[submodule "vendor/grammars/ampl"]
+	path = vendor/grammars/ampl
+	url = https://github.com/ampl/sublime-ampl
 [submodule "vendor/grammars/ant.tmbundle"]
 	path = vendor/grammars/ant.tmbundle
 	url = https://github.com/textmate/ant.tmbundle
@@ -220,81 +208,423 @@
 [submodule "vendor/grammars/apache.tmbundle"]
 	path = vendor/grammars/apache.tmbundle
 	url = https://github.com/textmate/apache.tmbundle
+[submodule "vendor/grammars/api-blueprint-sublime-plugin"]
+	path = vendor/grammars/api-blueprint-sublime-plugin
+	url = https://github.com/apiaryio/api-blueprint-sublime-plugin
 [submodule "vendor/grammars/applescript.tmbundle"]
 	path = vendor/grammars/applescript.tmbundle
 	url = https://github.com/textmate/applescript.tmbundle
+[submodule "vendor/grammars/asciidoc.tmbundle"]
+	path = vendor/grammars/asciidoc.tmbundle
+	url = https://github.com/zuckschwerdt/asciidoc.tmbundle
 [submodule "vendor/grammars/asp.tmbundle"]
 	path = vendor/grammars/asp.tmbundle
 	url = https://github.com/textmate/asp.tmbundle
+[submodule "vendor/grammars/assembly"]
+	path = vendor/grammars/assembly
+	url = https://github.com/nanoant/assembly.tmbundle
+[submodule "vendor/grammars/atom-fsharp"]
+	path = vendor/grammars/atom-fsharp
+	url = https://github.com/fsprojects/atom-fsharp
+[submodule "vendor/grammars/atom-language-1c-bsl"]
+	path = vendor/grammars/atom-language-1c-bsl
+	url = https://github.com/xDrivenDevelopment/atom-language-1c-bsl.git
+[submodule "vendor/grammars/atom-language-clean"]
+	path = vendor/grammars/atom-language-clean
+	url = https://github.com/timjs/atom-language-clean.git
+[submodule "vendor/grammars/atom-language-julia"]
+	path = vendor/grammars/atom-language-julia
+	url = https://github.com/JuliaEditorSupport/atom-language-julia
+[submodule "vendor/grammars/atom-language-nextflow"]
+	path = vendor/grammars/atom-language-nextflow
+	url = https://github.com/nextflow-io/atom-language-nextflow
+[submodule "vendor/grammars/atom-language-p4"]
+	path = vendor/grammars/atom-language-p4
+	url = https://github.com/TakeshiTseng/atom-language-p4
+[submodule "vendor/grammars/atom-language-perl6"]
+	path = vendor/grammars/atom-language-perl6
+	url = https://github.com/perl6/atom-language-perl6
+[submodule "vendor/grammars/atom-language-purescript"]
+	path = vendor/grammars/atom-language-purescript
+	url = https://github.com/purescript-contrib/atom-language-purescript
+[submodule "vendor/grammars/atom-language-rust"]
+	path = vendor/grammars/atom-language-rust
+	url = https://github.com/zargony/atom-language-rust
+[submodule "vendor/grammars/atom-language-srt"]
+	path = vendor/grammars/atom-language-srt
+	url = https://github.com/314eter/atom-language-srt
+[submodule "vendor/grammars/atom-language-stan"]
+	path = vendor/grammars/atom-language-stan
+	url = https://github.com/jrnold/atom-language-stan
+[submodule "vendor/grammars/atom-salt"]
+	path = vendor/grammars/atom-salt
+	url = https://github.com/saltstack/atom-salt
+[submodule "vendor/grammars/atomic-dreams"]
+	path = vendor/grammars/atomic-dreams
+	url = https://github.com/PJB3005/atomic-dreams
+[submodule "vendor/grammars/ats"]
+	path = vendor/grammars/ats
+	url = https://github.com/steinwaywhw/ats-mode-sublimetext
+[submodule "vendor/grammars/awk-sublime"]
+	path = vendor/grammars/awk-sublime
+	url = https://github.com/github-linguist/awk-sublime
 [submodule "vendor/grammars/bison.tmbundle"]
 	path = vendor/grammars/bison.tmbundle
 	url = https://github.com/textmate/bison.tmbundle
+[submodule "vendor/grammars/blitzmax"]
+	path = vendor/grammars/blitzmax
+	url = https://github.com/textmate/blitzmax.tmbundle
+[submodule "vendor/grammars/boo"]
+	path = vendor/grammars/boo
+	url = https://github.com/Shammah/boo-sublime
+[submodule "vendor/grammars/bro-sublime"]
+	path = vendor/grammars/bro-sublime
+	url = https://github.com/bro/bro-sublime
+[submodule "vendor/grammars/c.tmbundle"]
+	path = vendor/grammars/c.tmbundle
+	url = https://github.com/textmate/c.tmbundle
 [submodule "vendor/grammars/capnproto.tmbundle"]
 	path = vendor/grammars/capnproto.tmbundle
 	url = https://github.com/textmate/capnproto.tmbundle
+[submodule "vendor/grammars/carto-atom"]
+	path = vendor/grammars/carto-atom
+	url = https://github.com/yohanboniface/carto-atom
+[submodule "vendor/grammars/ceylon-sublimetext"]
+	path = vendor/grammars/ceylon-sublimetext
+	url = https://github.com/jeancharles-roger/ceylon-sublimetext
+[submodule "vendor/grammars/chapel-tmbundle"]
+	path = vendor/grammars/chapel-tmbundle
+	url = https://github.com/chapel-lang/chapel-tmbundle
 [submodule "vendor/grammars/cmake.tmbundle"]
 	path = vendor/grammars/cmake.tmbundle
 	url = https://github.com/textmate/cmake.tmbundle
+[submodule "vendor/grammars/conllu-linguist-grammar"]
+	path = vendor/grammars/conllu-linguist-grammar
+	url = https://github.com/odanoburu/conllu-linguist-grammar
+[submodule "vendor/grammars/cool-tmbundle"]
+	path = vendor/grammars/cool-tmbundle
+	url = https://github.com/anunayk/cool-tmbundle
 [submodule "vendor/grammars/cpp-qt.tmbundle"]
 	path = vendor/grammars/cpp-qt.tmbundle
 	url = https://github.com/textmate/cpp-qt.tmbundle
+[submodule "vendor/grammars/creole"]
+	path = vendor/grammars/creole
+	url = https://github.com/Siddley/Creole
+[submodule "vendor/grammars/cucumber-tmbundle"]
+	path = vendor/grammars/cucumber-tmbundle
+	url = https://github.com/cucumber/cucumber-tmbundle
+[submodule "vendor/grammars/cython"]
+	path = vendor/grammars/cython
+	url = https://github.com/textmate/cython.tmbundle
 [submodule "vendor/grammars/d.tmbundle"]
 	path = vendor/grammars/d.tmbundle
 	url = https://github.com/textmate/d.tmbundle
+[submodule "vendor/grammars/dartlang"]
+	path = vendor/grammars/dartlang
+	url = https://github.com/dart-atom/dartlang
+[submodule "vendor/grammars/data-weave-tmLanguage"]
+	path = vendor/grammars/data-weave-tmLanguage
+	url = https://github.com/mulesoft-labs/data-weave-tmLanguage
+[submodule "vendor/grammars/desktop.tmbundle"]
+	path = vendor/grammars/desktop.tmbundle
+	url = https://github.com/Mailaender/desktop.tmbundle.git
 [submodule "vendor/grammars/diff.tmbundle"]
 	path = vendor/grammars/diff.tmbundle
 	url = https://github.com/textmate/diff.tmbundle
 [submodule "vendor/grammars/dylan.tmbundle"]
 	path = vendor/grammars/dylan.tmbundle
 	url = https://github.com/textmate/dylan.tmbundle
+[submodule "vendor/grammars/ec.tmbundle"]
+	path = vendor/grammars/ec.tmbundle
+	url = https://github.com/ecere/ec.tmbundle
 [submodule "vendor/grammars/eiffel.tmbundle"]
 	path = vendor/grammars/eiffel.tmbundle
 	url = https://github.com/textmate/eiffel.tmbundle
+[submodule "vendor/grammars/ejs-tmbundle"]
+	path = vendor/grammars/ejs-tmbundle
+	url = https://github.com/gregory-m/ejs-tmbundle
+[submodule "vendor/grammars/elixir-tmbundle"]
+	path = vendor/grammars/elixir-tmbundle
+	url = https://github.com/elixir-lang/elixir-tmbundle
 [submodule "vendor/grammars/erlang.tmbundle"]
 	path = vendor/grammars/erlang.tmbundle
 	url = https://github.com/textmate/erlang.tmbundle
+[submodule "vendor/grammars/factor"]
+	path = vendor/grammars/factor
+	url = https://github.com/slavapestov/factor
+[submodule "vendor/grammars/fancy-tmbundle"]
+	path = vendor/grammars/fancy-tmbundle
+	url = https://github.com/fancy-lang/fancy-tmbundle
+[submodule "vendor/grammars/fish-tmbundle"]
+	path = vendor/grammars/fish-tmbundle
+	url = https://github.com/l15n/fish-tmbundle
+[submodule "vendor/grammars/forth"]
+	path = vendor/grammars/forth
+	url = https://github.com/textmate/forth.tmbundle
 [submodule "vendor/grammars/fortran.tmbundle"]
 	path = vendor/grammars/fortran.tmbundle
 	url = https://github.com/textmate/fortran.tmbundle
+[submodule "vendor/grammars/gap-tmbundle"]
+	path = vendor/grammars/gap-tmbundle
+	url = https://github.com/dhowden/gap-tmbundle
+[submodule "vendor/grammars/gdscript"]
+	path = vendor/grammars/gdscript
+	url = https://github.com/beefsack/GDScript-sublime
 [submodule "vendor/grammars/gettext.tmbundle"]
 	path = vendor/grammars/gettext.tmbundle
 	url = https://github.com/textmate/gettext.tmbundle
+[submodule "vendor/grammars/gnuplot-tmbundle"]
+	path = vendor/grammars/gnuplot-tmbundle
+	url = https://github.com/mattfoster/gnuplot-tmbundle
+[submodule "vendor/grammars/go-tmbundle"]
+	path = vendor/grammars/go-tmbundle
+	url = https://github.com/AlanQuatermain/go-tmbundle
+[submodule "vendor/grammars/grace"]
+	path = vendor/grammars/grace
+	url = https://github.com/zmthy/grace-tmbundle
+[submodule "vendor/grammars/gradle.tmbundle"]
+	path = vendor/grammars/gradle.tmbundle
+	url = https://github.com/alkemist/gradle.tmbundle
 [submodule "vendor/grammars/graphviz.tmbundle"]
 	path = vendor/grammars/graphviz.tmbundle
 	url = https://github.com/textmate/graphviz.tmbundle
 [submodule "vendor/grammars/groovy.tmbundle"]
 	path = vendor/grammars/groovy.tmbundle
 	url = https://github.com/textmate/groovy.tmbundle
+[submodule "vendor/grammars/haxe-sublime-bundle"]
+	path = vendor/grammars/haxe-sublime-bundle
+	url = https://github.com/clemos/haxe-sublime-bundle
 [submodule "vendor/grammars/html.tmbundle"]
 	path = vendor/grammars/html.tmbundle
 	url = https://github.com/textmate/html.tmbundle
+[submodule "vendor/grammars/idl.tmbundle"]
+	path = vendor/grammars/idl.tmbundle
+	url = https://github.com/mgalloy/idl.tmbundle
+[submodule "vendor/grammars/idris"]
+	path = vendor/grammars/idris
+	url = https://github.com/idris-hackers/idris-sublime.git
 [submodule "vendor/grammars/ini.tmbundle"]
 	path = vendor/grammars/ini.tmbundle
 	url = https://github.com/textmate/ini.tmbundle
-[submodule "vendor/grammars/desktop.tmbundle"]
-	path = vendor/grammars/desktop.tmbundle
-	url = https://github.com/Mailaender/desktop.tmbundle.git
 [submodule "vendor/grammars/io.tmbundle"]
 	path = vendor/grammars/io.tmbundle
 	url = https://github.com/textmate/io.tmbundle
+[submodule "vendor/grammars/ioke-outdated"]
+	path = vendor/grammars/ioke-outdated
+	url = https://github.com/vic/ioke-outdated
+[submodule "vendor/grammars/jade-tmbundle"]
+	path = vendor/grammars/jade-tmbundle
+	url = https://github.com/davidrios/jade-tmbundle
+[submodule "vendor/grammars/jasmin-sublime"]
+	path = vendor/grammars/jasmin-sublime
+	url = https://github.com/atmarksharp/jasmin-sublime
 [submodule "vendor/grammars/java.tmbundle"]
 	path = vendor/grammars/java.tmbundle
 	url = https://github.com/textmate/java.tmbundle
+[submodule "vendor/grammars/javadoc.tmbundle"]
+	path = vendor/grammars/javadoc.tmbundle
+	url = https://github.com/textmate/javadoc.tmbundle
 [submodule "vendor/grammars/javascript-objective-j.tmbundle"]
 	path = vendor/grammars/javascript-objective-j.tmbundle
 	url = https://github.com/textmate/javascript-objective-j.tmbundle
+[submodule "vendor/grammars/jflex.tmbundle"]
+	path = vendor/grammars/jflex.tmbundle
+	url = https://github.com/jflex-de/jflex.tmbundle.git
 [submodule "vendor/grammars/json.tmbundle"]
 	path = vendor/grammars/json.tmbundle
 	url = https://github.com/textmate/json.tmbundle
+[submodule "vendor/grammars/kotlin-sublime-package"]
+	path = vendor/grammars/kotlin-sublime-package
+	url = https://github.com/vkostyukov/kotlin-sublime-package
+[submodule "vendor/grammars/language-agc"]
+	path = vendor/grammars/language-agc
+	url = https://github.com/Alhadis/language-agc
+[submodule "vendor/grammars/language-apl"]
+	path = vendor/grammars/language-apl
+	url = https://github.com/Alhadis/language-apl.git
+[submodule "vendor/grammars/language-asn1"]
+	path = vendor/grammars/language-asn1
+	url = https://github.com/ajLangley12/language-asn1
+[submodule "vendor/grammars/language-babel"]
+	path = vendor/grammars/language-babel
+	url = https://github.com/github-linguist/language-babel
+[submodule "vendor/grammars/language-ballerina"]
+	path = vendor/grammars/language-ballerina
+	url = https://github.com/ballerinalang/plugin-vscode
+[submodule "vendor/grammars/language-batchfile"]
+	path = vendor/grammars/language-batchfile
+	url = https://github.com/mmims/language-batchfile
+[submodule "vendor/grammars/language-blade"]
+	path = vendor/grammars/language-blade
+	url = https://github.com/jawee/language-blade
+[submodule "vendor/grammars/language-click"]
+	path = vendor/grammars/language-click
+	url = https://github.com/stenverbois/language-click.git
+[submodule "vendor/grammars/language-clojure"]
+	path = vendor/grammars/language-clojure
+	url = https://github.com/atom/language-clojure
+[submodule "vendor/grammars/language-closure-templates"]
+	path = vendor/grammars/language-closure-templates
+	url = https://github.com/mthadley/language-closure-templates
+[submodule "vendor/grammars/language-coffee-script"]
+	path = vendor/grammars/language-coffee-script
+	url = https://github.com/atom/language-coffee-script
+[submodule "vendor/grammars/language-crystal"]
+	path = vendor/grammars/language-crystal
+	url = https://github.com/atom-crystal/language-crystal
+[submodule "vendor/grammars/language-csharp"]
+	path = vendor/grammars/language-csharp
+	url = https://github.com/atom/language-csharp
+[submodule "vendor/grammars/language-csound"]
+	path = vendor/grammars/language-csound
+	url = https://github.com/nwhetsell/language-csound
+[submodule "vendor/grammars/language-css"]
+	path = vendor/grammars/language-css
+	url = https://github.com/atom/language-css
+[submodule "vendor/grammars/language-cwl"]
+	path = vendor/grammars/language-cwl
+	url = https://github.com/manabuishii/language-cwl
+[submodule "vendor/grammars/language-emacs-lisp"]
+	path = vendor/grammars/language-emacs-lisp
+	url = https://github.com/Alhadis/language-emacs-lisp
+[submodule "vendor/grammars/language-fontforge"]
+	path = vendor/grammars/language-fontforge
+	url = https://github.com/Alhadis/language-fontforge
+[submodule "vendor/grammars/language-gfm"]
+	path = vendor/grammars/language-gfm
+	url = https://github.com/atom/language-gfm
+[submodule "vendor/grammars/language-gn"]
+	path = vendor/grammars/language-gn
+	url = https://github.com/devoncarew/language-gn
+[submodule "vendor/grammars/language-graphql"]
+	path = vendor/grammars/language-graphql
+	url = https://github.com/rmosolgo/language-graphql
+[submodule "vendor/grammars/language-haml"]
+	path = vendor/grammars/language-haml
+	url = https://github.com/ezekg/language-haml
+[submodule "vendor/grammars/language-haskell"]
+	path = vendor/grammars/language-haskell
+	url = https://github.com/atom-haskell/language-haskell
+[submodule "vendor/grammars/language-inform7"]
+	path = vendor/grammars/language-inform7
+	url = https://github.com/erkyrath/language-inform7
+[submodule "vendor/grammars/language-javascript"]
+	path = vendor/grammars/language-javascript
+	url = https://github.com/atom/language-javascript
+[submodule "vendor/grammars/language-jison"]
+	path = vendor/grammars/language-jison
+	url = https://github.com/cdibbs/language-jison
+[submodule "vendor/grammars/language-jolie"]
+	path = vendor/grammars/language-jolie
+	url = https://github.com/fmontesi/language-jolie
+[submodule "vendor/grammars/language-jsoniq"]
+	path = vendor/grammars/language-jsoniq
+	url = https://github.com/wcandillon/language-jsoniq
+[submodule "vendor/grammars/language-less"]
+	path = vendor/grammars/language-less
+	url = https://github.com/atom/language-less.git
+[submodule "vendor/grammars/language-maxscript"]
+	path = vendor/grammars/language-maxscript
+	url = https://github.com/Alhadis/language-maxscript
+[submodule "vendor/grammars/language-meson"]
+	path = vendor/grammars/language-meson
+	url = https://github.com/TingPing/language-meson
+[submodule "vendor/grammars/language-ncl"]
+	path = vendor/grammars/language-ncl
+	url = https://github.com/rpavlick/language-ncl.git
+[submodule "vendor/grammars/language-ninja"]
+	path = vendor/grammars/language-ninja
+	url = https://github.com/khyo/language-ninja
+[submodule "vendor/grammars/language-pan"]
+	path = vendor/grammars/language-pan
+	url = https://github.com/quattor/language-pan
+[submodule "vendor/grammars/language-pcb"]
+	path = vendor/grammars/language-pcb
+	url = https://github.com/Alhadis/language-pcb
+[submodule "vendor/grammars/language-povray"]
+	path = vendor/grammars/language-povray
+	url = https://github.com/c-lipka/language-povray
+[submodule "vendor/grammars/language-reason"]
+	path = vendor/grammars/language-reason
+	url = https://github.com/reasonml-editor/language-reason
+[submodule "vendor/grammars/language-regexp"]
+	path = vendor/grammars/language-regexp
+	url = https://github.com/Alhadis/language-regexp
+[submodule "vendor/grammars/language-renpy"]
+	path = vendor/grammars/language-renpy
+	url = https://github.com/williamd1k0/language-renpy.git
+[submodule "vendor/grammars/language-restructuredtext"]
+	path = vendor/grammars/language-restructuredtext
+	url = https://github.com/Lukasa/language-restructuredtext
+[submodule "vendor/grammars/language-ring"]
+	path = vendor/grammars/language-ring
+	url = https://github.com/MahmoudFayed/atom-language-ring
+[submodule "vendor/grammars/language-roff"]
+	path = vendor/grammars/language-roff
+	url = https://github.com/Alhadis/language-roff
+[submodule "vendor/grammars/language-rpm-spec"]
+	path = vendor/grammars/language-rpm-spec
+	url = https://github.com/waveclaw/language-rpm-spec
+[submodule "vendor/grammars/language-ruby"]
+	path = vendor/grammars/language-ruby
+	url = https://github.com/atom/language-ruby
+[submodule "vendor/grammars/language-shellscript"]
+	path = vendor/grammars/language-shellscript
+	url = https://github.com/atom/language-shellscript
+[submodule "vendor/grammars/language-supercollider"]
+	path = vendor/grammars/language-supercollider
+	url = https://github.com/supercollider/language-supercollider
+[submodule "vendor/grammars/language-toc-wow"]
+	path = vendor/grammars/language-toc-wow
+	url = https://github.com/nebularg/language-toc-wow
+[submodule "vendor/grammars/language-turing"]
+	path = vendor/grammars/language-turing
+	url = https://github.com/Alhadis/language-turing
+[submodule "vendor/grammars/language-typelanguage"]
+	path = vendor/grammars/language-typelanguage
+	url = https://github.com/goodmind/language-typelanguage
+[submodule "vendor/grammars/language-viml"]
+	path = vendor/grammars/language-viml
+	url = https://github.com/Alhadis/language-viml
+[submodule "vendor/grammars/language-wavefront"]
+	path = vendor/grammars/language-wavefront
+	url = https://github.com/Alhadis/language-wavefront
+[submodule "vendor/grammars/language-webassembly"]
+	path = vendor/grammars/language-webassembly
+	url = https://github.com/Alhadis/language-webassembly
+[submodule "vendor/grammars/language-xbase"]
+	path = vendor/grammars/language-xbase
+	url = https://github.com/hernad/atom-language-harbour
+[submodule "vendor/grammars/language-xcompose"]
+	path = vendor/grammars/language-xcompose
+	url = https://github.com/samcv/language-xcompose
+[submodule "vendor/grammars/language-yaml"]
+	path = vendor/grammars/language-yaml
+	url = https://github.com/atom/language-yaml
+[submodule "vendor/grammars/language-yang"]
+	path = vendor/grammars/language-yang
+	url = https://github.com/DzonyKalafut/language-yang.git
+[submodule "vendor/grammars/language-yara"]
+	path = vendor/grammars/language-yara
+	url = https://github.com/blacktop/language-yara
 [submodule "vendor/grammars/latex.tmbundle"]
 	path = vendor/grammars/latex.tmbundle
 	url = https://github.com/textmate/latex.tmbundle
 [submodule "vendor/grammars/lilypond.tmbundle"]
 	path = vendor/grammars/lilypond.tmbundle
 	url = https://github.com/textmate/lilypond.tmbundle
+[submodule "vendor/grammars/liquid.tmbundle"]
+	path = vendor/grammars/liquid.tmbundle
+	url = https://github.com/bastilian/validcode-textmate-bundles
 [submodule "vendor/grammars/lisp.tmbundle"]
 	path = vendor/grammars/lisp.tmbundle
 	url = https://github.com/textmate/lisp.tmbundle
+[submodule "vendor/grammars/llvm.tmbundle"]
+	path = vendor/grammars/llvm.tmbundle
+	url = https://github.com/whitequark/llvm.tmbundle
+[submodule "vendor/grammars/logos"]
+	path = vendor/grammars/logos
+	url = https://github.com/Cykey/Sublime-Logos
 [submodule "vendor/grammars/logtalk.tmbundle"]
 	path = vendor/grammars/logtalk.tmbundle
 	url = https://github.com/textmate/logtalk.tmbundle
@@ -304,51 +634,237 @@
 [submodule "vendor/grammars/make.tmbundle"]
 	path = vendor/grammars/make.tmbundle
 	url = https://github.com/textmate/make.tmbundle
+[submodule "vendor/grammars/mako-tmbundle"]
+	path = vendor/grammars/mako-tmbundle
+	url = https://github.com/marconi/mako-tmbundle
+[submodule "vendor/grammars/marko-tmbundle"]
+	path = vendor/grammars/marko-tmbundle
+	url = https://github.com/marko-js/marko-tmbundle
+[submodule "vendor/grammars/mathematica-tmbundle"]
+	path = vendor/grammars/mathematica-tmbundle
+	url = https://github.com/shadanan/mathematica-tmbundle
 [submodule "vendor/grammars/maven.tmbundle"]
 	path = vendor/grammars/maven.tmbundle
 	url = https://github.com/textmate/maven.tmbundle
+[submodule "vendor/grammars/mediawiki.tmbundle"]
+	path = vendor/grammars/mediawiki.tmbundle
+	url = https://github.com/textmate/mediawiki.tmbundle
+[submodule "vendor/grammars/mercury-tmlanguage"]
+	path = vendor/grammars/mercury-tmlanguage
+	url = https://github.com/sebgod/mercury-tmlanguage
+[submodule "vendor/grammars/monkey"]
+	path = vendor/grammars/monkey
+	url = https://github.com/gingerbeardman/monkey.tmbundle
+[submodule "vendor/grammars/moonscript-tmbundle"]
+	path = vendor/grammars/moonscript-tmbundle
+	url = https://github.com/leafo/moonscript-tmbundle
 [submodule "vendor/grammars/nemerle.tmbundle"]
 	path = vendor/grammars/nemerle.tmbundle
 	url = https://github.com/textmate/nemerle.tmbundle
+[submodule "vendor/grammars/nesC"]
+	path = vendor/grammars/nesC
+	url = https://github.com/cdwilson/nesC.tmbundle
+[submodule "vendor/grammars/nix"]
+	path = vendor/grammars/nix
+	url = https://github.com/wmertens/sublime-nix
+[submodule "vendor/grammars/nu.tmbundle"]
+	path = vendor/grammars/nu.tmbundle
+	url = https://github.com/jsallis/nu.tmbundle
 [submodule "vendor/grammars/objective-c.tmbundle"]
 	path = vendor/grammars/objective-c.tmbundle
 	url = https://github.com/textmate/objective-c.tmbundle
 [submodule "vendor/grammars/ocaml.tmbundle"]
 	path = vendor/grammars/ocaml.tmbundle
 	url = https://github.com/textmate/ocaml.tmbundle
+[submodule "vendor/grammars/ooc.tmbundle"]
+	path = vendor/grammars/ooc.tmbundle
+	url = https://github.com/nilium/ooc.tmbundle
+[submodule "vendor/grammars/opa.tmbundle"]
+	path = vendor/grammars/opa.tmbundle
+	url = https://github.com/mads379/opa.tmbundle
+[submodule "vendor/grammars/openscad.tmbundle"]
+	path = vendor/grammars/openscad.tmbundle
+	url = https://github.com/tbuser/openscad.tmbundle
+[submodule "vendor/grammars/oz-tmbundle"]
+	path = vendor/grammars/oz-tmbundle
+	url = https://github.com/eregon/oz-tmbundle
+[submodule "vendor/grammars/parrot"]
+	path = vendor/grammars/parrot
+	url = https://github.com/textmate/parrot.tmbundle
 [submodule "vendor/grammars/pascal.tmbundle"]
 	path = vendor/grammars/pascal.tmbundle
 	url = https://github.com/textmate/pascal.tmbundle
+[submodule "vendor/grammars/pawn-sublime-language"]
+	path = vendor/grammars/pawn-sublime-language
+	url = https://github.com/Southclaw/pawn-sublime-language.git
+[submodule "vendor/grammars/perl.tmbundle"]
+	path = vendor/grammars/perl.tmbundle
+	url = https://github.com/textmate/perl.tmbundle
 [submodule "vendor/grammars/php-smarty.tmbundle"]
 	path = vendor/grammars/php-smarty.tmbundle
 	url = https://github.com/textmate/php-smarty.tmbundle
 [submodule "vendor/grammars/php.tmbundle"]
 	path = vendor/grammars/php.tmbundle
 	url = https://github.com/textmate/php.tmbundle
+[submodule "vendor/grammars/pig-latin"]
+	path = vendor/grammars/pig-latin
+	url = https://github.com/goblindegook/sublime-text-pig-latin
+[submodule "vendor/grammars/pike-textmate"]
+	path = vendor/grammars/pike-textmate
+	url = https://github.com/hww3/pike-textmate
 [submodule "vendor/grammars/postscript.tmbundle"]
 	path = vendor/grammars/postscript.tmbundle
 	url = https://github.com/textmate/postscript.tmbundle
+[submodule "vendor/grammars/powershell"]
+	path = vendor/grammars/powershell
+	url = https://github.com/SublimeText/PowerShell
 [submodule "vendor/grammars/processing.tmbundle"]
 	path = vendor/grammars/processing.tmbundle
 	url = https://github.com/textmate/processing.tmbundle
+[submodule "vendor/grammars/protobuf-tmbundle"]
+	path = vendor/grammars/protobuf-tmbundle
+	url = https://github.com/michaeledgar/protobuf-tmbundle
 [submodule "vendor/grammars/python-django.tmbundle"]
 	path = vendor/grammars/python-django.tmbundle
 	url = https://github.com/textmate/python-django.tmbundle
 [submodule "vendor/grammars/r.tmbundle"]
 	path = vendor/grammars/r.tmbundle
 	url = https://github.com/textmate/r.tmbundle
+[submodule "vendor/grammars/rascal-syntax-highlighting"]
+	path = vendor/grammars/rascal-syntax-highlighting
+	url = https://github.com/usethesource/rascal-syntax-highlighting
+[submodule "vendor/grammars/ruby-slim.tmbundle"]
+	path = vendor/grammars/ruby-slim.tmbundle
+	url = https://github.com/slim-template/ruby-slim.tmbundle
+[submodule "vendor/grammars/sas.tmbundle"]
+	path = vendor/grammars/sas.tmbundle
+	url = https://github.com/rpardee/sas.tmbundle
+[submodule "vendor/grammars/sass-textmate-bundle"]
+	path = vendor/grammars/sass-textmate-bundle
+	url = https://github.com/nathos/sass-textmate-bundle
+[submodule "vendor/grammars/scala.tmbundle"]
+	path = vendor/grammars/scala.tmbundle
+	url = https://github.com/mads379/scala.tmbundle
 [submodule "vendor/grammars/scheme.tmbundle"]
 	path = vendor/grammars/scheme.tmbundle
 	url = https://github.com/textmate/scheme.tmbundle
 [submodule "vendor/grammars/scilab.tmbundle"]
 	path = vendor/grammars/scilab.tmbundle
 	url = https://github.com/textmate/scilab.tmbundle
+[submodule "vendor/grammars/secondlife-lsl"]
+	path = vendor/grammars/secondlife-lsl
+	url = https://github.com/textmate/secondlife-lsl.tmbundle
+[submodule "vendor/grammars/shaders-tmLanguage"]
+	path = vendor/grammars/shaders-tmLanguage
+	url = https://github.com/tgjones/shaders-tmLanguage
+[submodule "vendor/grammars/smali-sublime"]
+	path = vendor/grammars/smali-sublime
+	url = https://github.com/ShaneWilton/sublime-smali
+[submodule "vendor/grammars/smalltalk-tmbundle"]
+	path = vendor/grammars/smalltalk-tmbundle
+	url = https://github.com/tomas-stefano/smalltalk-tmbundle
+[submodule "vendor/grammars/sourcepawn"]
+	path = vendor/grammars/sourcepawn
+	url = https://github.com/github-linguist/sublime-sourcepawn
 [submodule "vendor/grammars/sql.tmbundle"]
 	path = vendor/grammars/sql.tmbundle
 	url = https://github.com/textmate/sql.tmbundle
+[submodule "vendor/grammars/squirrel-language"]
+	path = vendor/grammars/squirrel-language
+	url = https://github.com/mathewmariani/squirrel-language
+[submodule "vendor/grammars/st2-zonefile"]
+	path = vendor/grammars/st2-zonefile
+	url = https://github.com/sixty4k/st2-zonefile
 [submodule "vendor/grammars/standard-ml.tmbundle"]
 	path = vendor/grammars/standard-ml.tmbundle
 	url = https://github.com/textmate/standard-ml.tmbundle
+[submodule "vendor/grammars/sublime-MuPAD"]
+	path = vendor/grammars/sublime-MuPAD
+	url = https://github.com/ccreutzig/sublime-MuPAD
+[submodule "vendor/grammars/sublime-angelscript"]
+	path = vendor/grammars/sublime-angelscript
+	url = https://github.com/wronex/sublime-angelscript
+[submodule "vendor/grammars/sublime-aspectj"]
+	path = vendor/grammars/sublime-aspectj
+	url = https://github.com/pchaigno/sublime-aspectj
+[submodule "vendor/grammars/sublime-autoit"]
+	path = vendor/grammars/sublime-autoit
+	url = https://github.com/AutoIt/SublimeAutoItScript
+[submodule "vendor/grammars/sublime-befunge"]
+	path = vendor/grammars/sublime-befunge
+	url = https://github.com/johanasplund/sublime-befunge
+[submodule "vendor/grammars/sublime-bsv"]
+	path = vendor/grammars/sublime-bsv
+	url = https://github.com/thotypous/sublime-bsv
+[submodule "vendor/grammars/sublime-cirru"]
+	path = vendor/grammars/sublime-cirru
+	url = https://github.com/Cirru/sublime-cirru
+[submodule "vendor/grammars/sublime-clips"]
+	path = vendor/grammars/sublime-clips
+	url = https://github.com/psicomante/CLIPS-sublime
+[submodule "vendor/grammars/sublime-fantom"]
+	path = vendor/grammars/sublime-fantom
+	url = https://github.com/rkoeninger/sublime-fantom
+[submodule "vendor/grammars/sublime-glsl"]
+	path = vendor/grammars/sublime-glsl
+	url = https://github.com/euler0/sublime-glsl
+[submodule "vendor/grammars/sublime-golo"]
+	path = vendor/grammars/sublime-golo
+	url = https://github.com/TypeUnsafe/sublime-golo
+[submodule "vendor/grammars/sublime-mask"]
+	path = vendor/grammars/sublime-mask
+	url = https://github.com/tenbits/sublime-mask
+[submodule "vendor/grammars/sublime-nearley"]
+	path = vendor/grammars/sublime-nearley
+	url = https://github.com/Hardmath123/sublime-nearley
+[submodule "vendor/grammars/sublime-netlinx"]
+	path = vendor/grammars/sublime-netlinx
+	url = https://github.com/amclain/sublime-netlinx
+[submodule "vendor/grammars/sublime-nginx"]
+	path = vendor/grammars/sublime-nginx
+	url = https://github.com/brandonwamboldt/sublime-nginx
+[submodule "vendor/grammars/sublime-opal"]
+	path = vendor/grammars/sublime-opal
+	url = https://github.com/artifactz/sublime-opal
+[submodule "vendor/grammars/sublime-pony"]
+	path = vendor/grammars/sublime-pony
+	url = https://github.com/CausalityLtd/sublime-pony
+[submodule "vendor/grammars/sublime-rexx"]
+	path = vendor/grammars/sublime-rexx
+	url = https://github.com/mblocker/rexx-sublime
+[submodule "vendor/grammars/sublime-robot-plugin"]
+	path = vendor/grammars/sublime-robot-plugin
+	url = https://github.com/shellderp/sublime-robot-plugin
+[submodule "vendor/grammars/sublime-shen"]
+	path = vendor/grammars/sublime-shen
+	url = https://github.com/rkoeninger/sublime-shen
+[submodule "vendor/grammars/sublime-spintools"]
+	path = vendor/grammars/sublime-spintools
+	url = https://github.com/bitbased/sublime-spintools
+[submodule "vendor/grammars/sublime-tea"]
+	path = vendor/grammars/sublime-tea
+	url = https://github.com/pferruggiaro/sublime-tea
+[submodule "vendor/grammars/sublime-terra"]
+	path = vendor/grammars/sublime-terra
+	url = https://github.com/pyk/sublime-terra
+[submodule "vendor/grammars/sublime-text-ox"]
+	path = vendor/grammars/sublime-text-ox
+	url = https://github.com/andreashetland/sublime-text-ox
+[submodule "vendor/grammars/sublime-varnish"]
+	path = vendor/grammars/sublime-varnish
+	url = https://github.com/brandonwamboldt/sublime-varnish
+[submodule "vendor/grammars/sublime_cobol"]
+	path = vendor/grammars/sublime_cobol
+	url = https://bitbucket.org/bitlang/sublime_cobol
+[submodule "vendor/grammars/sublimeassembly"]
+	path = vendor/grammars/sublimeassembly
+	url = https://github.com/Nessphoro/sublimeassembly
+[submodule "vendor/grammars/sublimeprolog"]
+	path = vendor/grammars/sublimeprolog
+	url = https://github.com/alnkpa/sublimeprolog
+[submodule "vendor/grammars/sublimetext-cuda-cpp"]
+	path = vendor/grammars/sublimetext-cuda-cpp
+	url = https://github.com/harrism/sublimetext-cuda-cpp
 [submodule "vendor/grammars/swift.tmbundle"]
 	path = vendor/grammars/swift.tmbundle
 	url = https://github.com/textmate/swift.tmbundle
@@ -361,546 +877,30 @@
 [submodule "vendor/grammars/toml.tmbundle"]
 	path = vendor/grammars/toml.tmbundle
 	url = https://github.com/textmate/toml.tmbundle
-[submodule "vendor/grammars/verilog.tmbundle"]
-	path = vendor/grammars/verilog.tmbundle
-	url = https://github.com/textmate/verilog.tmbundle
-[submodule "vendor/grammars/xml.tmbundle"]
-	path = vendor/grammars/xml.tmbundle
-	url = https://github.com/textmate/xml.tmbundle
-[submodule "vendor/grammars/smalltalk-tmbundle"]
-	path = vendor/grammars/smalltalk-tmbundle
-	url = https://github.com/tomas-stefano/smalltalk-tmbundle
-[submodule "vendor/grammars/ioke-outdated"]
-	path = vendor/grammars/ioke-outdated
-	url = https://github.com/vic/ioke-outdated
-[submodule "vendor/grammars/kotlin-sublime-package"]
-	path = vendor/grammars/kotlin-sublime-package
-	url = https://github.com/vkostyukov/kotlin-sublime-package
-[submodule "vendor/grammars/c.tmbundle"]
-	path = vendor/grammars/c.tmbundle
-	url = https://github.com/textmate/c.tmbundle
-[submodule "vendor/grammars/zephir-sublime"]
-	path = vendor/grammars/zephir-sublime
-	url = https://github.com/phalcon/zephir-sublime
-[submodule "vendor/grammars/llvm.tmbundle"]
-	path = vendor/grammars/llvm.tmbundle
-	url = https://github.com/whitequark/llvm.tmbundle
-[submodule "vendor/grammars/oz-tmbundle"]
-	path = vendor/grammars/oz-tmbundle
-	url = https://github.com/eregon/oz-tmbundle
-[submodule "vendor/grammars/language-batchfile"]
-	path = vendor/grammars/language-batchfile
-	url = https://github.com/mmims/language-batchfile
-[submodule "vendor/grammars/sublime-mask"]
-	path = vendor/grammars/sublime-mask
-	url = https://github.com/tenbits/sublime-mask
-[submodule "vendor/grammars/sublime_cobol"]
-	path = vendor/grammars/sublime_cobol
-	url = https://bitbucket.org/bitlang/sublime_cobol
-[submodule "vendor/grammars/IDL-Syntax"]
-	path = vendor/grammars/IDL-Syntax
-	url = https://github.com/andik/IDL-Syntax
-[submodule "vendor/grammars/sas.tmbundle"]
-	path = vendor/grammars/sas.tmbundle
-	url = https://github.com/rpardee/sas.tmbundle
-[submodule "vendor/grammars/atom-salt"]
-	path = vendor/grammars/atom-salt
-	url = https://github.com/saltstack/atom-salt
-[submodule "vendor/grammars/Scalate.tmbundle"]
-	path = vendor/grammars/Scalate.tmbundle
-	url = https://github.com/scalate/Scalate.tmbundle
-[submodule "vendor/grammars/sublime-bsv"]
-	path = vendor/grammars/sublime-bsv
-	url = https://github.com/thotypous/sublime-bsv
-[submodule "vendor/grammars/sass-textmate-bundle"]
-	path = vendor/grammars/sass-textmate-bundle
-	url = https://github.com/nathos/sass-textmate-bundle
-[submodule "vendor/grammars/carto-atom"]
-	path = vendor/grammars/carto-atom
-	url = https://github.com/yohanboniface/carto-atom
-[submodule "vendor/grammars/Sublime-Nit"]
-	path = vendor/grammars/Sublime-Nit
-	url = https://github.com/R4PaSs/Sublime-Nit
-[submodule "vendor/grammars/Racket"]
-	path = vendor/grammars/Racket
-	url = https://github.com/soegaard/racket-highlight-for-github
 [submodule "vendor/grammars/turtle.tmbundle"]
 	path = vendor/grammars/turtle.tmbundle
 	url = https://github.com/peta/turtle.tmbundle
-[submodule "vendor/grammars/liquid.tmbundle"]
-	path = vendor/grammars/liquid.tmbundle
-	url = https://github.com/bastilian/validcode-textmate-bundles
-[submodule "vendor/grammars/Modelica"]
-	path = vendor/grammars/Modelica
-	url = https://github.com/BorisChumichev/modelicaSublimeTextPackage
-[submodule "vendor/grammars/sublime-golo"]
-	path = vendor/grammars/sublime-golo
-	url = https://github.com/TypeUnsafe/sublime-golo
-[submodule "vendor/grammars/TXL"]
-	path = vendor/grammars/TXL
-	url = https://github.com/MikeHoffert/Sublime-Text-TXL-syntax
-[submodule "vendor/grammars/G-Code"]
-	path = vendor/grammars/G-Code
-	url = https://github.com/robotmaster/sublime-text-syntax-highlighting
-[submodule "vendor/grammars/sublime-text-ox"]
-	path = vendor/grammars/sublime-text-ox
-	url = https://github.com/andreashetland/sublime-text-ox
-[submodule "vendor/grammars/AutoHotkey"]
-	path = vendor/grammars/AutoHotkey
-	url = https://github.com/ahkscript/SublimeAutoHotkey
-[submodule "vendor/grammars/ec.tmbundle"]
-	path = vendor/grammars/ec.tmbundle
-	url = https://github.com/ecere/ec.tmbundle
-[submodule "vendor/grammars/gap-tmbundle"]
-	path = vendor/grammars/gap-tmbundle
-	url = https://github.com/dhowden/gap-tmbundle
-[submodule "vendor/grammars/SublimePapyrus"]
-	path = vendor/grammars/SublimePapyrus
-	url = https://github.com/Kapiainen/SublimePapyrus
-[submodule "vendor/grammars/sublime-spintools"]
-	path = vendor/grammars/sublime-spintools
-	url = https://github.com/bitbased/sublime-spintools
-[submodule "vendor/grammars/PogoScript.tmbundle"]
-	path = vendor/grammars/PogoScript.tmbundle
-	url = https://github.com/featurist/PogoScript.tmbundle
-[submodule "vendor/grammars/sublime-opal"]
-	path = vendor/grammars/sublime-opal
-	url = https://github.com/artifactz/sublime-opal
-[submodule "vendor/grammars/mediawiki.tmbundle"]
-	path = vendor/grammars/mediawiki.tmbundle
-	url = https://github.com/textmate/mediawiki.tmbundle
-[submodule "vendor/grammars/SublimeClarion"]
-	path = vendor/grammars/SublimeClarion
-	url = https://github.com/fushnisoft/SublimeClarion
-[submodule "vendor/grammars/BrightScript.tmbundle"]
-	path = vendor/grammars/BrightScript.tmbundle
-	url = https://github.com/cmink/BrightScript.tmbundle
-[submodule "vendor/grammars/Stylus"]
-	path = vendor/grammars/Stylus
-	url = https://github.com/billymoon/Stylus
-[submodule "vendor/grammars/asciidoc.tmbundle"]
-	path = vendor/grammars/asciidoc.tmbundle
-	url = https://github.com/zuckschwerdt/asciidoc.tmbundle
-[submodule "vendor/grammars/Lean.tmbundle"]
-	path = vendor/grammars/Lean.tmbundle
-	url = https://github.com/leanprover/Lean.tmbundle
-[submodule "vendor/grammars/ampl"]
-	path = vendor/grammars/ampl
-	url = https://github.com/ampl/sublime-ampl
-[submodule "vendor/grammars/sublime-varnish"]
-	path = vendor/grammars/sublime-varnish
-	url = https://github.com/brandonwamboldt/sublime-varnish
-[submodule "vendor/grammars/xc.tmbundle"]
-	path = vendor/grammars/xc.tmbundle
-	url = https://github.com/graymalkin/xc.tmbundle
-[submodule "vendor/grammars/perl.tmbundle"]
-	path = vendor/grammars/perl.tmbundle
-	url = https://github.com/textmate/perl.tmbundle
-[submodule "vendor/grammars/sublime-netlinx"]
-	path = vendor/grammars/sublime-netlinx
-	url = https://github.com/amclain/sublime-netlinx
-[submodule "vendor/grammars/Sublime-Red"]
-	path = vendor/grammars/Sublime-Red
-	url = https://github.com/Oldes/Sublime-Red
-[submodule "vendor/grammars/jflex.tmbundle"]
-	path = vendor/grammars/jflex.tmbundle
-	url = https://github.com/jflex-de/jflex.tmbundle.git
-[submodule "vendor/grammars/Sublime-Modula-2"]
-	path = vendor/grammars/Sublime-Modula-2
-	url = https://github.com/harogaston/Sublime-Modula-2
-[submodule "vendor/grammars/ada.tmbundle"]
-	path = vendor/grammars/ada.tmbundle
-	url = https://github.com/textmate/ada.tmbundle
-[submodule "vendor/grammars/api-blueprint-sublime-plugin"]
-	path = vendor/grammars/api-blueprint-sublime-plugin
-	url = https://github.com/apiaryio/api-blueprint-sublime-plugin
-[submodule "vendor/grammars/Handlebars"]
-	path = vendor/grammars/Handlebars
-	url = https://github.com/daaain/Handlebars
-[submodule "vendor/grammars/smali-sublime"]
-	path = vendor/grammars/smali-sublime
-	url = https://github.com/ShaneWilton/sublime-smali
-[submodule "vendor/grammars/language-jsoniq"]
-	path = vendor/grammars/language-jsoniq
-	url = https://github.com/wcandillon/language-jsoniq
-[submodule "vendor/grammars/atom-fsharp"]
-	path = vendor/grammars/atom-fsharp
-	url = https://github.com/fsprojects/atom-fsharp
-[submodule "vendor/grammars/SMT.tmbundle"]
-	path = vendor/grammars/SMT.tmbundle
-	url = https://github.com/SRI-CSL/SMT.tmbundle.git
-[submodule "vendor/grammars/language-crystal"]
-	path = vendor/grammars/language-crystal
-	url = https://github.com/atom-crystal/language-crystal
-[submodule "vendor/grammars/language-xbase"]
-	path = vendor/grammars/language-xbase
-	url = https://github.com/hernad/atom-language-harbour
-[submodule "vendor/grammars/language-ncl"]
-	path = vendor/grammars/language-ncl
-	url = https://github.com/rpavlick/language-ncl.git
-[submodule "vendor/grammars/pawn-sublime-language"]
-	path = vendor/grammars/pawn-sublime-language
-	url = https://github.com/Southclaw/pawn-sublime-language.git
-[submodule "vendor/grammars/atom-language-purescript"]
-	path = vendor/grammars/atom-language-purescript
-	url = https://github.com/purescript-contrib/atom-language-purescript
-[submodule "vendor/grammars/vue-syntax-highlight"]
-	path = vendor/grammars/vue-syntax-highlight
-	url = https://github.com/vuejs/vue-syntax-highlight
-[submodule "vendor/grammars/st2-zonefile"]
-	path = vendor/grammars/st2-zonefile
-	url = https://github.com/sixty4k/st2-zonefile
-[submodule "vendor/grammars/sublimeprolog"]
-	path = vendor/grammars/sublimeprolog
-	url = https://github.com/alnkpa/sublimeprolog
-[submodule "vendor/grammars/sublime-aspectj"]
-	path = vendor/grammars/sublime-aspectj
-	url = https://github.com/pchaigno/sublime-aspectj
-[submodule "vendor/grammars/sublime-pony"]
-	path = vendor/grammars/sublime-pony
-	url = https://github.com/CausalityLtd/sublime-pony
-[submodule "vendor/grammars/X10"]
-	path = vendor/grammars/X10
-	url = https://github.com/x10-lang/x10-highlighting
-[submodule "vendor/grammars/UrWeb-Language-Definition"]
-	path = vendor/grammars/UrWeb-Language-Definition
-	url = https://github.com/gwalborn/UrWeb-Language-Definition.git
-[submodule "vendor/grammars/Stata.tmbundle"]
-	path = vendor/grammars/Stata.tmbundle
-	url = https://github.com/pschumm/Stata.tmbundle
-[submodule "vendor/grammars/FreeMarker.tmbundle"]
-	path = vendor/grammars/FreeMarker.tmbundle
-	url = https://github.com/freemarker/FreeMarker.tmbundle
-[submodule "vendor/grammars/MagicPython"]
-	path = vendor/grammars/MagicPython
-	url = https://github.com/MagicStack/MagicPython
-[submodule "vendor/grammars/language-click"]
-	path = vendor/grammars/language-click
-	url = https://github.com/stenverbois/language-click.git
-[submodule "vendor/grammars/language-maxscript"]
-	path = vendor/grammars/language-maxscript
-	url = https://github.com/Alhadis/language-maxscript
-[submodule "vendor/grammars/language-renpy"]
-	path = vendor/grammars/language-renpy
-	url = https://github.com/williamd1k0/language-renpy.git
-[submodule "vendor/grammars/language-inform7"]
-	path = vendor/grammars/language-inform7
-	url = https://github.com/erkyrath/language-inform7
-[submodule "vendor/grammars/atom-language-stan"]
-	path = vendor/grammars/atom-language-stan
-	url = https://github.com/jrnold/atom-language-stan
-[submodule "vendor/grammars/language-yang"]
-	path = vendor/grammars/language-yang
-	url = https://github.com/DzonyKalafut/language-yang.git
-[submodule "vendor/grammars/language-less"]
-	path = vendor/grammars/language-less
-	url = https://github.com/atom/language-less.git
-[submodule "vendor/grammars/language-povray"]
-	path = vendor/grammars/language-povray
-	url = https://github.com/c-lipka/language-povray
-[submodule "vendor/grammars/sublime-terra"]
-	path = vendor/grammars/sublime-terra
-	url = https://github.com/pyk/sublime-terra
-[submodule "vendor/grammars/SublimePuppet"]
-	path = vendor/grammars/SublimePuppet
-	url = https://github.com/russCloak/SublimePuppet
-[submodule "vendor/grammars/sublimeassembly"]
-	path = vendor/grammars/sublimeassembly
-	url = https://github.com/Nessphoro/sublimeassembly
-[submodule "vendor/grammars/monkey"]
-	path = vendor/grammars/monkey
-	url = https://github.com/gingerbeardman/monkey.tmbundle
-[submodule "vendor/grammars/assembly"]
-	path = vendor/grammars/assembly
-	url = https://github.com/nanoant/assembly.tmbundle
-[submodule "vendor/grammars/boo"]
-	path = vendor/grammars/boo
-	url = https://github.com/Shammah/boo-sublime
-[submodule "vendor/grammars/logos"]
-	path = vendor/grammars/logos
-	url = https://github.com/Cykey/Sublime-Logos
-[submodule "vendor/grammars/pig-latin"]
-	path = vendor/grammars/pig-latin
-	url = https://github.com/goblindegook/sublime-text-pig-latin
-[submodule "vendor/grammars/sourcepawn"]
-	path = vendor/grammars/sourcepawn
-	url = https://github.com/github-linguist/sublime-sourcepawn
-[submodule "vendor/grammars/gdscript"]
-	path = vendor/grammars/gdscript
-	url = https://github.com/beefsack/GDScript-sublime
-[submodule "vendor/grammars/nesC"]
-	path = vendor/grammars/nesC
-	url = https://github.com/cdwilson/nesC.tmbundle
-[submodule "vendor/grammars/ats"]
-	path = vendor/grammars/ats
-	url = https://github.com/steinwaywhw/ats-mode-sublimetext
-[submodule "vendor/grammars/grace"]
-	path = vendor/grammars/grace
-	url = https://github.com/zmthy/grace-tmbundle
-[submodule "vendor/grammars/ejs-tmbundle"]
-	path = vendor/grammars/ejs-tmbundle
-	url = https://github.com/gregory-m/ejs-tmbundle
-[submodule "vendor/grammars/nix"]
-	path = vendor/grammars/nix
-	url = https://github.com/wmertens/sublime-nix
-[submodule "vendor/grammars/idris"]
-	path = vendor/grammars/idris
-	url = https://github.com/idris-hackers/idris-sublime.git
-[submodule "vendor/grammars/atomic-dreams"]
-	path = vendor/grammars/atomic-dreams
-	url = https://github.com/PJB3005/atomic-dreams
-[submodule "vendor/grammars/language-apl"]
-	path = vendor/grammars/language-apl
-	url = https://github.com/Alhadis/language-apl.git
-[submodule "vendor/grammars/language-graphql"]
-	path = vendor/grammars/language-graphql
-	url = https://github.com/rmosolgo/language-graphql
-[submodule "vendor/grammars/language-toc-wow"]
-	path = vendor/grammars/language-toc-wow
-	url = https://github.com/nebularg/language-toc-wow
-[submodule "vendor/grammars/sublime-autoit"]
-	path = vendor/grammars/sublime-autoit
-	url = https://github.com/AutoIt/SublimeAutoItScript
-[submodule "vendor/grammars/TLA"]
-	path = vendor/grammars/TLA
-	url = https://github.com/agentultra/TLAGrammar
-[submodule "vendor/grammars/sublime-clips"]
-	path = vendor/grammars/sublime-clips
-	url = https://github.com/psicomante/CLIPS-sublime
-[submodule "vendor/grammars/creole"]
-	path = vendor/grammars/creole
-	url = https://github.com/Siddley/Creole
-[submodule "vendor/grammars/language-csound"]
-	path = vendor/grammars/language-csound
-	url = https://github.com/nwhetsell/language-csound
-[submodule "vendor/grammars/language-wavefront"]
-	path = vendor/grammars/language-wavefront
-	url = https://github.com/Alhadis/language-wavefront
-[submodule "vendor/grammars/nu.tmbundle"]
-	path = vendor/grammars/nu.tmbundle
-	url = https://github.com/jsallis/nu.tmbundle
-[submodule "vendor/grammars/Elm"]
-	path = vendor/grammars/Elm
-	url = https://github.com/elm-community/Elm.tmLanguage
-[submodule "vendor/grammars/language-restructuredtext"]
-	path = vendor/grammars/language-restructuredtext
-	url = https://github.com/Lukasa/language-restructuredtext
-[submodule "vendor/grammars/atom-language-clean"]
-	path = vendor/grammars/atom-language-clean
-	url = https://github.com/timjs/atom-language-clean.git
-[submodule "vendor/grammars/language-turing"]
-	path = vendor/grammars/language-turing
-	url = https://github.com/Alhadis/language-turing
-[submodule "vendor/grammars/atom-language-srt"]
-	path = vendor/grammars/atom-language-srt
-	url = https://github.com/314eter/atom-language-srt
-[submodule "vendor/grammars/language-agc"]
-	path = vendor/grammars/language-agc
-	url = https://github.com/Alhadis/language-agc
-[submodule "vendor/grammars/language-blade"]
-	path = vendor/grammars/language-blade
-	url = https://github.com/jawee/language-blade
-[submodule "vendor/grammars/SublimeGDB"]
-	path = vendor/grammars/SublimeGDB
-	url = https://github.com/quarnster/SublimeGDB
-[submodule "vendor/grammars/language-roff"]
-	path = vendor/grammars/language-roff
-	url = https://github.com/Alhadis/language-roff
-[submodule "vendor/grammars/language-haskell"]
-	path = vendor/grammars/language-haskell
-	url = https://github.com/atom-haskell/language-haskell
-[submodule "vendor/grammars/language-asn1"]
-	path = vendor/grammars/language-asn1
-	url = https://github.com/ajLangley12/language-asn1
-[submodule "vendor/grammars/atom-language-1c-bsl"]
-	path = vendor/grammars/atom-language-1c-bsl
-	url = https://github.com/xDrivenDevelopment/atom-language-1c-bsl.git
-[submodule "vendor/grammars/sublime-rexx"]
-	path = vendor/grammars/sublime-rexx
-	url = https://github.com/mblocker/rexx-sublime
-[submodule "vendor/grammars/blitzmax"]
-	path = vendor/grammars/blitzmax
-	url = https://github.com/textmate/blitzmax.tmbundle
-[submodule "vendor/grammars/cython"]
-	path = vendor/grammars/cython
-	url = https://github.com/textmate/cython.tmbundle
-[submodule "vendor/grammars/forth"]
-	path = vendor/grammars/forth
-	url = https://github.com/textmate/forth.tmbundle
-[submodule "vendor/grammars/parrot"]
-	path = vendor/grammars/parrot
-	url = https://github.com/textmate/parrot.tmbundle
-[submodule "vendor/grammars/secondlife-lsl"]
-	path = vendor/grammars/secondlife-lsl
-	url = https://github.com/textmate/secondlife-lsl.tmbundle
+[submodule "vendor/grammars/verilog.tmbundle"]
+	path = vendor/grammars/verilog.tmbundle
+	url = https://github.com/textmate/verilog.tmbundle
 [submodule "vendor/grammars/vhdl"]
 	path = vendor/grammars/vhdl
 	url = https://github.com/textmate/vhdl.tmbundle
-[submodule "vendor/grammars/language-rpm-spec"]
-	path = vendor/grammars/language-rpm-spec
-	url = https://github.com/waveclaw/language-rpm-spec
-[submodule "vendor/grammars/language-emacs-lisp"]
-	path = vendor/grammars/language-emacs-lisp
-	url = https://github.com/Alhadis/language-emacs-lisp
-[submodule "vendor/grammars/language-babel"]
-	path = vendor/grammars/language-babel
-	url = https://github.com/github-linguist/language-babel
-[submodule "vendor/CodeMirror"]
-	path = vendor/CodeMirror
-	url = https://github.com/codemirror/CodeMirror
-[submodule "vendor/grammars/MQL5-sublime"]
-	path = vendor/grammars/MQL5-sublime
-	url = https://github.com/mqsoft/MQL5-sublime
-[submodule "vendor/grammars/actionscript3-tmbundle"]
-	path = vendor/grammars/actionscript3-tmbundle
-	url = https://github.com/simongregory/actionscript3-tmbundle
-[submodule "vendor/grammars/ABNF.tmbundle"]
-	path = vendor/grammars/ABNF.tmbundle
-	url = https://github.com/sanssecours/ABNF.tmbundle
-[submodule "vendor/grammars/EBNF.tmbundle"]
-	path = vendor/grammars/EBNF.tmbundle
-	url = https://github.com/sanssecours/EBNF.tmbundle
-[submodule "vendor/grammars/language-haml"]
-	path = vendor/grammars/language-haml
-	url = https://github.com/ezekg/language-haml
-[submodule "vendor/grammars/language-ninja"]
-	path = vendor/grammars/language-ninja
-	url = https://github.com/khyo/language-ninja
-[submodule "vendor/grammars/language-fontforge"]
-	path = vendor/grammars/language-fontforge
-	url = https://github.com/Alhadis/language-fontforge
-[submodule "vendor/grammars/language-gn"]
-	path = vendor/grammars/language-gn
-	url = https://github.com/devoncarew/language-gn
-[submodule "vendor/grammars/rascal-syntax-highlighting"]
-	path = vendor/grammars/rascal-syntax-highlighting
-	url = https://github.com/usethesource/rascal-syntax-highlighting
-[submodule "vendor/grammars/atom-language-perl6"]
-	path = vendor/grammars/atom-language-perl6
-	url = https://github.com/perl6/atom-language-perl6
-[submodule "vendor/grammars/language-xcompose"]
-	path = vendor/grammars/language-xcompose
-	url = https://github.com/samcv/language-xcompose
-[submodule "vendor/grammars/SublimeEthereum"]
-	path = vendor/grammars/SublimeEthereum
-	url = https://github.com/davidhq/SublimeEthereum.git
-[submodule "vendor/grammars/atom-language-rust"]
-	path = vendor/grammars/atom-language-rust
-	url = https://github.com/zargony/atom-language-rust
-[submodule "vendor/grammars/language-css"]
-	path = vendor/grammars/language-css
-	url = https://github.com/atom/language-css
-[submodule "vendor/grammars/language-regexp"]
-	path = vendor/grammars/language-regexp
-	url = https://github.com/Alhadis/language-regexp
-[submodule "vendor/grammars/Terraform.tmLanguage"]
-	path = vendor/grammars/Terraform.tmLanguage
-	url = https://github.com/alexlouden/Terraform.tmLanguage
-[submodule "vendor/grammars/shaders-tmLanguage"]
-	path = vendor/grammars/shaders-tmLanguage
-	url = https://github.com/tgjones/shaders-tmLanguage
-[submodule "vendor/grammars/language-meson"]
-	path = vendor/grammars/language-meson
-	url = https://github.com/TingPing/language-meson
-[submodule "vendor/grammars/atom-language-p4"]
-	path = vendor/grammars/atom-language-p4
-	url = https://github.com/TakeshiTseng/atom-language-p4
-[submodule "vendor/grammars/language-jison"]
-	path = vendor/grammars/language-jison
-	url = https://github.com/cdibbs/language-jison
-[submodule "vendor/grammars/openscad.tmbundle"]
-	path = vendor/grammars/openscad.tmbundle
-	url = https://github.com/tbuser/openscad.tmbundle
-[submodule "vendor/grammars/marko-tmbundle"]
-	path = vendor/grammars/marko-tmbundle
-	url = https://github.com/marko-js/marko-tmbundle
-[submodule "vendor/grammars/language-jolie"]
-	path = vendor/grammars/language-jolie
-	url = https://github.com/fmontesi/language-jolie
-[submodule "vendor/grammars/language-typelanguage"]
-	path = vendor/grammars/language-typelanguage
-	url = https://github.com/goodmind/language-typelanguage
-[submodule "vendor/grammars/sublime-shen"]
-	path = vendor/grammars/sublime-shen
-	url = https://github.com/rkoeninger/sublime-shen
-[submodule "vendor/grammars/Sublime-Pep8"]
-	path = vendor/grammars/Sublime-Pep8
-	url = https://github.com/R4PaSs/Sublime-Pep8
-[submodule "vendor/grammars/dartlang"]
-	path = vendor/grammars/dartlang
-	url = https://github.com/dart-atom/dartlang
-[submodule "vendor/grammars/language-closure-templates"]
-	path = vendor/grammars/language-closure-templates
-	url = https://github.com/mthadley/language-closure-templates
-[submodule "vendor/grammars/language-webassembly"]
-	path = vendor/grammars/language-webassembly
-	url = https://github.com/Alhadis/language-webassembly
-[submodule "vendor/grammars/language-ring"]
-	path = vendor/grammars/language-ring
-	url = https://github.com/MahmoudFayed/atom-language-ring
-[submodule "vendor/grammars/sublime-fantom"]
-	path = vendor/grammars/sublime-fantom
-	url = https://github.com/rkoeninger/sublime-fantom
-[submodule "vendor/grammars/language-pan"]
-	path = vendor/grammars/language-pan
-	url = https://github.com/quattor/language-pan
-[submodule "vendor/grammars/language-pcb"]
-	path = vendor/grammars/language-pcb
-	url = https://github.com/Alhadis/language-pcb
-[submodule "vendor/grammars/language-reason"]
-	path = vendor/grammars/language-reason
-	url = https://github.com/reasonml-editor/language-reason
-[submodule "vendor/grammars/sublime-nearley"]
-	path = vendor/grammars/sublime-nearley
-	url = https://github.com/Hardmath123/sublime-nearley
-[submodule "vendor/grammars/data-weave-tmLanguage"]
-	path = vendor/grammars/data-weave-tmLanguage
-	url = https://github.com/mulesoft-labs/data-weave-tmLanguage
-[submodule "vendor/grammars/squirrel-language"]
-	path = vendor/grammars/squirrel-language
-	url = https://github.com/mathewmariani/squirrel-language
-[submodule "vendor/grammars/language-ballerina"]
-	path = vendor/grammars/language-ballerina
-	url = https://github.com/ballerinalang/plugin-vscode
-[submodule "vendor/grammars/language-yara"]
-	path = vendor/grammars/language-yara
-	url = https://github.com/blacktop/language-yara
-[submodule "vendor/grammars/language-ruby"]
-	path = vendor/grammars/language-ruby
-	url = https://github.com/atom/language-ruby
-[submodule "vendor/grammars/sublime-angelscript"]
-	path = vendor/grammars/sublime-angelscript
-	url = https://github.com/wronex/sublime-angelscript
-[submodule "vendor/grammars/TypeScript-TmLanguage"]
-	path = vendor/grammars/TypeScript-TmLanguage
-	url = https://github.com/Microsoft/TypeScript-TmLanguage
+[submodule "vendor/grammars/vscode-scala-syntax"]
+	path = vendor/grammars/vscode-scala-syntax
+	url = https://github.com/scala/vscode-scala-syntax
+[submodule "vendor/grammars/vue-syntax-highlight"]
+	path = vendor/grammars/vue-syntax-highlight
+	url = https://github.com/vuejs/vue-syntax-highlight
 [submodule "vendor/grammars/wdl-sublime-syntax-highlighter"]
 	path = vendor/grammars/wdl-sublime-syntax-highlighter
 	url = https://github.com/broadinstitute/wdl-sublime-syntax-highlighter
-[submodule "vendor/grammars/atom-language-julia"]
-	path = vendor/grammars/atom-language-julia
-	url = https://github.com/JuliaEditorSupport/atom-language-julia
-[submodule "vendor/grammars/language-cwl"]
-	path = vendor/grammars/language-cwl
-	url = https://github.com/manabuishii/language-cwl
-[submodule "vendor/grammars/Syntax-highlighting-for-PostCSS"]
-	path = vendor/grammars/Syntax-highlighting-for-PostCSS
-	url = https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS
-[submodule "vendor/grammars/MATLAB-Language-grammar"]
-	path = vendor/grammars/MATLAB-Language-grammar
-	url = https://github.com/mathworks/MATLAB-Language-grammar
-[submodule "vendor/grammars/javadoc.tmbundle"]
-	path = vendor/grammars/javadoc.tmbundle
-	url = https://github.com/textmate/javadoc.tmbundle
-[submodule "vendor/grammars/JSyntax"]
-	path = vendor/grammars/JSyntax
-	url = https://github.com/tikkanz/JSyntax
-[submodule "vendor/grammars/Sublime-HTTP"]
-	path = vendor/grammars/Sublime-HTTP
-	url = https://github.com/samsalisbury/Sublime-HTTP
-[submodule "vendor/grammars/atom-language-nextflow"]
-	path = vendor/grammars/atom-language-nextflow
-	url = https://github.com/nextflow-io/atom-language-nextflow
-[submodule "vendor/grammars/conllu-linguist-grammar"]
-	path = vendor/grammars/conllu-linguist-grammar
-	url = https://github.com/odanoburu/conllu-linguist-grammar
+[submodule "vendor/grammars/xc.tmbundle"]
+	path = vendor/grammars/xc.tmbundle
+	url = https://github.com/graymalkin/xc.tmbundle
+[submodule "vendor/grammars/xml.tmbundle"]
+	path = vendor/grammars/xml.tmbundle
+	url = https://github.com/textmate/xml.tmbundle
+[submodule "vendor/grammars/zephir-sublime"]
+	path = vendor/grammars/zephir-sublime
+	url = https://github.com/phalcon/zephir-sublime

--- a/script/add-grammar
+++ b/script/add-grammar
@@ -112,4 +112,5 @@ end
 
 log "Updating grammar documentation in vendor/README.md"
 command('bundle', 'exec', 'rake', 'samples')
+command('script/sort-submodules')
 command('script/list-grammars')

--- a/script/sort-submodules
+++ b/script/sort-submodules
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+
+ROOT = File.expand_path "../../", __FILE__
+
+
+# Extract and sort a list of submodules
+def sort_entries(file_data)
+  submodules = []
+  file_data.scan(/(^\[submodule[^\n]+\n)((?:\t[^\n]+\n)+)/).each do |head, body|
+    path = body.match(/^\tpath\s*=\s*\K(.+)$/)[0]
+    submodules << [path, head + body]
+  end
+  submodules.sort! { |a,b| a[0] <=> b[0] }
+  submodules.collect { |i| i[1] }
+end
+
+
+usage = <<-EOH
+Usage:
+  #{$0} [-t|--test] [-h|--help]
+
+Examples:
+  #{$0}         # Update .gitmodules file in-place
+  #{$0} --help  # Display this help message
+  #{$0} --test  # Exit with an error code if .gitmodules needs sorting
+EOH
+
+$testing = false
+OptionParser.new do |opts|
+  opts.banner = usage
+  opts.on("-h", "--help") do
+    puts usage
+    exit
+  end
+  opts.on("-t", "--test", "Don't update file; only test if it's unsorted") do
+    $testing = true
+  end
+end.parse!
+
+
+unsorted = File.read("#{ROOT}/.gitmodules")
+sorted = sort_entries(unsorted).join
+
+if $testing
+  exit unsorted == sorted
+else
+  File.write "#{ROOT}/.gitmodules", sorted
+end

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -44,6 +44,11 @@ class TestPedantic < Minitest::Test
     assert_sorted tests
   end
 
+  def test_submodules_are_sorted
+    system(File.expand_path("../../script/sort-submodules", __FILE__) + " -t")
+    assert $?.success?
+  end
+
   def assert_sorted(list)
     list.each_cons(2) do |previous, item|
       flunk "#{previous} should come after #{item}" if previous > item


### PR DESCRIPTION
This PR adds a script to sort the contents of [`.gitmodules`](https://github.com/github/linguist/blob/master/.gitmodules) each time a new grammar is added.

## Description
We see this all the time:

<img src="https://user-images.githubusercontent.com/2346707/36861794-103c1acc-1dd9-11e8-908a-5b2bf59a6567.png" width="706" />

This happens because newly-registered submodules are always added at the very bottom of the `.gitmodules` file, meaning that merging one PR usually blocks the next one until the submitter has resolved conflicts manually. This slows everybody down: a user has to fix the conflicts themselves, then @lildude needs to approve the changes later.

We can remedy this simply by forcing the submodule list to be alphabetised (case-sensitively). A test has been added to ensure that manually-added modules still get ordered correctly.

As of this writing, there are currently nine PRs sitting open which have conflicting module-lists: [`#4030`](https://github.com/github/linguist/pull/4030#partial-timeline-marker), [`#4005`](https://github.com/github/linguist/pull/4005#partial-timeline-marker), [`#3983`](https://github.com/github/linguist/pull/3983#partial-timeline-marker), [`#3869`](https://github.com/github/linguist/pull/3869#partial-timeline-marker), [`#3802`](https://github.com/github/linguist/pull/3802#partial-timeline-marker), [`#3772`](https://github.com/github/linguist/pull/3772#partial-timeline-marker), [`#3764`](https://github.com/github/linguist/pull/3764#partial-timeline-marker), [`#3689`](https://github.com/github/linguist/pull/3689#partial-timeline-marker), [`#3720`](https://github.com/github/linguist/pull/3720#partial-timeline-marker).

I haven't even bothered to count how many that are *closed* which have had similar conflicts. :wink: 

## Checklist:
- [X] **I am adding new or changing current functionality**
  - [X] I have added or updated the tests for the new or changed functionality.
