### PR TITLE
Update command line docs executable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ A repository's languages stats can also be assessed from the command line using 
 
 ```console
 $ cd /path-to-repository/
-$ github-linguist
+$ linguist
 ```
 
 You can try running `linguist` on the root directory in this repository itself:


### PR DESCRIPTION
The current documentation inconsistently lists the name of the executable as both `linguist` and `github-linguist`.
For my fresh install on Linux Mint 18, `github-linguist` was not defined, but `linguist` was, when installed through [the method listed in the project documentation.](https://github.com/github/linguist#installation)

However, when I install the tool from the hint that my shell provides:
```command
$ github-linguist
The program 'github-linguist' is currently not installed. You can install it by typing:
sudo apt install ruby-github-linguist

# After installing using the method hinted

$ which github-linguist
/usr/bin/github-linguist

```

Then `github-linguist` exists.

## Description
This corrects the example given in the readme to be consistent with the existing installation instructions.

## Checklist:
N/A, Documentation fix.