### PR TITLE
drop cache tempfile in same dir

### DIFF
--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -76,7 +76,7 @@ class GitLinguist
   def write_cache(object)
     return unless File.directory? @repo_path
 
-    Tempfile.open(cache_file) do |f|
+    Tempfile.open('cache_file', @repo_path) do |f|
       marshal = Marshal.dump(object)
       f.write(Zlib::Deflate.deflate(marshal))
       f.close


### PR DESCRIPTION
See https://github.com/github/linguist/pull/4195#issuecomment-405813272. We create the tempfile in the same directory as the cache file so when we do the rename it's not cross-device.

/cc @tenderlove @lildude 