### PR TITLE
Change Crystal color to black

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -891,7 +891,7 @@ Creole:
   language_id: 71
 Crystal:
   type: programming
-  color: "#776791"
+  color: "#000100"
   extensions:
   - ".cr"
   ace_mode: ruby


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description
This PR changes the GitHub color of [Crystal Language](https://crystal-lang.org/).

## Checklist:
- [x] I am changing the color of existing language from `#776791` to `#000100`.

## Motivation

Crystal associates with black color. It's logo is black, it's website and documentation are black-and-white. The API docs is colorful though, but it's about to change (insert issue # here). Black is solid and reliable, just like the language is. 

Speaking about colors in linguist. Ruby is `#701516`, just like its logo. Erlang is `#B83998` just like its logo. Julia has that purple `#a270ba` dot in the brand. Go has blue (`#375eab`) hamster as their official mascot. Rust has the color of rust - `#dea584`. And Crystal is purple `#776791` because *why*? 

Crystal also states black, white and gray colors as its brand colors - https://crystal-lang.org/media/.

## Preview of the changes

![image](https://user-images.githubusercontent.com/7955682/46599815-f79ca480-caf0-11e8-8403-dcffac83616c.png)
![image](https://user-images.githubusercontent.com/7955682/46599820-fcf9ef00-caf0-11e8-8f51-51c97787cafb.png)
![image](https://user-images.githubusercontent.com/7955682/46599830-02573980-caf1-11e8-84c4-33c14c0768f5.png)