### PR TITLE
Tidy languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1,29 +1,32 @@
 # Defines all Languages known to GitHub.
 #
-# type              - Either data, programming, markup, prose, or nil
-# aliases           - An Array of additional aliases (implicitly
-#                     includes name.downcase)
-# ace_mode          - A String name of the Ace Mode used for highlighting whenever
-#                     a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
-#                     Use "text" if a mode does not exist.
-# codemirror_mode   - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
-#                     This must match a mode from https://git.io/vi9Fx
-# wrap              - Boolean wrap to enable line wrapping (default: false)
-# extensions        - An Array of associated extensions (the first one is
-#                     considered the primary extension, the others should be
-#                     listed alphabetically)
-# interpreters      - An Array of associated interpreters
-# searchable        - Boolean flag to enable searching (defaults to true)
-# language_id       - Integer used as a language-name-independent indexed field so that we can rename
-#                     languages in Linguist without reindexing all the code on GitHub. Must not be
-#                     changed for existing languages without the explicit permission of GitHub staff.
-# color             - CSS hex color to represent the language. Only used if type is "programming" or "prose".
-# tm_scope          - The TextMate scope that represents this programming
-#                     language. This should match one of the scopes listed in
-#                     the grammars.yml file. Use "none" if there is no grammar
-#                     for this language.
-# group             - Name of the parent language. Languages in a group are counted
-#                     in the statistics as the parent language.
+# type                  - Either data, programming, markup, prose, or nil
+# aliases               - An Array of additional aliases (implicitly
+#                         includes name.downcase)
+# ace_mode              - A String name of the Ace Mode used for highlighting whenever
+#                         a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
+#                         Use "text" if a mode does not exist.
+# codemirror_mode       - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
+#                         This must match a mode from https://git.io/vi9Fx
+# codemirror_mime_type  - A String name of the file mime type used for highlighting whenever a file is edited.
+#                         This should match the `mime` associated with the mode from https://git.io/f4SoQ
+# wrap                  - Boolean wrap to enable line wrapping (default: false)
+# extensions            - An Array of associated extensions (the first one is
+#                         considered the primary extension, the others should be
+#                         listed alphabetically)
+# filenames             - An Array of filenames commonly associated with the language
+# interpreters          - An Array of associated interpreters
+# searchable            - Boolean flag to enable searching (defaults to true)
+# language_id           - Integer used as a language-name-independent indexed field so that we can rename
+#                         languages in Linguist without reindexing all the code on GitHub. Must not be
+#                         changed for existing languages without the explicit permission of GitHub staff.
+# color                 - CSS hex color to represent the language. Only used if type is "programming" or "prose".
+# tm_scope              - The TextMate scope that represents this programming
+#                         language. This should match one of the scopes listed in
+#                         the grammars.yml file. Use "none" if there is no grammar
+#                         for this language.
+# group                 - Name of the parent language. Languages in a group are counted
+#                         in the statistics as the parent language.
 #
 # Any additions or modifications (even trivial) should have corresponding
 # test changes in `test/test_blob.rb`.

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2947,7 +2947,6 @@ NetLogo:
   language_id: 246
 NewLisp:
   type: programming
-  lexer: NewLisp
   color: "#87AED7"
   extensions:
   - ".nl"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -731,7 +731,7 @@ Closure Templates:
   ace_mode: soy_template
   codemirror_mode: soy
   codemirror_mime_type: text/x-soy
-  alias:
+  aliases:
   - soy
   extensions:
   - ".soy"
@@ -827,7 +827,8 @@ Common Lisp:
   codemirror_mime_type: text/x-common-lisp
   language_id: 66
 Common Workflow Language:
-  alias: cwl
+  aliases:
+  - cwl
   type: programming
   ace_mode: yaml
   codemirror_mode: yaml


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description
As pointed out in https://github.com/github/linguist/issues/4172...

- the `codemirror_mime_type` and `filenames` fields are not documented 
- two instances of `alias` are used instead of `aliases`
- a single instance of `lexer` is left over and was missed in https://github.com/github/linguist/pull/1707

This PR addresses these points.

## Checklist:
- [ ] **I am ~adding new or changing current functionality~ tidying things up**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

Gonna investigate how hard it'll be to implement a type of schema validation for the `languages.yml` file so we can catch things like incorrect use of `alias` or unused fields.

Fixes https://github.com/github/linguist/issues/4172