### PR TITLE
Use correct scope for Razor-plus grammar

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -637,7 +637,7 @@ vendor/grammars/r.tmbundle:
 vendor/grammars/rascal-syntax-highlighting:
 - source.rascal
 vendor/grammars/razor-plus:
-- text.html.razor
+- text.html.cshtml
 vendor/grammars/ruby-slim.tmbundle:
 - text.slim
 vendor/grammars/sas.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1876,7 +1876,7 @@ HTML+PHP:
   language_id: 151
 HTML+Razor:
   type: markup
-  tm_scope: text.html.razor
+  tm_scope: text.html.cshtml
   group: HTML
   extensions:
   - ".cshtml"


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description

Whilst generating and testing the upcoming v7.1.0 release I noticed that the cshtml/razor change in https://github.com/github/linguist/pull/4314 introduced the wrong scope for the grammar and this is picked up by the grammar compiler:

```
- [ ] repository `vendor/grammars/razor-plus` (from https://github.com/austincummings/razor-plus) (2 errors)
    - [ ] Unexpected scope in repository: `text.html.cshtml` declared in `text.html.cshtml` (in `syntaxes/cshtml.tmLanguage.json`) was not listed in grammars.yml
    - [ ] Missing scope in repository: `text.html.razor` is listed in grammars.yml but cannot be found
```

The correct scope is `text.html.cshtml` as the error reports and can be confirmed by [checking the grammar itself](https://github.com/austincummings/razor-plus/blob/d1d3a9b5178f1afb963034c788eb143a090df5b9/syntaxes/cshtml.tmLanguage.json#L3).  This PR corrects the scope as using the wrong scope results in _no_ syntax highlighting at all.

This would have been picked up by the `script/add-grammar` script that should have been used to replace the grammar. I suspect it wasn't, hence this slipped through.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

A quick review on this would be ✨ so I can get the release back into testing today.

/cc @worldbeater FYI as the author of https://github.com/github/linguist/pull/4314