### PR TITLE
Heuristic rule for Puppet and Pascal .pp files

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -268,6 +268,12 @@ disambiguations:
     named_pattern: perl6
   - language: XPM
     pattern: '^\s*\/\* XPM \*\/'
+- extensions: ['.pp']
+  rules:
+  - language: Pascal
+    pattern: '^\s*end[.;]'
+  - language: Puppet
+    pattern: '^\s+\w+\s+=>\s'
 - extensions: ['.pro']
   rules:
   - language: Prolog

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -322,6 +322,14 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  # Candidate languages = ["Pascal", "Puppet"]
+  def test_pp_by_heuristics
+    assert_heuristics({
+      "Pascal" => all_fixtures("Pascal", "*.pp"),
+      "Puppet" => all_fixtures("Puppet", "*.pp") - ["#{samples_path}/Puppet/stages-example.pp", "#{samples_path}/Puppet/hiera_include.pp"]
+    })
+  end
+
   # Candidate languages = ["IDL", "Prolog", "QMake", "INI"]
   def test_pro_by_heuristics
     assert_heuristics({


### PR DESCRIPTION
This pull request adds a heuristic rule for Puppet and Pascal `.pp` files. Fixes #3605.

/cc @Caged

## Checklist:
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
