### PR TITLE
Display parsing errors in grammar compiler

### DIFF
--- a/tools/grammars/compiler/converter.go
+++ b/tools/grammars/compiler/converter.go
@@ -64,7 +64,7 @@ func (conv *Converter) tmpScopes() map[string]bool {
 
 func (conv *Converter) AddGrammar(source string) error {
 	repo := conv.Load(source)
-	if len(repo.Files) == 0 {
+	if len(repo.Files) == 0 && len(repo.Errors) == 0 {
 		return fmt.Errorf("source '%s' contains no grammar files", source)
 	}
 


### PR DESCRIPTION
Display parsing errors in grammar compiler. Fixes #4141.

Here's how the error from #4141 would appear:
```
Checking docker is installed and running
$ docker ps
Registering new submodule: vendor/grammars/textmate-snort
$ git submodule add -f https://github.com/infosec-intern/textmate-snort vendor/grammars/textmate-snort
$ script/grammar-compiler add vendor/grammars/textmate-snort
  > The new grammar repository `vendor/grammars/textmate-snort` (from https://github.com/infosec-intern/textmate-snort) contains 1 errors:
  >     - Grammar conversion failed. File `syntaxes/snort.tmLanguage` failed to parse: XML syntax error on line 157: expected element name after <
  >
  > failed to compile the given grammar
Command failed. Aborting.
```

/cc @wesinator 

*Removed template as it doesn't apply.*