### PR TITLE
Strategies take result from previous strategy into account

### DIFF
--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -3,13 +3,15 @@ module Linguist
     # Public: Use shebang to detect language of the blob.
     #
     # blob               - An object that quacks like a blob.
+    # candidates         - A list of candidate languages.
     #
     # Examples
     #
     #   Shebang.call(FileBlob.new("path/to/file"))
     #
-    # Returns an Array with one Language if the blob has a shebang with a valid
-    # interpreter, or empty if there is no shebang.
+    # Returns an Array of Languages from the candidate list for which the
+    # blob's shebang is valid. Returns an empty list if there is not shebang.
+    # If the candidate list is empty, any language is a valid candidate.
     def self.call(blob, candidates)
       return [] if blob.symlink?
 

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -10,10 +10,11 @@ module Linguist
     #
     # Returns an Array with one Language if the blob has a shebang with a valid
     # interpreter, or empty if there is no shebang.
-    def self.call(blob, _ = nil)
+    def self.call(blob, candidates)
       return [] if blob.symlink?
 
-      Language.find_by_interpreter interpreter(blob.data)
+      languages = Language.find_by_interpreter interpreter(blob.data)
+      if candidates.any? then candidates & languages else languages end
     end
 
     # Public: Get the interpreter from the shebang

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -9,8 +9,8 @@ module Linguist
     #
     #   Shebang.call(FileBlob.new("path/to/file"))
     #
-    # Returns an Array of Languages from the candidate list for which the
-    # blob's shebang is valid. Returns an empty list if there is not shebang.
+    # Returns an array of languages from the candidate list for which the
+    # blob's shebang is valid. Returns an empty list if there is no shebang.
     # If the candidate list is empty, any language is a valid candidate.
     def self.call(blob, candidates)
       return [] if blob.symlink?

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -16,7 +16,7 @@ module Linguist
       return [] if blob.symlink?
 
       languages = Language.find_by_interpreter interpreter(blob.data)
-      if candidates.any? then candidates & languages else languages end
+      candidates.any? ? candidates & languages : languages
     end
 
     # Public: Get the interpreter from the shebang

--- a/lib/linguist/strategy/extension.rb
+++ b/lib/linguist/strategy/extension.rb
@@ -2,8 +2,9 @@ module Linguist
   module Strategy
     # Detects language based on extension
     class Extension
-      def self.call(blob, _)
-        Language.find_by_extension(blob.name.to_s)
+      def self.call(blob, candidates)
+        languages = Language.find_by_extension(blob.name.to_s)
+        if candidates.any? then languages & candidates else languages end
       end
     end
   end

--- a/lib/linguist/strategy/extension.rb
+++ b/lib/linguist/strategy/extension.rb
@@ -16,7 +16,7 @@ module Linguist
       # in which case any language is a valid candidate.
       def self.call(blob, candidates)
         languages = Language.find_by_extension(blob.name.to_s)
-        if candidates.any? then languages & candidates else languages end
+        candidates.any? ? candidates & languages : languages
       end
     end
   end

--- a/lib/linguist/strategy/extension.rb
+++ b/lib/linguist/strategy/extension.rb
@@ -2,6 +2,18 @@ module Linguist
   module Strategy
     # Detects language based on extension
     class Extension
+      # Public: Use the file extension to detect the blob's language.
+      #
+      # blob               - An object that quacks like a blob.
+      # candidates         - A list of candidate languages.
+      #
+      # Examples
+      #
+      #   Extension.call(FileBlob.new("path/to/file"))
+      #
+      # Returns an Array of Languages associated blob's file extension.
+      # Selected Languages must be in the candidate list, except if it's empty,
+      # in which case any language is a valid candidate.
       def self.call(blob, candidates)
         languages = Language.find_by_extension(blob.name.to_s)
         if candidates.any? then languages & candidates else languages end

--- a/lib/linguist/strategy/extension.rb
+++ b/lib/linguist/strategy/extension.rb
@@ -11,8 +11,8 @@ module Linguist
       #
       #   Extension.call(FileBlob.new("path/to/file"))
       #
-      # Returns an Array of Languages associated blob's file extension.
-      # Selected Languages must be in the candidate list, except if it's empty,
+      # Returns an array of languages associated with a blob's file extension.
+      # Selected languages must be in the candidate list, except if it's empty,
       # in which case any language is a valid candidate.
       def self.call(blob, candidates)
         languages = Language.find_by_extension(blob.name.to_s)

--- a/lib/linguist/strategy/filename.rb
+++ b/lib/linguist/strategy/filename.rb
@@ -2,9 +2,10 @@ module Linguist
   module Strategy
     # Detects language based on filename
     class Filename
-      def self.call(blob, _)
+      def self.call(blob, candidates)
         name = blob.name.to_s
-        Language.find_by_filename(name)
+        languages = Language.find_by_filename(name)
+        if candidates.any? then candidates & languages else languages end
       end
     end
   end

--- a/lib/linguist/strategy/filename.rb
+++ b/lib/linguist/strategy/filename.rb
@@ -17,7 +17,7 @@ module Linguist
       def self.call(blob, candidates)
         name = blob.name.to_s
         languages = Language.find_by_filename(name)
-        if candidates.any? then candidates & languages else languages end
+        candidates.any? ? candidates & languages : languages
       end
     end
   end

--- a/lib/linguist/strategy/filename.rb
+++ b/lib/linguist/strategy/filename.rb
@@ -2,6 +2,18 @@ module Linguist
   module Strategy
     # Detects language based on filename
     class Filename
+      # Public: Use the filename to detect the blob's language.
+      #
+      # blob               - An object that quacks like a blob.
+      # candidates         - A list of candidate languages.
+      #
+      # Examples
+      #
+      #   Filename.call(FileBlob.new("path/to/file"))
+      #
+      # Returns an Array of Languages associated blob's filename. Selected
+      # Languages must be in the candidate list, except if it's empty, in which
+      # case any language is a valid candidate.
       def self.call(blob, candidates)
         name = blob.name.to_s
         languages = Language.find_by_filename(name)

--- a/lib/linguist/strategy/filename.rb
+++ b/lib/linguist/strategy/filename.rb
@@ -11,9 +11,9 @@ module Linguist
       #
       #   Filename.call(FileBlob.new("path/to/file"))
       #
-      # Returns an Array of Languages associated blob's filename. Selected
-      # Languages must be in the candidate list, except if it's empty, in which
-      # case any language is a valid candidate.
+      # Returns an array of languages with a associated blob's filename.
+      # Selected languages must be in the candidate list, except if it's empty,
+      # in which case any language is a valid candidate.
       def self.call(blob, candidates)
         name = blob.name.to_s
         languages = Language.find_by_filename(name)

--- a/test/fixtures/Perl/01-methods.pl
+++ b/test/fixtures/Perl/01-methods.pl
@@ -1,0 +1,51 @@
+#!perl
+use Test::More;
+use Test::Exception;
+
+use_ok 'Music::ScaleNote';
+
+my $msn = Music::ScaleNote->new(
+    scale_note => 'C',
+    scale_name => 'pminor',
+#    verbose    => 1,
+);
+isa_ok $msn, 'Music::ScaleNote';
+
+my $x;
+
+throws_ok { $x = $msn->get_offset() }
+    qr/note_name, note_format or offset not provided/, 'invalid get_offset';
+
+my $format = 'midinum';
+$x = $msn->get_offset(
+    note_name   => 60,
+    note_format => $format,
+    offset      => 1,
+);
+is $x->format($format), 63, 'get_offset';
+
+$format = 'ISO';
+$x = $msn->get_offset(
+    note_name   => 'D#4',
+    note_format => $format,
+    offset      => -1,
+);
+is $x->format($format), 'C4', 'get_offset';
+
+throws_ok {
+    $x = $msn->get_offset(
+        note_name   => 'C0',
+        note_format => $format,
+        offset      => -1,
+    )
+} qr/Octave: -1 out of bounds/, 'out of bounds';
+
+throws_ok {
+    $x = $msn->get_offset(
+        note_name   => 'A#127',
+        note_format => $format,
+        offset      => 1,
+    )
+} qr/Octave: 128 out of bounds/, 'out of bounds';
+
+done_testing();


### PR DESCRIPTION
With this pull request, each strategy takes as candidates the language outputted by the previous strategy, if any. This was already the case for the Classifier and Heuristic strategies as these couldn't generate new candidate languages (as opposed to the Modeline, Filename, Shebang, and Extension strategies).

In practice, this signifies that if, for example, the Shebang strategy finds two possible languages for a given file (as is currently possible with the `perl` interpreter), the next strategy, the Extension strategy, will use that information and further reduce the set of possible language.
Currently, without this commit, the Extension strategy would discard the results from the previous strategy and start anew, possibly returning a different language from those returned by the Shebang strategy.

The first commit adds a fixture file to show the error happening (see [Travis CI](https://travis-ci.org/github/linguist/builds/366515803?utm_source=github_status&utm_medium=notification)) when a shebang (in this case the `perl` shebang) is owned by several languages (Perl and Pod). According to [this small and dirty script](https://gist.github.com/pchaigno/616aecceeb759e3ad19730439e146bea), 2 other interpreters are shared by 4 languages:
```
$ ./find-shared.py interpreters
OCaml and Reason share set(['ocaml'])
Terra and Lua share set(['lua'])
Parrot Internal Representation and Parrot Assembly share set(['parrot'])
Parrot Assembly and Parrot Internal Representation share set(['parrot'])
Reason and OCaml share set(['ocaml'])
Perl and Pod share set(['perl'])
Lua and Terra share set(['lua'])
Pod and Perl share set(['perl'])
``` 

Fixes #4090.
Fixes #4094.