### PR TITLE
Fix languages.yml's header

### DIFF
--- a/script/set-language-ids
+++ b/script/set-language-ids
@@ -7,30 +7,33 @@ require 'pry'
 header = <<-EOF
 # Defines all Languages known to GitHub.
 #
-# type              - Either data, programming, markup, prose, or nil
-# aliases           - An Array of additional aliases (implicitly
-#                     includes name.downcase)
-# ace_mode          - A String name of the Ace Mode used for highlighting whenever
-#                     a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
-#                     Use "text" if a mode does not exist.
-# codemirror_mode   - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
-#                     This must match a mode from https://git.io/vi9Fx
-# wrap              - Boolean wrap to enable line wrapping (default: false)
-# extensions        - An Array of associated extensions (the first one is
-#                     considered the primary extension, the others should be
-#                     listed alphabetically)
-# interpreters      - An Array of associated interpreters
-# searchable        - Boolean flag to enable searching (defaults to true)
-# language_id       - Integer used as a language-name-independent indexed field so that we can rename
-#                     languages in Linguist without reindexing all the code on GitHub. Must not be
-#                     changed for existing languages without the explicit permission of GitHub staff.
-# color             - CSS hex color to represent the language. Only used if type is "programming" or "prose".
-# tm_scope          - The TextMate scope that represents this programming
-#                     language. This should match one of the scopes listed in
-#                     the grammars.yml file. Use "none" if there is no grammar
-#                     for this language.
-# group             - Name of the parent language. Languages in a group are counted
-#                     in the statistics as the parent language.
+# type                  - Either data, programming, markup, prose, or nil
+# aliases               - An Array of additional aliases (implicitly
+#                         includes name.downcase)
+# ace_mode              - A String name of the Ace Mode used for highlighting whenever
+#                         a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
+#                         Use "text" if a mode does not exist.
+# codemirror_mode       - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
+#                         This must match a mode from https://git.io/vi9Fx
+# codemirror_mime_type  - A String name of the file mime type used for highlighting whenever a file is edited.
+#                         This should match the `mime` associated with the mode from https://git.io/f4SoQ
+# wrap                  - Boolean wrap to enable line wrapping (default: false)
+# extensions            - An Array of associated extensions (the first one is
+#                         considered the primary extension, the others should be
+#                         listed alphabetically)
+# filenames             - An Array of filenames commonly associated with the language
+# interpreters          - An Array of associated interpreters
+# searchable            - Boolean flag to enable searching (defaults to true)
+# language_id           - Integer used as a language-name-independent indexed field so that we can rename
+#                         languages in Linguist without reindexing all the code on GitHub. Must not be
+#                         changed for existing languages without the explicit permission of GitHub staff.
+# color                 - CSS hex color to represent the language. Only used if type is "programming" or "prose".
+# tm_scope              - The TextMate scope that represents this programming
+#                         language. This should match one of the scopes listed in
+#                         the grammars.yml file. Use "none" if there is no grammar
+#                         for this language.
+# group                 - Name of the parent language. Languages in a group are counted
+#                         in the statistics as the parent language.
 #
 # Any additions or modifications (even trivial) should have corresponding
 # test changes in `test/test_blob.rb`.


### PR DESCRIPTION
`languages.yml`'s header is defined in two files (`languages.yml` itself and `script/set-language-ids`). #4173 changed it in `languages.yml`, but not in the script. Without this commit, the changes will be overwritten next time we run `script/set-language-ids`.

*Removed template as it doesn't apply here.*

/cc @lildude 