### PR TITLE
Add ".rdg" as a registered XML file extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5114,6 +5114,7 @@ XML:
   - ".psc1"
   - ".pt"
   - ".rdf"
+  - ".rdg"
   - ".resx"
   - ".rss"
   - ".sch"

--- a/samples/XML/rdcman.rdg
+++ b/samples/XML/rdcman.rdg
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RDCMan programVersion="2.7" schemaVersion="3">
+  <file>
+    <credentialsProfiles />
+    <properties>
+      <expanded>True</expanded>
+      <name>rdcman</name>
+    </properties>
+    <group>
+      <properties>
+        <expanded>True</expanded>
+        <name>GroupATX</name>
+      </properties>
+      <group>
+        <properties>
+          <expanded>True</expanded>
+          <name>GroupDMZ</name>
+        </properties>
+        <server>
+          <properties>
+            <name>ServerDMZ01</name>
+          </properties>
+        </server>
+        <server>
+          <properties>
+            <name>ServerDMZ02</name>
+          </properties>
+        </server>
+      </group>
+      <group>
+        <properties>
+          <expanded>False</expanded>
+          <name>GroupInternal</name>
+        </properties>
+      </group>
+    </group>
+  </file>
+  <connected />
+  <favorites />
+  <recentlyUsed />
+</RDCMan>


### PR DESCRIPTION
This PR registers `.rdg` as a recognised file extension for XML data.

## Description
My first encounter with the extension happened a [few days ago](https://github.com/file-icons/atom/issues/727), where a user complained about `rdg` files not using the usual XML icon. After addressing their issue, I decided to see if the extension had enough in-the-wild use to warrant being registered with Linguist.

Which proved to be a pain, thanks to very skewed metrics:

1. Roughly [3,015 `.rdg` files](https://github.com/search?q=extension%3Ardg+NOT+nothack&type=Code) exist on GitHub
2. Of the [2,019 URLs](https://github.com/Alhadis/Linguist-Silo/blob/rdg/urls.log) I managed to harvest, 1,968 of them were non-XML files from the same [user and repository](https://github.com/Titroid/FortressOfOz/blob/efa29f8bad762a3c9610c332d9d97b3dcc34de61/18291929_Project2_Part1/RW%20144%20Project%202/Levels/Level991.rdg).
3. That leaves only 51 files: [8 were non-XML](https://github.com/Alhadis/Linguist-Silo/tree/rdg/files/unknown-various), and [44 were indeed XML](https://rawgit.com/Alhadis/Linguist-Silo/rdg/files/xml/!ORIGIN_LIST.html).

All this accounts for just 27 unique repos, and 26 unique users. Not acceptable usage IMHO.

#### However...
[Harvester](https://github.com/Alhadis/Harvester) has no way of collecting the 996 remaining URLs because the ~1960 non-XML results from [`Titroid/FortressOfOz`](https://github.com/Titroid/FortressOfOz/tree/efa29f8bad762a3c9610c332d9d97b3dcc34de61) keep filling up the bulk of search result pages.

And it's (apparently?) impossible to exclude individual users or repositories in search results. E.g., the query [`extension:rdg NOT user:Titroid NOT nothack`](https://github.com/search?utf8=%E2%9C%93&q=extension%3Ardg+NOT+user%3ATitroid+NOT+nothack&type=) doesn't work. The non-XML `rdg` files are comprised only of digits and semicolons, giving us no common pattern with which to exclude it from searches.

@pchaigno Do you know how to exclude specific users/repos?

## Origin of sample

The [`rdcman.rdg`](https://github.com/KevinMarquette/kevinmarquette.github.io/blob/1ae0717e9093198ad57b2a53595042c6330e2a83/public/rdcman.rdg) file was sourced from [`kevinmarquette.github.io`](https://github.com/KevinMarquette/kevinmarquette.github.io/tree/1ae0717e9093198ad57b2a53595042c6330e2a83), released under the [MIT license](https://github.com/KevinMarquette/kevinmarquette.github.io/blob/master/LICENSE).