### PR TITLE
Register `.gsf` as a supported PostScript extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3582,7 +3582,7 @@ PostScript:
   extensions:
   - ".ps"
   - ".eps"
-  - ".gfs"
+  - ".gsf"
   - ".pfa"
   tm_scope: source.postscript
   aliases:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3582,6 +3582,7 @@ PostScript:
   extensions:
   - ".ps"
   - ".eps"
+  - ".gfs"
   - ".pfa"
   tm_scope: source.postscript
   aliases:

--- a/samples/PostScript/hrpldb.gsf
+++ b/samples/PostScript/hrpldb.gsf
@@ -1,0 +1,24 @@
+%!
+/deriveHersheyFontGS993 where { pop save {restore} } { {} } ifelse
+userdict begin
+/deriveHersheyFontGS993	% <newfontname> <uid> <xuid> <paintwidth>
+			%   <italicangle> <oldfontname>
+{	findfont dup length 1 add dict begin
+		{1 index /FID ne {def} {pop pop} ifelse} forall
+		FontInfo dup length dict copy begin
+			/ItalicAngle exch def
+		/FontInfo currentdict end def
+		Private dup length dict copy begin
+			/UniqueID 3 index def
+		/Private currentdict end readonly def
+		/FontMatrix [.001 0 FontInfo /ItalicAngle get neg sin 1000 div
+			     .001 0 0] def
+		/StrokeWidth exch 1000 28 div mul round cvi def
+		/XUID exch def
+		/UniqueID exch def
+		/FontName 1 index def
+	currentdict end definefont pop
+} def
+end exec
+/Hershey-Plain-Duplex-Bold 5066549 [107 0 5066549]
+  2.1 0 /Hershey-Plain-Duplex deriveHersheyFontGS993


### PR DESCRIPTION
This PR adds `.gsf` ("GhostScript Font") to the list of recognised PostScript extensions.

## Description
This extension appears to be used by various GhostScript tools for converting various bitmap font-formats to PostScript (with `gsf` presumably meaning "GhostScript font"). The sample I added is a conversion of one of the [Hershey fonts](https://en.wikipedia.org/wiki/Hershey_fonts), released to the public domain.

In-the-wild usage is detailed below, with Harvester managing to collect each `.gsf` file currently indexed on GitHub. I've archived [them here](https://github.com/Alhadis/Linguist-Silo/tree/gsf).

| Format           | Percentage | Total files | Repos | Users |
| ---------------- | ---------- | ----------- | ----- | ----- |
| [PostScript][]   | 68%        | 1,011       | 78    | 47    |
| [Grads Script][] | 16.3%      | 242         | 15    | 13    | 
| [Binary][]       | 8.5%       | 127         | 34    | 29    |
| [Other][]        | 4.7%       | 70          | 46    | 42    | 
| [Images (BMP)][] | 0.87%      | 13          | 4     | 4     |
| [Shell][]        | 0.74%      | 11          | 11    | 11    |
| [XML][]          | 0.6%       | 9           | 4     | 4     |

**Total: 1483**

There are no conflicting languages, with the closest competitor being [GraDS Script](http://cola.gmu.edu/grads/gadoc/script.html), which isn't currently supported on GitHub (and doesn't appear to have enough usage to qualify, although my research there is limited to the `gsf` extension only...)

[PostScript]: https://github.com/Alhadis/Linguist-Silo/tree/gsf/files/PostScript
[Grads Script]: https://github.com/Alhadis/Linguist-Silo/tree/gsf/files/Grads%20Script
[Binary]: https://github.com/Alhadis/Linguist-Silo/tree/gsf/files/Binary
[Other]: https://github.com/Alhadis/Linguist-Silo/tree/gsf/files/Other
[Images (BMP)]: https://github.com/Alhadis/Linguist-Silo/tree/gsf/files/Images
[Shell]: https://github.com/Alhadis/Linguist-Silo/tree/gsf/files/Shell
[XML]: https://github.com/Alhadis/Linguist-Silo/tree/gsf/files/XML


## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - [Search results for each extension](https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Agsf+NOT+nothack)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
