### PR TITLE
Exclude R package doc directory

### DIFF
--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -15,6 +15,7 @@
 - ^[Mm]an/
 - ^[Ee]xamples/
 - ^[Dd]emos?/
+- ^inst/doc/
 
 ## Documentation files ##
 

--- a/lib/linguist/documentation.yml
+++ b/lib/linguist/documentation.yml
@@ -15,7 +15,7 @@
 - ^[Mm]an/
 - ^[Ee]xamples/
 - ^[Dd]emos?/
-- ^inst/doc/
+- (^|/)inst/doc/
 
 ## Documentation files ##
 


### PR DESCRIPTION
A standard path for documentation in R packages is `inst/doc`. `linguist` is picking up files in this directory and mis-classifying R packages as html. This PR excludes `inst/doc` from linguist analysis.

## Description
There are numerous examples at https://github.com/cran/. For example:

* https://github.com/cran/rtrim
* https://github.com/cran/wheatmap
