### PR TITLE
Add color for the GDScript language (#355570)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1450,6 +1450,7 @@ GDB:
   language_id: 122
 GDScript:
   type: programming
+  color: "#355570"
   extensions:
   - ".gd"
   tm_scope: source.gdscript


### PR DESCRIPTION

## Description

I've added coloring (`#355570`) to the GDScript programming language, since I got tired of seeing gray. `#478cbf` is the hex code for the color used in the Godot logo and icon, which would be the best to use, but conflicts. However this color (`#355570`) also works well, it's the background color for the icon:

![icon](https://user-images.githubusercontent.com/1646875/42420766-812d7656-8290-11e8-8728-466584b96fc9.png)

I would make it brighter, but if I did, then it would conflict with other colors.

## Checklist:

I removed the checklist as none of the items applied.
