### PR TITLE
Fix adding/replacing a grammar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ To run Linguist from the cloned repository:
 
 ### Dependencies
 
-Linguist uses the [`charlock_holmes`](https://github.com/brianmario/charlock_holmes) character encoding detection library which in turn uses [ICU](http://site.icu-project.org/), and the libgit2 bindings for Ruby provided by [`rugged`](https://github.com/libgit2/rugged). These components have their own dependencies - `icu4c`, and `cmake` and `pkg-config` respectively - which you may need to install before you can install Linguist.
+Linguist uses the [`charlock_holmes`](https://github.com/brianmario/charlock_holmes) character encoding detection library which in turn uses [ICU](http://site.icu-project.org/), and the libgit2 bindings for Ruby provided by [`rugged`](https://github.com/libgit2/rugged). [Docker](https://www.docker.com/) is also required when adding or updating grammars. These components have their own dependencies - `icu4c`, and `cmake` and `pkg-config` respectively - which you may need to install before you can install Linguist.
 
-For example, on macOS with [Homebrew](http://brew.sh/): `brew install cmake pkg-config icu4c` and on Ubuntu: `apt-get install cmake pkg-config libicu-dev`.
+For example, on macOS with [Homebrew](http://brew.sh/): `brew install cmake pkg-config icu4c docker` and on Ubuntu: `apt-get install cmake pkg-config libicu-dev docker-ce`.
 
 ## Adding an extension to a language
 

--- a/script/add-grammar
+++ b/script/add-grammar
@@ -107,7 +107,7 @@ log "Confirming license"
 if repo_old
   command('script/licensed')
 else
-  command('script/licensed', '--module', repo_new)
+  command('script/licensed', '--module', "#{File.expand_path("../", File.dirname(__FILE__))}/#{repo_new}")
 end
 
 log "Updating grammar documentation in vendor/README.md"

--- a/script/add-grammar
+++ b/script/add-grammar
@@ -111,7 +111,8 @@ log "Confirming license"
 if repo_old
   command('script/licensed')
 else
-  command('script/licensed', '--module', "#{File.expand_path("../", File.dirname(__FILE__))}/#{repo_new}")
+  repo_new = File.absolute_path(repo_new)
+  command('script/licensed', '--module', repo_new)
 end
 
 log "Updating grammar documentation in vendor/README.md"

--- a/script/add-grammar
+++ b/script/add-grammar
@@ -84,6 +84,10 @@ unless $url
   exit 1;
 end
 
+# Exit early if docker isn't installed or running.
+log "Checking docker is installed and running"
+command('docker', 'ps')
+
 # Ensure the given URL is an HTTPS link
 parts    = parse_url $url
 https    = "https://#{parts[:host]}/#{parts[:user]}/#{parts[:repo]}"


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description

Whilst looking into the problems with https://github.com/github/linguist/pull/4088, I discovered adding a new grammar broke with the merging of https://github.com/github/linguist/pull/3982 as follows:

```
$ script/add-grammar https://github.com/munificent/wren-sublime
Registering new submodule: vendor/grammars/wren-sublime
$ git submodule add -f https://github.com/munificent/wren-sublime vendor/grammars/wren-sublime
$ script/grammar-compiler add vendor/grammars/wren-sublime
Confirming license
$ script/licensed --module vendor/grammars/wren-sublime
  > Caching licenes for linguist:
  >   grammar dependencies:
  > /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/dependency.rb:19:in `initialize': Dependency path vendor/grammars/wren-sublime must be absolute (RuntimeError)
  > 	from script/licensed:26:in `new'
  > 	from script/licensed:26:in `block in dependencies'
  > 	from script/licensed:24:in `map'
  > 	from script/licensed:24:in `dependencies'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:27:in `block (3 levels) in run'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:20:in `map'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:20:in `block (2 levels) in run'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:17:in `chdir'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:17:in `block in run'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:12:in `each'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:12:in `flat_map'
  > 	from /Users/lildude/github/linguist/vendor/gems/ruby/2.4.0/gems/licensed-1.0.0/lib/licensed/command/cache.rb:12:in `run'
  > 	from script/licensed:53:in `<main>'
  > caching vendor/grammars/wren-sublime
$
```

This was because we missed a spot where we needed to pass in a full repo path to licensed.

Whilst I'm at it, I've also put a quick guard to ensure Docker is installed and running so users get a nicer failure experience:

```
$ script/add-grammar https://github.com/munificent/wren-sublime
Detecting docker
$ docker ps
  > Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
$
```

I've also updated the CONTRIBUTING.md to point out Docker is required for adding or replacing grammars.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
