### PR TITLE
Restrict Vim modeline parsing to a single line

### DIFF
--- a/lib/linguist/strategy/modeline.rb
+++ b/lib/linguist/strategy/modeline.rb
@@ -36,7 +36,7 @@ module Linguist
 
         # Start modeline. Could be `vim:`, `vi:` or `ex:`
         (?:
-          (?:\s|^)
+          (?:[[:blank:]]|^)
           vi
           (?:m[<=>]?\d+|m)? # Version-specific modeline
           |
@@ -49,10 +49,10 @@ module Linguist
         # serves as a terminator for an option sequence, delimited by whitespace.
         (?=
           # So we have to ensure the modeline ends with a colon
-          : (?=\s* set? \s [^\n:]+ :) |
+          : (?=[[:blank:]]* set? [[:blank:]] [^\n:]+ :) |
 
           # Otherwise, it isn't valid syntax and should be ignored
-          : (?!\s* set? \s)
+          : (?![[:blank:]]* set? [[:blank:]])
         )
 
         # Possible (unrelated) `option=value` pairs to skip past
@@ -60,9 +60,9 @@ module Linguist
           # Option separator. Vim uses whitespace or colons to separate options (except if
           # the alternate "vim: set " form is used, where only whitespace is used)
           (?:
-            \s
+            [[:blank:]]
             |
-            \s* : \s* # Note that whitespace around colons is accepted too:
+            [[:blank:]]* : [[:blank:]]* # Note that whitespace around colons is accepted too:
           )           # vim: noai :  ft=ruby:noexpandtab
 
           # Option's name. All recognised Vim options have an alphanumeric form.
@@ -71,11 +71,11 @@ module Linguist
           # Possible value. Not every option takes an argument.
           (?:
             # Whitespace between name and value is allowed: `vim: ft   =ruby`
-            \s*=
+            [[:blank:]]*=
 
             # Option's value. Might be blank; `vim: ft= ` says "use no filetype".
             (?:
-              [^\\\s] # Beware of escaped characters: titlestring=\ ft=ruby
+              [^\\[[:blank:]]] # Beware of escaped characters: titlestring=\ ft=ruby
               |       # will be read by Vim as { titlestring: " ft=ruby" }.
               \\.
             )*
@@ -83,13 +83,13 @@ module Linguist
         )*
 
         # The actual filetype declaration
-        [\s:] (?:filetype|ft|syntax) \s*=
+        [[[:blank:]]:] (?:filetype|ft|syntax) [[:blank:]]*=
 
         # Language's name
         (\w+)
 
         # Ensure it's followed by a legal separator
-        (?=\s|:|$)
+        (?=[[:blank:]]|:|$)
       /xi
 
       MODELINES = [EMACS_MODELINE, VIM_MODELINE]

--- a/lib/linguist/strategy/modeline.rb
+++ b/lib/linguist/strategy/modeline.rb
@@ -63,7 +63,7 @@ module Linguist
             [ \t]
             |
             [ \t]* : [ \t]* # Note that whitespace around colons is accepted too:
-          )           # vim: noai :  ft=ruby:noexpandtab
+          )                 # vim: noai :  ft=ruby:noexpandtab
 
           # Option's name. All recognised Vim options have an alphanumeric form.
           \w*
@@ -76,7 +76,7 @@ module Linguist
             # Option's value. Might be blank; `vim: ft= ` says "use no filetype".
             (?:
               [^\\[ \t]] # Beware of escaped characters: titlestring=\ ft=ruby
-              |       # will be read by Vim as { titlestring: " ft=ruby" }.
+              |          # will be read by Vim as { titlestring: " ft=ruby" }.
               \\.
             )*
           )?

--- a/lib/linguist/strategy/modeline.rb
+++ b/lib/linguist/strategy/modeline.rb
@@ -36,7 +36,7 @@ module Linguist
 
         # Start modeline. Could be `vim:`, `vi:` or `ex:`
         (?:
-          (?:[[:blank:]]|^)
+          (?:[ \t]|^)
           vi
           (?:m[<=>]?\d+|m)? # Version-specific modeline
           |
@@ -49,10 +49,10 @@ module Linguist
         # serves as a terminator for an option sequence, delimited by whitespace.
         (?=
           # So we have to ensure the modeline ends with a colon
-          : (?=[[:blank:]]* set? [[:blank:]] [^\n:]+ :) |
+          : (?=[ \t]* set? [ \t] [^\n:]+ :) |
 
           # Otherwise, it isn't valid syntax and should be ignored
-          : (?![[:blank:]]* set? [[:blank:]])
+          : (?![ \t]* set? [ \t])
         )
 
         # Possible (unrelated) `option=value` pairs to skip past
@@ -60,9 +60,9 @@ module Linguist
           # Option separator. Vim uses whitespace or colons to separate options (except if
           # the alternate "vim: set " form is used, where only whitespace is used)
           (?:
-            [[:blank:]]
+            [ \t]
             |
-            [[:blank:]]* : [[:blank:]]* # Note that whitespace around colons is accepted too:
+            [ \t]* : [ \t]* # Note that whitespace around colons is accepted too:
           )           # vim: noai :  ft=ruby:noexpandtab
 
           # Option's name. All recognised Vim options have an alphanumeric form.
@@ -71,11 +71,11 @@ module Linguist
           # Possible value. Not every option takes an argument.
           (?:
             # Whitespace between name and value is allowed: `vim: ft   =ruby`
-            [[:blank:]]*=
+            [ \t]*=
 
             # Option's value. Might be blank; `vim: ft= ` says "use no filetype".
             (?:
-              [^\\[[:blank:]]] # Beware of escaped characters: titlestring=\ ft=ruby
+              [^\\[ \t]] # Beware of escaped characters: titlestring=\ ft=ruby
               |       # will be read by Vim as { titlestring: " ft=ruby" }.
               \\.
             )*
@@ -83,13 +83,13 @@ module Linguist
         )*
 
         # The actual filetype declaration
-        [[[:blank:]]:] (?:filetype|ft|syntax) [[:blank:]]*=
+        [[ \t]:] (?:filetype|ft|syntax) [ \t]*=
 
         # Language's name
         (\w+)
 
         # Ensure it's followed by a legal separator
-        (?=[[:blank:]]|:|$)
+        (?=[ \t]|:|$)
       /xi
 
       MODELINES = [EMACS_MODELINE, VIM_MODELINE]


### PR DESCRIPTION
## Description

Files which have a similar syntax to Vim modelines, such as YAML, can trigger regex matching behavior that makes filetype detection very slow. In this pull request, I've replaced `\s` in the Vim modeline regex (which considers newlines as whitespace) with the POSIX bracket expression `[[:blank:]]`, which doesn't (`[ \t]` should also work, if that's preferred). This constrains the parsing of each modeline to a single line and avoids the pathological case.

This short YAML file can be used to reproduce the behavior:

```
# vim: ft=yaml:ts=2:sw=2:expandtab
defaults:
  milestone: q1
  priority:  2
branches:
  master:
    events:
      push:
        :state: integrate
        :resolution: change
      merge:
        :state: analyze
        :substate: review
```

Before the change, using Ruby 2.4.2 on Linux:

```
$ time bundle exec bin/linguist pathological.yml 
pathological.yml: 15 lines (13 sloc)
  type:      Text
  mime type: text/x-yaml
  language:  YAML

real	1m3.701s
user	1m3.144s
sys	0m0.156s
```

After:

```
$ time bundle exec bin/linguist pathological.yml 
pathological.yml: 15 lines (13 sloc)
  type:      Text
  mime type: text/x-yaml
  language:  YAML

real	0m0.850s
user	0m0.524s
sys	0m0.104s
```

<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

I have not added any tests here, as I think the existing coverage in fixtures like _test/fixtures/Data/Modelines/iamjs2.pl_ already covers the desired behavior. If I've missed anything, please let me know!