### PR TITLE
Added support for Pest grammars.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3511,6 +3511,13 @@ Perl 6:
   codemirror_mode: perl
   codemirror_mime_type: text/x-perl
   language_id: 283
+Pest:
+  type: programming
+  color: "#e66448"
+  extensions:
+  - ".pest"
+  ace_mode: text
+  language_id: 432
 Pic:
   type: markup
   group: Roff

--- a/samples/Pest/json.pest
+++ b/samples/Pest/json.pest
@@ -1,0 +1,32 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+json = { SOI ~ (object | array) ~ EOI }
+
+object = { "{" ~ pair ~ ("," ~ pair)* ~ "}" | "{" ~ "}" }
+pair   = { string ~ ":" ~ value }
+
+array = { "[" ~ value ~ ("," ~ value)* ~ "]" | "[" ~ "]" }
+
+value = { string | number | object | array | bool | null }
+
+string  = @{ "\"" ~ inner ~ "\"" }
+inner   = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ inner)? }
+escape  = @{ "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | unicode) }
+unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} }
+
+number = @{ "-"? ~ int ~ ("." ~ ASCII_DIGIT+ ~ exp? | exp)? }
+int    = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+exp    = @{ ("E" | "e") ~ ("+" | "-")? ~ ASCII_DIGIT+ }
+
+bool = { "true" | "false" }
+
+null = { "null" }
+
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/samples/Pest/toml.pest
+++ b/samples/Pest/toml.pest
@@ -1,0 +1,74 @@
+// pest. The Elegant Parser
+// Copyright (c) 2018 Dragoș Tiselice
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+toml = { SOI ~ (table | array_table | pair)* ~ EOI }
+
+table       = { "[" ~ key ~ ("." ~ key)* ~ "]" ~ pair* }
+array_table = { "[[" ~ key ~ ("." ~ key)* ~ "]]" ~ pair* }
+pair        = { key ~ "=" ~ value }
+
+key   = @{ identifier | string | literal }
+value = _{
+    inline_table |
+    array |
+    multi_line_string |
+    string |
+    multi_line_literal |
+    literal |
+    date_time |
+    local_date_time |
+    full_date |
+    partial_time |
+    float |
+    integer |
+    boolean
+}
+
+inline_table = { "{" ~ pair ~ ("," ~ pair)* ~ ","? ~ "}" | "{" ~ "}" }
+
+array = { "[" ~ value ~ ("," ~ value)* ~ ","? ~ "]" | "[" ~ "]" }
+
+identifier = { (ASCII_ALPHANUMERIC | "_" | "-")+ }
+
+multi_line_string  = @{ "\"\"\"" ~ inner ~ "\"\"\"" }
+string             = @{ "\"" ~ inner ~ "\"" }
+inner              = @{ (!("\"" | "\\" | "\u{0000}" | "\u{001F}") ~ ANY)* ~ (escape ~ inner)? }
+multi_line_literal = @{ "'''" ~ (!"'''" ~ ANY)* ~ "'''" }
+literal            = @{ "'" ~ (!"'" ~ ANY)* ~ "'" }
+
+escape  = @{ "\\" ~ ("b" | "t" | "n" | "f" | "r" | "\"" | "\\" | unicode | NEWLINE)? }
+unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} | "U" ~ ASCII_HEX_DIGIT{8} }
+
+date_time       = ${ full_date ~ "T" ~ full_time }
+local_date_time = ${ full_date ~ "T" ~ partial_time }
+
+partial_time = ${ time_hour ~ ":" ~ time_minute ~ ":" ~ time_second ~ time_secfrac? }
+full_date    = ${ date_fullyear ~ "-" ~ date_month ~ "-" ~ date_mday }
+full_time    = ${ partial_time ~ time_offset }
+
+date_fullyear = @{ ASCII_DIGIT{4} }
+date_month    = @{ ASCII_DIGIT{2} }
+date_mday     = @{ ASCII_DIGIT{2} }
+
+time_hour    = @{ ASCII_DIGIT{2} }
+time_minute  = @{ ASCII_DIGIT{2} }
+time_second  = @{ ASCII_DIGIT{2} }
+time_secfrac = @{ "." ~ ASCII_DIGIT+ }
+time_offset  = ${ "Z" | ("+" | "-") ~ time_hour ~ ":" ~ time_minute }
+
+integer = @{ ("+" | "-")? ~ int }
+float   = @{ ("+" | "-")? ~ int ~ ("." ~ digits ~ exp? | exp)? }
+int     = @{ "0" | (ASCII_NONZERO_DIGIT ~ digits?) }
+digits  = @{ (ASCII_DIGIT | ("_" ~ ASCII_DIGIT))+ }
+exp     = @{ ("E" | "e") ~ ("+" | "-")? ~ int }
+
+boolean = { "true" | "false" }
+
+WHITESPACE = _{ " " | "\t" | NEWLINE }
+COMMENT    = _{ "#" ~ (!NEWLINE ~ ANY)* }


### PR DESCRIPTION
I'm adding support for [Pest](https://pest-parser.github.io/) grammars.

Usage:
https://github.com/search?q=extension%3Apest+NOT+nothack&type=Code

[Examples](https://github.com/pest-parser/pest/tree/master/grammars/src/grammars) have been added from the main repo, but here are a few others:

* [comrak](https://github.com/kivikakk/comrak/blob/master/src/lexer.pest)
* [handlebars-rust](https://github.com/sunng87/handlebars-rust/blob/master/src/grammar.pest)
* [Huia](https://gitlab.com/jimsy/huia/blob/master/parser/src/grammar.pest)
* [sql](https://github.com/gwenn/sqlpest/blob/6da014ecce33cac13c857641b0dbfd5655ac22a6/src/sql.pest)
* [tera](https://github.com/Keats/tera/blob/master/src/parser/tera.pest)

I don't have a TextMate grammar yet, but I can work on one if this PR is fine.