### PR TITLE
Change GameMakerLanguage colour to reflect the "Game Maker Green"

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1505,7 +1505,7 @@ GN:
   language_id: 302957008
 Game Maker Language:
   type: programming
-  color: "#8fb200"
+  color: "#71b417"
   extensions:
   - ".gml"
   tm_scope: source.c++


### PR DESCRIPTION
As the title states, this is pretty much it.

The colour that was originally in there was a yellow-ish colour, this reflects the new, Game Maker style green more;
![image](https://user-images.githubusercontent.com/1442796/44728905-d900c200-aadd-11e8-9d07-f26ece16a537.png)

Old color:
![image](https://user-images.githubusercontent.com/1442796/44790782-6b699a00-aba0-11e8-8c60-06b98fba9899.png)

## Checklist:
Removed all checklists since they don't really apply here.

This is a kind of addition to my earlier PR; https://github.com/github/linguist/pull/4130