### PR TITLE
fix php disambiguation regex

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -355,7 +355,7 @@ module Linguist
     disambiguate ".php" do |data|
       if data.include?("<?hh")
         Language["Hack"]
-      elsif /<?[^h]/.match(data)
+      elsif /<\?[^h]/.match(data)
         Language["PHP"]
       end
     end


### PR DESCRIPTION
## Description
Because of an error in the regular expression, disambiguation rule for the .php
matched any non-empty file as PHP, except for Hack files.

Note that this means that now files with .php but containing no `<?` will be not classified as PHP unless other strategy kicks in. If that is not the desired behaviour, we should just remove the PHP regex and make it explicit that it is a catch-all fallback.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
