### PR TITLE
simplify .ms heuristic

### DIFF
--- a/lib/linguist/heuristics.rb
+++ b/lib/linguist/heuristics.rb
@@ -323,7 +323,7 @@ module Linguist
     disambiguate ".ms" do |data|
       if /^[.'][a-z][a-z](\s|$)/i.match(data)
         Language["Roff"]
-      elsif /(?<!\S)\.(include|globa?l)\s/.match(data) || /(?<!\/\*)(\A|\n)\s*\.[A-Za-z][_A-Za-z0-9]*:/.match(data.gsub(/"([^\\"]|\\.)*"|'([^\\']|\\.)*'|\\\s*(?:--.*)?\n/, ""))
+      elsif !/\/\*/.match(data) && /^\s*\.(?:include\s|globa?l\s|[A-Za-z][_A-Za-z0-9]*:)/.match(data)
         Language["Unix Assembly"]
       else
         Language["MAXScript"]


### PR DESCRIPTION
Simplify .ms heuristic for Unix Assembly by just checking that there is no
`/*` string in the file. This is simpler and seems to work with all Unix Assembly
files in GitHub. A synthetic MAXScript file was also tested by adding assembly inside
a multiline comment.

## Checklist:

None applies?