### PR TITLE
Update script/licensed usage to accommodate upstream changes

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'yajl-ruby'
   s.add_development_dependency 'color-proximity', '~> 0.2.1'
-  s.add_development_dependency 'licensed', '~> 1.0.0'
+  s.add_development_dependency 'licensed', '~> 1.1.0'
   s.add_development_dependency 'licensee'
 end

--- a/script/licensed
+++ b/script/licensed
@@ -9,11 +9,13 @@ require "optparse"
 module Licensed
   module Source
     class Filesystem
-      attr_reader :type
 
-      def initialize(glob, type: "directory")
+      def self.type
+        "grammar"
+      end
+
+      def initialize(glob)
         @glob = glob
-        @type = type
       end
 
       def enabled?
@@ -24,7 +26,7 @@ module Licensed
         Dir.glob(@glob).map do |directory|
           puts "caching #{directory}"
           Licensed::Dependency.new(directory, {
-            "type" => type,
+            "type" => Filesystem.type,
             "name" => File.basename(directory)
           })
         end
@@ -40,7 +42,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-source = Licensed::Source::Filesystem.new(module_path || "#{File.expand_path("../", File.dirname(__FILE__))}/vendor/grammars/*/", type: "grammar")
+source = Licensed::Source::Filesystem.new(module_path || "#{File.expand_path("../", File.dirname(__FILE__))}/vendor/grammars/*/")
 config = Licensed::Configuration.load_from(File.expand_path("../vendor/licenses/config.yml", File.dirname(__FILE__)))
 config.sources << source
 

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -12,17 +12,17 @@ class TestGrammars < Minitest::Test
 
   HASH_WHITELIST = [
     "2edac46b0a63309c96442d2826321a442217472f", # Agda.tmbundle
-    "7dfce11e2e3579ee43b83e69b1b64e77a2e378f0", # ant.tmbundle
+    "4da01d631a29c76456fd0bd16749c71e8d5f6dbf", # ant.tmbundle
     "79e72fd673dcebadd8fbace8d43db3da96d2c09f", # bro-sublime
-    "62b97e52b78439c14550a44a3fe51332aeffb3a1", # elixir-tmbundle
+    "220e011c8d686129e9c4163a7c655b9d64f61e59", # elixir-tmbundle
     "75cf04a9121ca7bb5a9c122b33007ac016ba72e7", # factor
-    "0acff2bb1536a3942a39ac74987ffd9c44905a6b", # FreeMarker.tmbundle
+    "b81acf2ba52d312754bf5055845a723123bda388", # FreeMarker.tmbundle
     "ee77ce4cf9121bccc3e37ba6b98f8e7acd589aaf", # gap-tmbundle
     "4cfc7ce12de920ccc836bbab2d748151d5ba7e38", # go-tmbundle
     "6c2e34d62c08f97a3e2ece3eedc65fbd99873ff4", # idl.tmbundle
     "e5212ae103917a9c2c3c1429a4569df466686fbd", # Isabelle.tmbundle
     "bb56ce634fb7ddd38eee988c593ab7cb98a04f64", # jflex.tmbundle
-    "41cdc7e9f9d2e62eb8ac68a1a9359b9c39a7a9bf", # mako-tmbundle
+    "39f092c726491ca6a02354dbc6c3a0920bb44d4c", # mako-tmbundle
     "7821982b18bc35d6925cc16ece68d9c71f1fbba3", # moonscript-tmbundle
     "c235154dbf7864612ac0d337ef5fe79a586b061a", # PHP-Twig.tmbundle
     "0c216b112f3a4e6d5848128504d8378d8c7eee00", # r.tmbundle


### PR DESCRIPTION
The next version of [licensed](https://github.com/github/licensed/) will cause a breakage in our ability to add grammars, particularly around grabbing the license.  This PR fixes that.

## Description

[licensed](https://github.com/github/licensed/) changed the method sources are defined in https://github.com/github/licensed/pull/33. As we use a self-defined Filesystem source, we don't get the upstream changes for free so need to make changes ourselves else we'll get failures like this when users attempt to add or update a grammar:

```console
$ script/add-grammar https://github.com/newgrammars/m3
Checking docker is installed and running
$ docker ps
Registering new submodule: vendor/grammars/m3
$ git submodule add -f https://github.com/newgrammars/m3 vendor/grammars/m3
$ script/grammar-compiler add vendor/grammars/m3
Confirming license
$ script/licensed --module /Users/lildude/github/linguist/vendor/grammars/m3
  > Caching licenes for linguist:
  > /Users/lildude/github/licensed/lib/licensed/command/cache.rb:21:in `block (3 levels) in run': undefined method `type' for Licensed::Source::Filesystem:Class (NoMethodError)
  > 	from /Users/lildude/github/licensed/lib/licensed/command/cache.rb:20:in `map'
  > 	from /Users/lildude/github/licensed/lib/licensed/command/cache.rb:20:in `block (2 levels) in run'
  > 	from /Users/lildude/github/licensed/lib/licensed/command/cache.rb:17:in `chdir'
  > 	from /Users/lildude/github/licensed/lib/licensed/command/cache.rb:17:in `block in run'
  > 	from /Users/lildude/github/licensed/lib/licensed/command/cache.rb:12:in `each'
  > 	from /Users/lildude/github/licensed/lib/licensed/command/cache.rb:12:in `flat_map'
  > 	from /Users/lildude/github/licensed/lib/licensed/command/cache.rb:12:in `run'
  > 	from script/licensed:53:in `<main>'
```

This PR fixes this by slightly modifying and simplifying our self-defined Filesystem source.

```console
$ script/add-grammar https://github.com/newgrammars/m3
Checking docker is installed and running
$ docker ps
Registering new submodule: vendor/grammars/m3
$ git submodule add -f https://github.com/newgrammars/m3 vendor/grammars/m3
$ script/grammar-compiler add vendor/grammars/m3
Confirming license
$ script/licensed --module /Users/lildude/github/linguist/vendor/grammars/m3
Updating grammar documentation in vendor/README.md
$ bundle exec rake samples
$ script/sort-submodules
$ script/list-grammars
$
$ git status
On branch lildude/accom-new-licensed
Your branch is up to date with 'origin/lildude/accom-new-licensed'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   .gitmodules
	modified:   Gemfile
	modified:   grammars.yml

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	vendor/grammars/m3/
	vendor/licenses/grammar/m3.txt

no changes added to commit (use "git add" and/or "git commit -a")
$
```

This will mean we need to enforce a minimum requirement for Licensed once a new release has been made that includes the changes from https://github.com/github/licensed/pull/33 and https://github.com/github/licensed/pull/41.  I'll add this to this PR once the release has been made.

@jonabc do you see any problems with the approach I've taken here? Or maybe we should be changing the method we use entirely so we don't have to do this if licensed changes like this again in future?

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
