### PR TITLE
Add support for Svelte.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -901,6 +901,9 @@
 [submodule "vendor/grammars/sublimetext-cuda-cpp"]
 	path = vendor/grammars/sublimetext-cuda-cpp
 	url = https://github.com/harrism/sublimetext-cuda-cpp
+[submodule "vendor/grammars/svelte-atom"]
+	path = vendor/grammars/svelte-atom
+	url = https://github.com/umanghome/svelte-atom
 [submodule "vendor/grammars/swift.tmbundle"]
 	path = vendor/grammars/swift.tmbundle
 	url = https://github.com/textmate/swift.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -738,6 +738,8 @@ vendor/grammars/sublimeprolog:
 - source.prolog.eclipse
 vendor/grammars/sublimetext-cuda-cpp:
 - source.cuda-c++
+vendor/grammars/svelte-atom:
+- source.svelte
 vendor/grammars/swift.tmbundle:
 - source.swift
 vendor/grammars/tcl.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4353,6 +4353,7 @@ Svelte:
   color: "#e34c26"
   extensions:
   - ".svelte"
+  - ".htmlx"
 SVG:
   type: data
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4343,6 +4343,16 @@ STON:
   tm_scope: source.smalltalk
   ace_mode: text
   language_id: 336
+Svelte:
+  type: markup
+  tm_scope: text.html.svelte
+  group: HTML
+  ace_mode: html
+  codemirror_mode: htmlmixed
+  codemirror_mime_type: text/html
+  color: "#e34c26"
+  extensions:
+  - ".svelte"
 SVG:
   type: data
   extensions:

--- a/samples/Svelte/Form.htmlx
+++ b/samples/Svelte/Form.htmlx
@@ -1,0 +1,37 @@
+<form on:submit="createHandler(event)">
+  <div>
+    <label for="slinky-title">Title</label>
+    <input
+      bind:value='title'
+      id="slinky-title"
+      name="title"
+      type="text"
+    />
+  </div>
+  <button type="submit">Add Now</button>
+  <button type="button" on:click="logState()">Log</button>
+</form>
+
+<script>
+  const defaultData = {
+    title: '',
+  }
+
+  export default {
+    data: () => defaultData,
+
+    methods: {
+      logState() {
+        console.log(this.get())
+      },
+
+      createHandler(event) {
+        event.preventDefault()
+        // parse, validate, fire, reset
+        const slinky = this.get()
+        this.fire('create', slinky)
+        this.set(defaultData)
+      }
+    },
+  }
+</script>

--- a/samples/Svelte/Form.svelte
+++ b/samples/Svelte/Form.svelte
@@ -1,0 +1,37 @@
+<form on:submit="createHandler(event)">
+  <div>
+    <label for="slinky-title">Title</label>
+    <input
+      bind:value='title'
+      id="slinky-title"
+      name="title"
+      type="text"
+    />
+  </div>
+  <button type="submit">Add Now</button>
+  <button type="button" on:click="logState()">Log</button>
+</form>
+
+<script>
+  const defaultData = {
+    title: '',
+  }
+
+  export default {
+    data: () => defaultData,
+
+    methods: {
+      logState() {
+        console.log(this.get())
+      },
+
+      createHandler(event) {
+        event.preventDefault()
+        // parse, validate, fire, reset
+        const slinky = this.get()
+        this.fire('create', slinky)
+        this.set(defaultData)
+      }
+    },
+  }
+</script>

--- a/vendor/licenses/grammar/svelte-atom.txt
+++ b/vendor/licenses/grammar/svelte-atom.txt
@@ -1,0 +1,27 @@
+---
+type: grammar
+name: svelte-atom
+version: 5a6914d90972db02b57822b47682107fc26f13bc
+license: mit
+---
+MIT License
+
+Copyright (c) 2018 Umang Galaiya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Add support for [Svelte](https://svelte.technology).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?q=extension%3Asvelte+export+default+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [`Form.svelte`](https://github.com/umanghome/linguist/blob/svelte/samples/Svelte/Form.svelte)
    - Sample license(s):
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fumanghome%2Fsvelte-atom%2Fmaster%2Fgrammars%2Fsvelte.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fumanghome%2Flinguist%2Fsvelte%2Fsamples%2FSvelte%2FCatList.svelte&code=
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/
  
- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
