### PR TITLE
Add varlink grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -595,6 +595,9 @@
 [submodule "vendor/grammars/language-typelanguage"]
 	path = vendor/grammars/language-typelanguage
 	url = https://github.com/goodmind/language-typelanguage
+[submodule "vendor/grammars/language-varlink"]
+	path = vendor/grammars/language-varlink
+	url = https://github.com/varlink/language-varlink
 [submodule "vendor/grammars/language-viml"]
 	path = vendor/grammars/language-viml
 	url = https://github.com/Alhadis/language-viml

--- a/grammars.yml
+++ b/grammars.yml
@@ -503,6 +503,8 @@ vendor/grammars/language-turing:
 - source.turing
 vendor/grammars/language-typelanguage:
 - source.tl
+vendor/grammars/language-varlink:
+- source.varlink
 vendor/grammars/language-viml:
 - source.viml
 vendor/grammars/language-wavefront:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5424,6 +5424,14 @@ sed:
   ace_mode: text
   tm_scope: source.sed
   language_id: 847830017
+varlink:
+  type: programming
+  color: "#5882FA"
+  extensions:
+  - ".varlink"
+  ace_mode: text
+  tm_scope: source.varlink
+  language_id: 396563549
 wdl:
   type: programming
   color: "#42f1f4"

--- a/samples/varlink/com.redhat.system.varlink
+++ b/samples/varlink/com.redhat.system.varlink
@@ -1,0 +1,49 @@
+#
+# Source: https://github.com/varlink/com.redhat.system/blob/master/src/com.redhat.system.varlink
+# Licenses:
+# MIT - https://github.com/varlink/com.redhat.system/blob/master/LICENSE-MIT
+# Apache - https://github.com/varlink/com.redhat.system/blob/master/LICENSE-APACHE
+#
+#
+# The Activator Interface allows to configure and maintain a list of available
+# interfaces. When an interface is accessed by a client, the activator receives
+# the initial message, starts the service which implements this interface, and
+# hands over the listening connection with the initial message.
+interface com.redhat.system
+
+type Executable (
+  path: string,
+  user_id: ?int,
+  group_id: ?int
+)
+
+type Service (
+  address: string,
+  interfaces: [string](),
+  executable: ?Executable,
+  activate_at_startup: ?bool
+)
+
+type Config (
+  vendor: string,
+  product: string,
+  version: string,
+  url: string,
+  services: []Service,
+  systems: [string]string
+)
+
+# Retrieve the current configuration.
+method GetConfig() -> (config: Config)
+
+# Add services to the list of managed services.
+method AddServices(services: []Service) -> ()
+
+# Add systems to the list of known systems.
+method AddSystems(systems: [string]string) -> ()
+
+# Remove and stop services from the list of manages services.
+method RemoveServices(services: []Service) -> ()
+
+# Remove and stop services from the list of manages services.
+method RemoveSystems(systems: []string) -> ()

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -385,6 +385,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **UnrealScript:** [textmate/java.tmbundle](https://github.com/textmate/java.tmbundle)
 - **UrWeb:** [gwalborn/UrWeb-Language-Definition](https://github.com/gwalborn/UrWeb-Language-Definition)
 - **Vala:** [technosophos/Vala-TMBundle](https://github.com/technosophos/Vala-TMBundle)
+- **varlink:** [varlink/language-varlink](https://github.com/varlink/language-varlink)
 - **VCL:** [brandonwamboldt/sublime-varnish](https://github.com/brandonwamboldt/sublime-varnish)
 - **Verilog:** [textmate/verilog.tmbundle](https://github.com/textmate/verilog.tmbundle)
 - **VHDL:** [textmate/vhdl.tmbundle](https://github.com/textmate/vhdl.tmbundle)

--- a/vendor/licenses/grammar/language-varlink.txt
+++ b/vendor/licenses/grammar/language-varlink.txt
@@ -1,0 +1,27 @@
+---
+type: grammar
+name: language-varlink
+license: mit
+---
+
+MIT License
+
+Copyright (c) 2018 Harald Hoyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->
Added the [varlink](https://varlink.org) grammar and a sample.

## Checklist:
- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&q=extension%3Avarlink+NOT+notahack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/varlink/com.redhat.system/blob/master/src/com.redhat.system.varlink
    - Sample license(s):
      - MIT and Apache
  - [x] I have included a syntax highlighting grammar.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
