### PR TITLE
Remove depth limit in Travis CI to pass incremental statistics test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ notifications:
 
 git:
   submodules: false
-  depth: 3
+  depth: false
 
 cache: bundler
 dist: trusty


### PR DESCRIPTION
The Travis CI builds are currently failing because one of the tests, [`test_incremental_stats`](https://github.com/github/linguist/blob/3176166966731806828e4681385424ddcfcf5543/test/test_repository.rb#L34-L47), attempts to reference an older commit even though Travis CI only retrieves [the last 3 commits](https://github.com/github/linguist/blob/4f11062304ae28b09a9b90c4536a92a27e142dcb/.travis.yml#L27).

This pull request changes the [Travis CI configuration to retrieve all commits](https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth), thereby fixing the builds. I haven't noticed a strong increase in build time; the time to download submodules dominates the total download time anyway.

I'm not sure this is the appropriate fix as I don't understand why it worked before... It does fix the build though :-)

*Template doesn't apply.*