### PR TITLE
Associate file extension .sol to Solidity files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4566,6 +4566,8 @@ Smarty:
   language_id: 353
 Solidity:
   type: programming
+  extensions:
+  - ".sol"
   color: "#AA6746"
   ace_mode: text
   tm_scope: source.solidity

--- a/samples/Solidity/contract.sol
+++ b/samples/Solidity/contract.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.0;
+
+contract SimpleStorage {
+    uint storedData;
+
+    function set(uint x) public {
+        storedData = x;
+    }
+
+    function get() public view returns (uint) {
+        return storedData;
+    }
+}


### PR DESCRIPTION
Associate the file extension `.sol` to Solidity files.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3ASOL+CONTRACT+SOLIDITY
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/ethereum/solidity/blob/v0.4.24/docs/introduction-to-smart-contracts.rst
    - Sample license(s):
      - https://github.com/ethereum/solidity/blob/v0.4.24/LICENSE.txt
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
