### PR TITLE
WIP: Use Licensed manifest method for caching license metadata

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'yajl-ruby'
   s.add_development_dependency 'color-proximity', '~> 0.2.1'
-  s.add_development_dependency 'licensed', '~> 1.1.0'
+  s.add_development_dependency 'licensed', '~> 1.3.0'
   s.add_development_dependency 'licensee'
 end

--- a/vendor/licenses/config.yml
+++ b/vendor/licenses/config.yml
@@ -1,4 +1,15 @@
 cache_path: "vendor/licenses"
+source_path: 'vendor/grammars'
+manifest:
+  #path: 'vendor/licenses/manifest.yml'
+  #exclude:
+  #  - "**/*"
+  #  - "!vendor/grammars/**/*"
+  dependencies:
+    grammars:
+      - "vendor/grammars/**/*"
+  #licenses:
+  #  creole: "vendor/grammars/creole/The MIT License (MIT)"
 
 allowed:
   - apache-2.0


### PR DESCRIPTION
Floating this WIP early to ease getting feedback as I work this. I'll add in the apt parts of the template later.

For the moment, I'm working on using the latest `licensed` directly as I iterate on the configuration:

```
$ bundle exec licensed cache -c vendor/licenses/config.yml
Caching licenses for grammars:
  manifest dependencies:
License caching complete!
* grammars manifest dependencies: 0
$
```

Commented out parts are things I've considered and will need to reconsider later too, so feel free to ignore those parts or comment as necessary.

I'll update the `script/licensed` and `script/add-grammar` later.

/cc @jonabc https://github.com/github/linguist/issues/4265