### PR TITLE
Add stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,11 +10,11 @@ unmarkComment: false
 # limitPerRun: 30
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 30
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: 14
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,55 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Label to use when marking as stale
+staleLabel: Stale
+
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+# limitPerRun: 30
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - Good First Issue
+  - Add Language
+  - Help Wanted
+  - Blocked
+  - Bug
+
+# Set to true to ignore issues in a project (defaults to false)
+# exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+# exemptMilestones: false
+
+issues:
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had activity
+    in a long time. If this issue is still relevant and should remain open, please reply
+    with a short explanation (e.g. "I have checked the code and this issue is still relevant because ___.").
+    Thank you for your contributions.
+  closeComment: >
+    This issue has been automatically closed because it has not had
+    activity in a long time. Please feel free to reopen it or create a new issue.
+
+pulls:
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had recent
+    activity, and will be closed if no further activity occurs. If this pull request was
+    overlooked, forgotten, or should remain open for any other reason, please reply
+    here to call attention to it and remove the stale status.
+    Thank you for your contributions.
+  closeComment: >
+    This pull request has been automatically closed because it has not had
+    activity in a long time. Please feel free to reopen it or create a new issue.
+


### PR DESCRIPTION
@pchaigno has been doing a marvellous job of marking old issues and PRs stale but I feel this is a waste of his skills. Lets outsource this to a robot: [stalebot](https://github.com/probot/stale).

The app has been added to the repo, so we just need to configure it - this PR.

I've gone with the default `daysUntil*` values as they seem like a good place to start.

_Template removed as it's not relevant._