### PR TITLE
Replace PowerShell grammar by a better one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -729,7 +729,7 @@
 	url = https://github.com/textmate/postscript.tmbundle
 [submodule "vendor/grammars/powershell"]
 	path = vendor/grammars/powershell
-	url = https://github.com/SublimeText/PowerShell
+	url = https://github.com/PowerShell/EditorSyntax
 [submodule "vendor/grammars/processing.tmbundle"]
 	path = vendor/grammars/processing.tmbundle
 	url = https://github.com/textmate/processing.tmbundle

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -286,7 +286,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **PostCSS:** [hudochenkov/Syntax-highlighting-for-PostCSS](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS)
 - **PostScript:** [textmate/postscript.tmbundle](https://github.com/textmate/postscript.tmbundle)
 - **POV-Ray SDL:** [c-lipka/language-povray](https://github.com/c-lipka/language-povray)
-- **PowerShell:** [SublimeText/PowerShell](https://github.com/SublimeText/PowerShell)
+- **PowerShell:** [PowerShell/EditorSyntax](https://github.com/PowerShell/EditorSyntax)
 - **Processing:** [textmate/processing.tmbundle](https://github.com/textmate/processing.tmbundle)
 - **Prolog:** [alnkpa/sublimeprolog](https://github.com/alnkpa/sublimeprolog)
 - **Propeller Spin:** [bitbased/sublime-spintools](https://github.com/bitbased/sublime-spintools)


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->
Replace PowerShell grammar from using https://github.com/sublimetext/powershell to using https://github.com/PowerShell/EditorSyntax .

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
In #2047 we switched to using https://github.com/sublimetext/powershell for the grammar.
Since then a new project got created: 1 project to rule all the powershell tmLanguage grammars.
https://github.com/PowerShell/EditorSyntax

Today ST switched to using EditorSyntax, and it doesn't make sense anymore to use ST grammar in linguist: it should go directly to EditorSyntax.

cc @omniomi @tylerl0706

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FSublimeText%2FPowerShell%2Fblob%2F61eac16114081a2de1731092bad41db499678ab3%2FSupport%2FPowershellSyntax.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2FPowerShell%2FEditorSyntax%2Fblob%2F8ec90660044b1729d9724d83c37fec5d40d16186%2Fspec%2Ftestfiles%2Fsyntax_test_TheBigTestFile.ps1&code=
  - New: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FPowerShell%2FEditorSyntax%2Fblob%2F8ec90660044b1729d9724d83c37fec5d40d16186%2FPowerShellSyntax.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2FPowerShell%2FEditorSyntax%2Fblob%2F8ec90660044b1729d9724d83c37fec5d40d16186%2Fspec%2Ftestfiles%2Fsyntax_test_TheBigTestFile.ps1&code=

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
