### PR TITLE
Escape asterisks in generated README for grammars

### DIFF
--- a/script/list-grammars
+++ b/script/list-grammars
@@ -83,6 +83,7 @@ class GrammarList
         short_url = submodule[:short]
         long_url  = submodule[:url]
       end
+      item = item.gsub("*", "\\*")
       markdown += "- **#{item}:** [#{short_url}](#{long_url})\n"
     end
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -113,7 +113,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **EQ:** [atom/language-csharp](https://github.com/atom/language-csharp)
 - **Erlang:** [textmate/erlang.tmbundle](https://github.com/textmate/erlang.tmbundle)
 - **F#:** [fsprojects/atom-fsharp](https://github.com/fsprojects/atom-fsharp)
-- **F*:** [FStarLang/atom-fstar](https://github.com/FStarLang/atom-fstar)
+- **F\*:** [FStarLang/atom-fstar](https://github.com/FStarLang/atom-fstar)
 - **Factor:** [slavapestov/factor](https://github.com/slavapestov/factor)
 - **Fancy:** [fancy-lang/fancy-tmbundle](https://github.com/fancy-lang/fancy-tmbundle)
 - **Fantom:** [rkoeninger/sublime-fantom](https://github.com/rkoeninger/sublime-fantom)


### PR DESCRIPTION
As discussed in [#4178 (Comment)](https://github.com/github/linguist/pull/4178#discussion_r211110014), this pull request updates the `list-grammars` script to escape asterisks in language's names. I've also fixed the entry for F* by running the script again.

*Template doesn't apply.*