### PR TITLE
Fix blatant lie in description of colour field

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -20,7 +20,7 @@
 # language_id           - Integer used as a language-name-independent indexed field so that we can rename
 #                         languages in Linguist without reindexing all the code on GitHub. Must not be
 #                         changed for existing languages without the explicit permission of GitHub staff.
-# color                 - CSS hex color to represent the language. Only used if type is "programming" or "prose".
+# color                 - CSS hex color to represent the language. Only used if type is "programming" or "markup".
 # tm_scope              - The TextMate scope that represents this programming
 #                         language. This should match one of the scopes listed in
 #                         the grammars.yml file. Use "none" if there is no grammar


### PR DESCRIPTION
A [glaring mistake](https://github.com/github/linguist/blob/1221480189454d80e02f3811612f79e2aadd8f91/lib/linguist/languages.yml#L23) is sitting in plain sight in `language.yml`'s description of the `color` field:

> Only used if type is "programming" or **"prose".**

This should, of course, say `markup`, not `prose`. 😉