### PR TITLE
Fix OID test

### DIFF
--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -6,7 +6,7 @@ class TestRepository < Minitest::Test
   end
 
   def master_oid
-    '2a6dd02c6e81b7e30d978806d43d4ba1a7ba8003'
+    '7dbcffcf982e766fc711e633322de848f2b60ba5'
   end
 
   def linguist_repo(oid = master_oid)


### PR DESCRIPTION
The Linguist commit id in the tests was changed in #4208, but since commits from pull requests are squashed, the hardcoded commit doesn't exist anymore. This pull request fixes that.

*Template doesn't apply.*