### PR TITLE
Fix up macOS build

### DIFF
--- a/ext/linguist/strndup.c
+++ b/ext/linguist/strndup.c
@@ -8,13 +8,3 @@ char *strndup(const char *s1, size_t n)
 	return copy;
 }
 #endif
-
-
-#if defined(__APPLE__)
-char *strndup(const char *s1, size_t n)
-{
-  char *copy = calloc(n + 1, sizeof(char));
-  memcpy(copy, s1, n);
-  return copy;
-}
-#endif


### PR DESCRIPTION
Fix the macOS build by not defining `strndup` for it; it's already in the standard library.

/cc @lildude 