### PR TITLE
Extend Language ID tests to prevent re-use and manual generation

### DIFF
--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -385,7 +385,8 @@ class TestLanguage < Minitest::Test
   end
 
   def test_all_languages_have_a_valid_id
-    invalid = Language.all.select { |language| language.language_id < 0 || language.language_id >= (2**31 - 1) }
+    deleted_language_ids = [21]  # Prevent re-use of deleted language IDs
+    invalid = Language.all.select { |language| language.language_id < 0 || deleted_language_ids.include?(language.language_id) || (language.language_id > 431 && language.language_id < 1024) || language.language_id >= (2**31 - 1) }
 
     message = "The following languages do not have a valid language_id. Please run `script/update-ids` as per the contribution guidelines.\n"
     invalid.each { |language| message << "#{language.name}\n" }


### PR DESCRIPTION
## Description

As discovered in https://github.com/github/linguist/pull/4314 our current tests don't detect if someone has manually incremented the language ID instead of using `script/update-ids`.  This PR attempts to implement changes to catch this scenario.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.

Template doesn't really apply, but gonna keep this as the closest.