### PR TITLE
Use correct tm_scope for Unix Assembler

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4828,7 +4828,7 @@ Unix Assembly:
   extensions:
   - ".s"
   - ".ms"
-  tm_scope: source.assembly.unix
+  tm_scope: source.x86
   ace_mode: assembly_x86
   language_id: 120
 Uno:


### PR DESCRIPTION
## Description
As pointed out in https://github.com/github/linguist/issues/4163, GNU/Unix Assembler files are not being syntax highlighted.

@pchaigno spotted that this is because the `tm_scope` is incorrect. This PR corrects that.

## Checklist:

- [x] **I am ~adding new or changing current functionality~ fixing a bug**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

Fixes https://github.com/github/linguist/issues/4163