### PR TITLE
Add support for `sed` as a programming language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -568,6 +568,9 @@
 [submodule "vendor/grammars/language-ruby"]
 	path = vendor/grammars/language-ruby
 	url = https://github.com/atom/language-ruby
+[submodule "vendor/grammars/language-sed"]
+	path = vendor/grammars/language-sed
+	url = https://github.com/Alhadis/language-sed
 [submodule "vendor/grammars/language-shellscript"]
 	path = vendor/grammars/language-shellscript
 	url = https://github.com/atom/language-shellscript

--- a/grammars.yml
+++ b/grammars.yml
@@ -484,6 +484,8 @@ vendor/grammars/language-ruby:
 - source.ruby
 - source.ruby.gemfile
 - text.html.erb
+vendor/grammars/language-sed:
+- source.sed
 vendor/grammars/language-shellscript:
 - source.shell
 - text.shell-session

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5360,6 +5360,19 @@ reStructuredText:
   codemirror_mode: rst
   codemirror_mime_type: text/x-rst
   language_id: 419
+sed:
+  type: programming
+  color: "#64b970"
+  extensions:
+  - ".sed"
+  interpreters:
+  - gsed
+  - minised
+  - sed
+  - ssed
+  ace_mode: text
+  tm_scope: source.sed
+  language_id: 847830017
 wdl:
   type: programming
   color: "#42f1f4"

--- a/samples/sed/hanoi.sed
+++ b/samples/sed/hanoi.sed
@@ -1,0 +1,103 @@
+# Towers of Hanoi in sed.
+#
+#	@(#)hanoi.sed	8.1 (Berkeley) 6/6/93
+# $FreeBSD$
+#
+#
+# Ex:
+# Run "sed -f hanoi.sed", and enter:
+#
+#	:abcd: : :<CR>
+#
+# note -- TWO carriage returns were once required, this will output the
+# sequence of states involved in moving 4 rings, the largest called "a" and
+# the smallest called "d", from the first to the second of three towers, so
+# that the rings on any tower at any time are in descending order of size.
+# You can start with a different arrangement and a different number of rings,
+# say :ce:b:ax: and it will give the shortest procedure for moving them all
+# to the middle tower.  The rules are: the names of the rings must all be
+# lower-case letters, they must be input within 3 fields (representing the
+# towers) and delimited by 4 colons, such that the letters within each field
+# are in alphabetical order (i.e. rings are in descending order of size).
+#
+# For the benefit of anyone who wants to figure out the script, an "internal"
+# line of the form
+#		b:0abx:1a2b3 :2   :3x2
+# has the following meaning: the material after the three markers :1, :2,
+# and :3 represents the three towers; in this case the current set-up is
+# ":ab :   :x  :".  The numbers after a, b and x in these fields indicate
+# that the next time it gets a chance, it will move a to tower 2, move b
+# to tower 3, and move x to tower 2.  The string after :0 just keeps track
+# of the alphabetical order of the names of the rings.  The b at the
+# beginning means that it is now dealing with ring b (either about to move
+# it, or re-evaluating where it should next be moved to).
+#
+# Although this version is "limited" to 26 rings because of the size of the
+# alphabet, one could write a script using the same idea in which the rings
+# were represented by arbitrary [strings][within][brackets], and in place of
+# the built-in line of the script giving the order of the letters of the
+# alphabet, it would accept from the user a line giving the ordering to be
+# assumed, e.g. [ucbvax][decvax][hplabs][foo][bar].
+#
+#			George Bergman
+#			Math, UC Berkeley 94720 USA
+
+# cleaning, diagnostics
+s/  *//g
+/^$/d
+/[^a-z:]/{a\
+Illegal characters: use only a-z and ":".  Try again.
+d
+}
+/^:[a-z]*:[a-z]*:[a-z]*:$/!{a\
+Incorrect format: use\
+\	: string1 : string2 : string3 :<CR>\
+Try again.
+d
+}
+/\([a-z]\).*\1/{a\
+Repeated letters not allowed.  Try again.
+d
+}
+# initial formatting
+h
+s/[a-z]/ /g
+G
+s/^:\( *\):\( *\):\( *\):\n:\([a-z]*\):\([a-z]*\):\([a-z]*\):$/:1\4\2\3:2\5\1\3:3\6\1\2:0/
+s/[a-z]/&2/g
+s/^/abcdefghijklmnopqrstuvwxyz/
+:a
+s/^\(.\).*\1.*/&\1/
+s/.//
+/^[^:]/ba
+s/\([^0]*\)\(:0.*\)/\2\1:/
+s/^[^0]*0\(.\)/\1&/
+:b
+# outputting current state without markers
+h
+s/.*:1/:/
+s/[123]//gp
+g
+:c
+# establishing destinations
+/^\(.\).*\1:1/td
+/^\(.\).*:1[^:]*\11/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\31/
+/^\(.\).*:1[^:]*\12/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\33/
+/^\(.\).*:1[^:]*\13/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\32/
+/^\(.\).*:2[^:]*\11/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\33/
+/^\(.\).*:2[^:]*\12/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\32/
+/^\(.\).*:2[^:]*\13/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\31/
+/^\(.\).*:3[^:]*\11/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\32/
+/^\(.\).*:3[^:]*\12/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\31/
+/^\(.\).*:3[^:]*\13/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\33/
+bc
+# iterate back to find smallest out-of-place ring
+:d
+s/^\(.\)\(:0[^:]*\([^:]\)\1.*:\([123]\)[^:]*\1\)\4/\3\2\4/
+td
+# move said ring (right, resp. left)
+s/^\(.\)\(.*\)\1\([23]\)\(.*:\3[^ ]*\) /\1\2 \4\1\3/
+s/^\(.\)\(.*:\([12]\)[^ ]*\) \(.*\)\1\3/\1\2\1\3\4 /
+tb
+s/.*/Done!  Try another, or end with ^D./p
+d

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -329,6 +329,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Scheme:** [textmate/scheme.tmbundle](https://github.com/textmate/scheme.tmbundle)
 - **Scilab:** [textmate/scilab.tmbundle](https://github.com/textmate/scilab.tmbundle)
 - **SCSS:** [MarioRicalde/SCSS.tmbundle](https://github.com/MarioRicalde/SCSS.tmbundle)
+- **sed:** [Alhadis/language-sed](https://github.com/Alhadis/language-sed)
 - **ShaderLab:** [tgjones/shaders-tmLanguage](https://github.com/tgjones/shaders-tmLanguage)
 - **Shell:** [atom/language-shellscript](https://github.com/atom/language-shellscript)
 - **ShellSession:** [atom/language-shellscript](https://github.com/atom/language-shellscript)

--- a/vendor/licenses/grammar/language-sed.txt
+++ b/vendor/licenses/grammar/language-sed.txt
@@ -1,0 +1,18 @@
+---
+type: grammar
+name: language-sed
+license: isc
+---
+Copyright (c) 2018, John Gardner
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
## Description
This PR adds [`sed`](https://en.wikipedia.org/wiki/Sed) to GitHub's list of recognised programming languages. `sed` is [Turing-complete](http://www.catonmat.net/blog/proof-that-sed-is-turing-complete/), and has been used to program [Tetris](http://www.catonmat.net/ftp/sed/sedtris.sed), [calculators](http://www.catonmat.net/ftp/sed/dc.sed), and your average [Turing machine](http://sed.sourceforge.net/grabbag/scripts/turing.sed).

## In-the-wild usage
The number of `sed` scripts on GitHub is surprising: searching for [`.sed` files](https://github.com/search?q=extension%3Ased+NOT+nothack&type=Code) brings back almost 600,000 results. All [959 samples](https://github.com/Alhadis/Linguist-Silo/tree/sed/files) I downloaded were unambiguously `sed` code.

## Sample file
Locating an unencumbered `sed` script with a clear license was hard. Thankfully, FreeBSD's `sed` contained a [decent-looking example](https://github.com/freebsd/freebsd/blob/41a8d8c29552ddd9098cfb09a71927f503a28371/usr.bin/sed/tests/hanoi.sed) of `sed` programming.

Licensed under the BSD-2-clause.

## Language grammar
[My own work](https://github.com/Alhadis/language-sed#sed-script-syntax-highlighting), which I wrote especially for you guys. :wink:
