### PR TITLE
Add ruby-dev as a dependency on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Linguist uses [`charlock_holmes`](https://github.com/brianmario/charlock_holmes)
     * [libcurl](https://curl.haxx.se/libcurl/)
     * [OpenSSL](https://www.openssl.org)
 
-You may need to install missing dependencies before you can install Linguist. For example, on macOS with [Homebrew](http://brew.sh/): `brew install cmake pkg-config icu4c` and on Ubuntu: `sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev`.
+You may need to install missing dependencies before you can install Linguist. For example, on macOS with [Homebrew](http://brew.sh/): `brew install cmake pkg-config icu4c` and on Ubuntu: `sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev`.
 
 ### Application usage
 


### PR DESCRIPTION
On Ubuntu 18.04, you'll need `ruby-dev` to be installed in order to build native extensions.

## Description
`README.md` describes Ubuntu prerequisites, but it's missing one.

## Checklist:
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
  - [ ] I have included a real-world usage sample for all extensions added in this PR
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
  - [ ] I have included a real-world usage sample for all extensions added in this PR
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**

- [ ] **I am updating a grammar submodule**

- [ ] **I am adding new or changing current functionality**
  - [ ] I have added or updated the tests for the new or changed functionality.
