### PR TITLE
Release v6.3.1

### DIFF
--- a/lib/linguist/version.rb
+++ b/lib/linguist/version.rb
@@ -1,3 +1,3 @@
 module Linguist
-  VERSION = "6.3.0"
+  VERSION = "6.3.1"
 end


### PR DESCRIPTION
This only pulls in an update to the Elixir grammar. We happened to catch it with a bad commit that was then fixed the day we released Linguist v6.3.0.

Fixes github/linguist#4203

Template omitted as it's not relevant for a release.

/cc @kivikakk