### PR TITLE
Silence warnings being emitted when running tests

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -411,7 +411,7 @@ module Linguist
     end
 
     disambiguate ".q" do |data|
-      if /[A-Z\.][\w\d\.]*:{/i.match(data) || /(^|\n)\\(cd?|d|l|p|ts?) /.match(data)
+      if /[A-Z.][\w.]*:{/i.match(data) || /(^|\n)\\(cd?|d|l|p|ts?) /.match(data)
         Language["q"]
       elsif /SELECT\s+[\w*,]+\s+FROM/i.match(data) || /(CREATE|ALTER|DROP)\s(DATABASE|SCHEMA|TABLE)/i.match(data)
         Language["HiveQL"]

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -27,9 +27,9 @@ module Linguist
     @alias_index        = {}
     @language_id_index  = {}
 
-    @extension_index          = Hash.new { |h,k| h[k] = [] }
-    @interpreter_index        = Hash.new { |h,k| h[k] = [] }
-    @filename_index           = Hash.new { |h,k| h[k] = [] }
+    @extension_index    = Hash.new { |h,k| h[k] = [] }
+    @interpreter_index  = Hash.new { |h,k| h[k] = [] }
+    @filename_index     = Hash.new { |h,k| h[k] = [] }
 
     # Valid Languages types
     TYPES = [:data, :markup, :programming, :prose]
@@ -291,9 +291,9 @@ module Linguist
       @language_id = attributes[:language_id]
 
       # Set extensions or default to [].
-      @extensions = attributes[:extensions] || []
-      @interpreters = attributes[:interpreters]   || []
-      @filenames  = attributes[:filenames]  || []
+      @extensions   = attributes[:extensions]   || []
+      @interpreters = attributes[:interpreters] || []
+      @filenames    = attributes[:filenames]    || []
 
       # Set popular, and searchable flags
       @popular    = attributes.key?(:popular)    ? attributes[:popular]    : false
@@ -499,12 +499,12 @@ module Linguist
     end
   end
 
-  extensions = Samples.cache['extnames']
+  extensions   = Samples.cache['extnames']
   interpreters = Samples.cache['interpreters']
-  filenames = Samples.cache['filenames']
-  popular = YAML.load_file(File.expand_path("../popular.yml", __FILE__))
+  filenames    = Samples.cache['filenames']
+  popular      = YAML.load_file(File.expand_path("../popular.yml", __FILE__))
 
-  languages_yml = File.expand_path("../languages.yml", __FILE__)
+  languages_yml  = File.expand_path("../languages.yml",  __FILE__)
   languages_json = File.expand_path("../languages.json", __FILE__)
 
   if File.exist?(languages_json) && defined?(Yajl)
@@ -514,9 +514,9 @@ module Linguist
   end
 
   languages.each do |name, options|
-    options['extensions'] ||= []
+    options['extensions']   ||= []
     options['interpreters'] ||= []
-    options['filenames'] ||= []
+    options['filenames']    ||= []
 
     if extnames = extensions[name]
       extnames.each do |extname|
@@ -527,9 +527,8 @@ module Linguist
       end
     end
 
-    if interpreters == nil
-      interpreters = {}
-    end
+    interpreters = {} if interpreters.nil?
+    filenames    = {} if filenames.nil?
 
     if interpreter_names = interpreters[name]
       interpreter_names.each do |interpreter|

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -501,7 +501,6 @@ module Linguist
 
   extensions   = Samples.cache['extnames']
   interpreters = Samples.cache['interpreters']
-  filenames    = Samples.cache['filenames']
   popular      = YAML.load_file(File.expand_path("../popular.yml", __FILE__))
 
   languages_yml  = File.expand_path("../languages.yml",  __FILE__)
@@ -527,8 +526,7 @@ module Linguist
       end
     end
 
-    interpreters = {} if interpreters.nil?
-    filenames    = {} if filenames.nil?
+    interpreters ||= {}
 
     if interpreter_names = interpreters[name]
       interpreter_names.each do |interpreter|


### PR DESCRIPTION
I saw these warnings as I was running tests for #4133:

~~~
lib/linguist/heuristics.rb:414: warning: character class has duplicated range: /[A-Z\.][\w\d\.]*:{/
lib/linguist/language.rb:504: warning: assigned but unused variable - filenames
~~~

They're trivial but still unrelated to what #4133 is doing, so I siphoned these changes off to a separate PR. :-) Explanation of changes:

> warning: character class has duplicated range: `/[A-Z\.][\w\d\.]*:{/`

That's happening because `\w` already covers the character ranges that `\d` does. Using them together in a bracketed character class is therefore redundant.

I also removed the backslash from the dots too, because hold no special meaning when used within a character class. It wouldn't make sense for it to match any single character in a defined subset of specific characters you're trying to match. =)

> warning: assigned but unused variable - filenames

Admittedly, I don't even know what this line is doing:

~~~rb
filenames = Samples.cache['filenames']
~~~

But I didn't wanna remove it in case it was there to deliberately invoke a side-effect by accessing `Samples.cache['filenames']`. But I wanted it to shut up so I found a way to make it "used" by sprucing up a conditional assignment:

~~~rb
-    if interpreters == nil	+    interpreters = {} if interpreters.nil?
-      interpreters = {}	+    filenames    = {} if filenames.nil?
-    end
+    interpreters = {} if interpreters.nil?
+    filenames    = {} if filenames.nil?
~~~

Which inevitably lead to me polishing whitespace elsewhere in the file, as you'll see by the diffs. :grin: I'd apologise for being a neat-freak, but you guys know I'm not actually sorry. :heart: 