### PR TITLE
Detect duplicate colours

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1588,7 +1588,7 @@ Gherkin:
   language_id: 76
 Glyph:
   type: programming
-  color: "#e4cc98"
+  color: "#c1ac7f"
   extensions:
   - ".glf"
   tm_scope: source.tcl
@@ -2252,7 +2252,7 @@ Jupyter Notebook:
   language_id: 185
 KRL:
   type: programming
-  color: "#28431f"
+  color: "#28430A"
   extensions:
   - ".krl"
   tm_scope: none
@@ -3971,7 +3971,7 @@ RenderScript:
   language_id: 323
 Ring:
   type: programming
-  color: "#0e60e3"
+  color: "#2D54CB"
   extensions:
   - ".ring"
   tm_scope: source.ring
@@ -4867,7 +4867,7 @@ UrWeb:
   language_id: 383
 VCL:
   type: programming
-  color: "#0298c3"
+  color: "#148AA8"
   extensions:
   - ".vcl"
   tm_scope: source.varnish.vcl

--- a/test/test_color_proximity.rb
+++ b/test/test_color_proximity.rb
@@ -12,7 +12,7 @@ class TestColorProximity < Minitest::Test
     cp = ColorProximity.new(0.05, langs_with_colors.map { |lang| cut_hash(lang.color) })
     failing_threshold = langs_with_colors.map do |lang|
       state = cp.past_threshold?(cut_hash(lang.color))
-      if !state.first && lang.color != "##{state.last.first}"
+      if !state.first && lang.color != "##{state.last.first}" || state.last.uniq.length != state.last.length
         "- #{lang} (#{lang.color}) is too close to #{state.last}"
       end
     end.compact


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description
As discovered in https://github.com/github/linguist/pull/4182, our current testing allows the reuse of colours as our test wasn't catering for the fact that in the event the two colours are the same, the result from [`past_threshold?()`](https://github.com/gjtorikian/color-proximity/blob/53d3f39112655cdc0a236d213cba2f1aa78729c6/lib/color-proximity.rb#L13-L21) would fail and include the same language twice, one for the newly added language and one for the duplicate.

This PR addresses that.

With the change to the test I discovered we have four duplicates:


```
$ bundle exec ruby test/test_color_proximity.rb
Run options: --seed 55279

# Running:

F

Finished in 0.932629s, 1.0722 runs/s, 1.0722 assertions/s.

  1) Failure:
TestColorProximity#test_color_proximity [test/test_color_proximity.rb:21]:
The following 8 languages have failing color thresholds. Please modify the hex color.
- Glyph (#e4cc98) is too close to ["e4cc98", "e4cc98"]
- Harbour (#0e60e3) is too close to ["0e60e3", "0e60e3"]
- KRL (#28431f) is too close to ["28431f", "28431f"]
- NCL (#28431f) is too close to ["28431f", "28431f"]
- Perl (#0298c3) is too close to ["0298c3", "0298c3"]
- Ring (#0e60e3) is too close to ["0e60e3", "0e60e3"]
- Tcl (#e4cc98) is too close to ["e4cc98", "e4cc98"]
- VCL (#0298c3) is too close to ["0298c3", "0298c3"]

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

I've adjusted those slightly by picking the language that had its colour set most recently and then:

- loaded that colour into [Google's colour picker](https://www.google.co.uk/search?q=color+picker),
- added or subtracted at least 16 (the minimum acceptable distance) from the colour,
- verified it looked similar to the original colour,
- updated `languages.yml` with the colour,
- ran just the proximity tests: `bundle exec ruby test/test_color_proximity.rb`,
- rinsed and repeated, adjusting the difference by a few here and there, until I got a non-clashing colour.

When that didn't work or was taking too long, I dragged the colour cursor ever-so-slightly and did the same thing again.

The results:

Glyph: `#e4cc98` -> `#c1ac7f`  
KRL: `#28431f` -> `#28430A`
Ring: `#0e60e3` -> `#2D54CB`
VCL: `#0298c3` -> `#148AA8`

I think those are close enough to the originals and certainly meet our proximity requirements.

## Checklist:
- [ ] **I am ~adding new or changing current functionality~ fixing a test**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [N/A] I have added or updated the tests for the new or changed functionality.
