### PR TITLE
Add HXML support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1885,6 +1885,13 @@ Haxe:
   - ".hxsl"
   tm_scope: source.hx
   language_id: 158
+HXML:
+  type: data
+  ace_mode: text
+  extensions:
+  - ".hxml"
+  tm_scope: source.hxml
+  language_id: 786683730
 Hy:
   type: programming
   ace_mode: text

--- a/samples/HXML/checkstyle.hxml
+++ b/samples/HXML/checkstyle.hxml
@@ -1,0 +1,10 @@
+buildGlobal.hxml
+-lib mcover:2.1.1
+-D unittest
+-x TestMain
+--macro mcover.MCover.coverage(['checkstyle'], ['src'], ['checkstyle.reporter', 'checkstyle.Main'])
+
+--next
+-cmd neko run -s src -s test -p resources/static-analysis.txt
+-cmd neko run --default-config resources/default-config.json
+-cmd neko run -c resources/default-config.json

--- a/samples/HXML/vshaxe.hxml
+++ b/samples/HXML/vshaxe.hxml
@@ -1,0 +1,31 @@
+# This file is generated with vshaxe-build - DO NOT EDIT MANUALLY!
+-cp vscode-extern/src
+-cp src-api
+-cp src
+-cp server/src
+-cp server/protocol/src
+-cp server/formatter/src
+-cp server/test
+-cp server/formatter/test
+-cp syntaxes/src
+-D analyzer-optimize
+-D js_unflatten
+-D hxnodejs-no-version-warning
+-D JSTACK_MAIN=vshaxe.Main.main
+-D JSTACK_ASYNC_ENTRY
+-D JSTACK_FORMAT=vscode
+-lib hxnodejs
+-lib jstack
+-lib haxe-hxparser
+-lib compiletime
+-lib mockatoo
+-lib mconsole
+-lib hx3compat
+-lib hxargs
+-lib json2object
+-lib yaml
+-lib plist
+-debug
+-js bin/build.js
+--no-inline
+-main Build


### PR DESCRIPTION
This adds support for HXML (https://haxe.org/manual/compiler-usage-hxml.html), which is a file format used for storing Haxe compiler arguments. Generally speaking it's used by most Haxe projects not using a library that come with its own build tool / project description format.

## Description

A HXML grammar is already containd in the haxe-TmLanguage submodule I added earlier in #4079, so it's not necessary to add a new submodule.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?p=1&q=extension%3Ahxml+cp&type=Code&utf8=%E2%9C%93
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
        - [vshaxe.hxml](https://github.com/vshaxe/vshaxe/blob/master/complete.hxml)
        - [checkstyle.hxml](https://github.com/HaxeCheckstyle/haxe-checkstyle/blob/dev/buildTest.hxml)
    - Sample license(s):
        - [MIT](https://github.com/vshaxe/vshaxe/blob/master/LICENSE.md)
        - [MIT](https://github.com/HaxeCheckstyle/haxe-checkstyle/blob/dev/LICENCE.md)
  - [ ] I have included a syntax highlighting grammar.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
