### PR TITLE
Make Dockerfile a programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1057,7 +1057,7 @@ Diff:
   codemirror_mime_type: text/x-diff
   language_id: 88
 Dockerfile:
-  type: data
+  type: programming
   tm_scope: source.dockerfile
   extensions:
   - ".dockerfile"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1058,6 +1058,7 @@ Diff:
   language_id: 88
 Dockerfile:
   type: programming
+  color: "#0db7ed"
   tm_scope: source.dockerfile
   extensions:
   - ".dockerfile"


### PR DESCRIPTION
## Description
Dockerfiles have grown hugely in popularity since first added to Linguist and are essentially scripts. To quote https://docs.docker.com/engine/reference/builder/:

> A Dockerfile is a text document that contains all the commands a user could call on the command line to assemble an image. 

... which is essentially what a shell script it.  This PR flips the categorisation from `data` to `programming` so these files are now included in the language stats.

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

No need for new or different tests as we're just changing how a language is classified.

#### TODO: 
- [x] Find a colour that is representative, but doesn't conflict - gonna be tough as Docker ❤️ blue, like everyone else.

Fixes https://github.com/github/linguist/issues/3628