### PR TITLE
Syntax Highlighting for Hy Files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -409,6 +409,9 @@
 [submodule "vendor/grammars/html.tmbundle"]
 	path = vendor/grammars/html.tmbundle
 	url = https://github.com/textmate/html.tmbundle
+[submodule "vendor/grammars/hy.tmLanguage"]
+	path = vendor/grammars/hy.tmLanguage
+	url = https://github.com/Slowki/hy.tmLanguage.git
 [submodule "vendor/grammars/idl.tmbundle"]
 	path = vendor/grammars/idl.tmbundle
 	url = https://github.com/mgalloy/idl.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -333,6 +333,8 @@ vendor/grammars/haxe-TmLanguage:
 - source.hxml
 vendor/grammars/html.tmbundle:
 - text.html.basic
+vendor/grammars/hy.tmLanguage:
+- source.hy
 vendor/grammars/idl.tmbundle:
 - source.idl
 - source.idl-dlm

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1951,7 +1951,7 @@ Hy:
   - hy
   aliases:
   - hylang
-  tm_scope: none
+  tm_scope: source.hy
   language_id: 159
 HyPhy:
   type: programming

--- a/test/test_grammars.rb
+++ b/test/test_grammars.rb
@@ -19,6 +19,7 @@ class TestGrammars < Minitest::Test
     "b81acf2ba52d312754bf5055845a723123bda388", # FreeMarker.tmbundle
     "ee77ce4cf9121bccc3e37ba6b98f8e7acd589aaf", # gap-tmbundle
     "4cfc7ce12de920ccc836bbab2d748151d5ba7e38", # go-tmbundle
+    "01868f4a2476fad9abb8b7199ea1547d33cd48db", # hy.tmLanguage
     "6c2e34d62c08f97a3e2ece3eedc65fbd99873ff4", # idl.tmbundle
     "e68efca5a844aa78729cadcf42507013151e6605", # jflex.tmbundle
     "39f092c726491ca6a02354dbc6c3a0920bb44d4c", # mako-tmbundle

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -167,6 +167,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **HTML+PHP:** [textmate/php.tmbundle](https://github.com/textmate/php.tmbundle)
 - **HTTP:** [samsalisbury/Sublime-HTTP](https://github.com/samsalisbury/Sublime-HTTP)
 - **HXML:** [vshaxe/haxe-TmLanguage](https://github.com/vshaxe/haxe-TmLanguage)
+- **Hy:** [Slowki/hy.tmLanguage](https://github.com/Slowki/hy.tmLanguage)
 - **IDL:** [mgalloy/idl.tmbundle](https://github.com/mgalloy/idl.tmbundle)
 - **Idris:** [idris-hackers/idris-sublime](https://github.com/idris-hackers/idris-sublime)
 - **Inform 7:** [erkyrath/language-inform7](https://github.com/erkyrath/language-inform7)

--- a/vendor/licenses/grammar/hy.tmLanguage.txt
+++ b/vendor/licenses/grammar/hy.tmLanguage.txt
@@ -1,0 +1,68 @@
+---
+type: grammar
+name: hy.tmLanguage
+license: mit
+---
+Copyright 2018 Stephan Wolski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------
+
+This repository's contents are derived from an Atom package located at
+https://github.com/atom/language-clojure which is distributed under the
+following license, located in `LICENSE.md`:
+
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------
+
+This repository's contents are indirectly derived from a TextMate bundle located at
+https://github.com/mmcgrana/textmate-clojure which is distributed under the
+following license, located in `LICENSE.md`:
+
+The MIT License (MIT)
+
+Copyright (c) 2010- Mark McGranaghan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
This pull request adds support for highlighting Hy files.

## Checklist:
- [x] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: **N/A**, (there's no Hy grammar in `github/linguist:master` at the moment, this was just the closest matching subsection of the checklist)
  - [New](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2FSlowki%2Fhy-grammar%2Fmaster%2Fhy.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fhylang%2Fhy%2Fblob%2Fmaster%2Fhy%2Fcore%2Flanguage.hy&code=)

(Implements hylang/hy#1675)