### PR TITLE
Register "cperl" as an alias of Perl 5

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3371,6 +3371,7 @@ Perl:
   filenames:
   - cpanfile
   interpreters:
+  - cperl
   - perl
   aliases:
   - cperl

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3372,6 +3372,8 @@ Perl:
   - cpanfile
   interpreters:
   - perl
+  aliases:
+  - cperl
   language_id: 282
 Perl 6:
   type: programming


### PR DESCRIPTION
This PR enables recognition of Perl files containing cperl modelines:

~~~perl
#!/usr/bin/env perl
# -*- cperl -*-
~~~

## Description
Emacs ships with an enhanced major-mode for editing Perl 5 with embedded C sections (called `cperl-mode`, appropriately enough). One of the [sample files](https://github.com/github/linguist/pull/4066/files#diff-bfce7097cfedb19b250fbcbf3ad47aa6R1) added in #4066 reminded me about the mode, and I noticed it isn't being picked up by Linguist.

Since the mode has to be manually activated per file (since it isn't the default), the odds of it being used in embedded modeline are pretty high.
