### PR TITLE
Associate node interpreter to TypeScript

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4844,6 +4844,8 @@ TypeScript:
   color: "#2b7489"
   aliases:
   - ts
+  interpreters:
+  - node
   extensions:
   - ".ts"
   - ".tsx"

--- a/samples/JavaScript/run
+++ b/samples/JavaScript/run
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+    
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+
+var fs = require('fs'),
+    path = require('path'),
+    nopt  = require('nopt'),
+    url = require('url'),
+    cordovaServe = require('cordova-serve');
+
+var args = process.argv;
+
+start(args);
+
+function start(argv) {
+    var args  = nopt({'help': Boolean, 'target': String, 'port': Number}, {'help': ['/?', '-h', 'help', '-help', '/help']}, argv);
+    if(args.help) {
+        help();
+    }
+
+    // defaults
+    args.port = args.port || 8000;
+    args.target = args.target || "chrome";
+
+    var root = path.join(__dirname, '../'),
+        configFile = path.resolve(path.join(root, 'config.xml')),
+        configXML = fs.readFileSync(configFile, 'utf8'),
+        sourceFile = /<content[\s]+?src\s*=\s*"(.*?)"/i.exec(configXML);
+
+    var server = cordovaServe();
+    server.servePlatform('browser', {port: args.port, noServerInfo: true}).then(function () {
+        var projectUrl = url.resolve('http://localhost:' + server.port + '/', sourceFile ? sourceFile[1] : 'index.html');
+        console.log('Static file server running @ ' + projectUrl + '\nCTRL + C to shut down');
+        return cordovaServe.launchBrowser({target: args.target, url: projectUrl});
+    }).catch(function (error) {
+        console.log(error.message || error.toString());
+        if (server.server) {
+            server.server.close();
+        }
+    });
+}
+
+function help() {
+    console.log("\nUsage: run [ --target=<browser> ] [ --port=<number> ]");
+    console.log("    --target=<browser> : Launches the specified browser. Chrome is default.");
+    console.log("    --port=<number>    : Http server uses specified port number.");
+    console.log("Examples:");
+    console.log("    run");
+    console.log("    run -- --target=ie");
+    console.log("    run -- --target=chrome --port=8000");
+    console.log("");
+    process.exit(0);
+}

--- a/test/fixtures/TypeScript/main
+++ b/test/fixtures/TypeScript/main
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Must be imported first, because Angular decorators throw on load.
+import 'reflect-metadata';
+
+import * as ts from 'typescript';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tsickle from 'tsickle';
+import * as api from './transformers/api';
+import * as ngc from './transformers/entry_points';
+import {GENERATED_FILES} from './transformers/util';
+
+import {exitCodeFromResult, performCompilation, readConfiguration, formatDiagnostics, Diagnostics, ParsedConfiguration, PerformCompilationResult, filterErrorsAndWarnings} from './perform_compile';
+import {performWatchCompilation, createPerformWatchHost} from './perform_watch';
+
+export function main(
+    args: string[], consoleError: (s: string) => void = console.error,
+    config?: NgcParsedConfiguration): number {
+  let {project, rootNames, options, errors: configErrors, watch, emitFlags} =
+      config || readNgcCommandLineAndConfiguration(args);
+  if (configErrors.length) {
+    return reportErrorsAndExit(configErrors, /*options*/ undefined, consoleError);
+  }
+  if (watch) {
+    const result = watchMode(project, options, consoleError);
+    return reportErrorsAndExit(result.firstCompileResult, options, consoleError);
+  }
+  const {diagnostics: compileDiags} = performCompilation(
+      {rootNames, options, emitFlags, emitCallback: createEmitCallback(options)});
+  return reportErrorsAndExit(compileDiags, options, consoleError);
+}
+
+
+function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|undefined {
+  const transformDecorators =
+      options.enableIvy !== 'ngtsc' && options.annotationsAs !== 'decorators';
+  const transformTypesToClosure = options.annotateForClosureCompiler;
+  if (!transformDecorators && !transformTypesToClosure) {
+    return undefined;
+  }
+  if (transformDecorators) {
+    // This is needed as a workaround for https://github.com/angular/tsickle/issues/635
+    // Otherwise tsickle might emit references to non imported values
+    // as TypeScript elided the import.
+    options.emitDecoratorMetadata = true;
+  }
+  const tsickleHost: Pick<
+      tsickle.TsickleHost, 'shouldSkipTsickleProcessing'|'pathToModuleName'|
+      'shouldIgnoreWarningsForPath'|'fileNameToModuleId'|'googmodule'|'untyped'|
+      'convertIndexImportShorthand'|'transformDecorators'|'transformTypesToClosure'> = {
+    shouldSkipTsickleProcessing: (fileName) =>
+                                     /\.d\.ts$/.test(fileName) || GENERATED_FILES.test(fileName),
+    pathToModuleName: (context, importPath) => '',
+    shouldIgnoreWarningsForPath: (filePath) => false,
+    fileNameToModuleId: (fileName) => fileName,
+    googmodule: false,
+    untyped: true,
+    convertIndexImportShorthand: false, transformDecorators, transformTypesToClosure,
+  };
+
+  return ({
+           program,
+           targetSourceFile,
+           writeFile,
+           cancellationToken,
+           emitOnlyDtsFiles,
+           customTransformers = {},
+           host,
+           options
+         }) =>
+             tsickle.emitWithTsickle(
+                 program, {...tsickleHost, options, host}, host, options, targetSourceFile,
+                 writeFile, cancellationToken, emitOnlyDtsFiles, {
+                   beforeTs: customTransformers.before,
+                   afterTs: customTransformers.after,
+                 });
+}
+
+export interface NgcParsedConfiguration extends ParsedConfiguration { watch?: boolean; }
+
+function readNgcCommandLineAndConfiguration(args: string[]): NgcParsedConfiguration {
+  const options: api.CompilerOptions = {};
+  const parsedArgs = require('minimist')(args);
+  if (parsedArgs.i18nFile) options.i18nInFile = parsedArgs.i18nFile;
+  if (parsedArgs.i18nFormat) options.i18nInFormat = parsedArgs.i18nFormat;
+  if (parsedArgs.locale) options.i18nInLocale = parsedArgs.locale;
+  const mt = parsedArgs.missingTranslation;
+  if (mt === 'error' || mt === 'warning' || mt === 'ignore') {
+    options.i18nInMissingTranslations = mt;
+  }
+  const config = readCommandLineAndConfiguration(
+      args, options, ['i18nFile', 'i18nFormat', 'locale', 'missingTranslation', 'watch']);
+  const watch = parsedArgs.w || parsedArgs.watch;
+  return {...config, watch};
+}
+
+export function readCommandLineAndConfiguration(
+    args: string[], existingOptions: api.CompilerOptions = {},
+    ngCmdLineOptions: string[] = []): ParsedConfiguration {
+  let cmdConfig = ts.parseCommandLine(args);
+  const project = cmdConfig.options.project || '.';
+  const cmdErrors = cmdConfig.errors.filter(e => {
+    if (typeof e.messageText === 'string') {
+      const msg = e.messageText;
+      return !ngCmdLineOptions.some(o => msg.indexOf(o) >= 0);
+    }
+    return true;
+  });
+  if (cmdErrors.length) {
+    return {
+      project,
+      rootNames: [],
+      options: cmdConfig.options,
+      errors: cmdErrors,
+      emitFlags: api.EmitFlags.Default
+    };
+  }
+  const allDiagnostics: Diagnostics = [];
+  const config = readConfiguration(project, cmdConfig.options);
+  const options = {...config.options, ...existingOptions};
+  if (options.locale) {
+    options.i18nInLocale = options.locale;
+  }
+  return {
+    project,
+    rootNames: config.rootNames, options,
+    errors: config.errors,
+    emitFlags: config.emitFlags
+  };
+}
+
+function reportErrorsAndExit(
+    allDiagnostics: Diagnostics, options?: api.CompilerOptions,
+    consoleError: (s: string) => void = console.error): number {
+  const errorsAndWarnings = filterErrorsAndWarnings(allDiagnostics);
+  if (errorsAndWarnings.length) {
+    let currentDir = options ? options.basePath : undefined;
+    const formatHost: ts.FormatDiagnosticsHost = {
+      getCurrentDirectory: () => currentDir || ts.sys.getCurrentDirectory(),
+      getCanonicalFileName: fileName => fileName,
+      getNewLine: () => ts.sys.newLine
+    };
+    consoleError(formatDiagnostics(errorsAndWarnings, formatHost));
+  }
+  return exitCodeFromResult(allDiagnostics);
+}
+
+export function watchMode(
+    project: string, options: api.CompilerOptions, consoleError: (s: string) => void) {
+  return performWatchCompilation(createPerformWatchHost(project, diagnostics => {
+    consoleError(formatDiagnostics(diagnostics));
+  }, options, options => createEmitCallback(options)));
+}
+
+// CLI entry point
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  process.exitCode = main(args);
+}


### PR DESCRIPTION
This pull request adds the `node` interpreter to TypeScript to help with the recognition of TypeScript files with a `.js` extension.

## Description

The node interpreter is already associated to JavaScript, but thanks to #4099, subsequent strategies (e.g., the Extension Strategy) can now refine the results and distinguish between TypeScript and JavaScript file.

Fixes #4112.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - https://github.com/ricardolissa/Biblioteca/blob/24f43313448abf8def285ed71e49bdc9ba7b4cb9/apibiblioteca/platforms/browser/cordova/run
      - https://github.com/BlueWaterloo/Angular/blob/7ae706d6cf61247b507b8fd48d355197f6ee78e1/packages/compiler-cli/src/main.ts
    - Sample license(s): MIT for both.
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.