### PR TITLE
Cython is no longer grouped under Python

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -951,7 +951,6 @@ Cycript:
   language_id: 78
 Cython:
   type: programming
-  group: Python
   extensions:
   - ".pyx"
   - ".pxd"


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description
In theory, this should be a fairly straightforward change, but that may depend on the philosophy `linguist` uses for grouping languages under an umbrella. In particular, the `Cython` programming language is described as a creole language that combines Python, C, and C++ features in [one of its prominent textbooks](https://www.safaribooksonline.com/library/view/cython/9781491901731/).

In practice, when `linguist` merges Python and Cython source files under a single Python language category (current behavior), this makes it really difficult to assess how much raw Python vs. low-level Cython code there is--consider that a Cython module can effectively be written to contain no pure Python functions whatsoever & look much more like C -- being used to i.e., expose an external C or C++ header library.

The above issue arose while we (the SciPy community) [were trying to write a section of an upcoming manuscript about our language choices / justifications](https://github.com/scipy/scipy-articles/pull/36). I suppose we can simply use my fork to do that for now, but since the distinction between Cython & Python is important for us it may be beneficial to have i.e., the top bar on github display this as well.

This is a pretty minor change, but if you'd like to guide me to write a test for it (if the change is of interest), I can try to do that (informally, this PR branch does seem to be able to distinguish Cython from Python reasonably well, though one or two `pyx` files still end up under Python).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
