### PR TITLE
Improve Rust color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4232,7 +4232,7 @@ Ruby:
   language_id: 326
 Rust:
   type: programming
-  color: "#dea584"
+  color: "#9f1d20"
   extensions:
   - ".rs"
   - ".rs.in"


### PR DESCRIPTION
The Rust color on GitHub doesn't look much like rust, and I don't see where it could have come from (not on the website or part of the logo). In fact, it looks rather pale and sickly, rather than vibrant and robust.

#9f1d20 is much nicer. It resembles the red paints that have traditionally been made with iron oxide.