### PR TITLE
Update Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
   apt:
     packages:
     - libicu-dev
-    - libicu48
+    - libicu52
 
 before_install: script/travis/before_install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ git:
   depth: 3
 
 cache: bundler
-dist: precise
+dist: trusty
 
 bundler_args: --without debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ script:
   - script/licensed verify
 
 rvm:
-  - 2.1
-  - 2.2
   - 2.3.3
   - 2.4.0
+  - 2.5.0
 
 notifications:
   disabled: true


### PR DESCRIPTION
Update the Travis configuration to switch to using Trusty and remove EOL and soon-to-be-EOL'd versions of Ruby.

## Description

Builds have suddenly started failing whilst attempting to install the rugged gem. As part of investigating this I noticed our Travis config is really out of date and given Travis have no clear intentions of [supporting Precise beyond March 2018](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status) (only 3 days left) I thought it best to switch us to Trusty now.

This happens to have resolved the problem installing the rugged gem too 😄 

Whilst I was at it, I've also removed testing against [Ruby 2.1 as it is already EOL and 2.2 as it is EOL at the end of March too](https://www.ruby-lang.org/en/downloads/branches/).

Removing the rest of the checklist as it doesn't apply.