### PR TITLE
Revert rust color change

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4232,7 +4232,7 @@ Ruby:
   language_id: 326
 Rust:
   type: programming
-  color: "#a62c00"
+  color: "#dea584"
   extensions:
   - ".rs"
   - ".rs.in"


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->
The previous change #4319  made it hard to distinguish the language and made it hard to recognize for all users that are used to the old color. Practically speaking the change introduced more problems than the esthetics it wanted to solve gained us. Also esthetics are personal opinions, so I'd leave a new color up to the rust team to decide.