### PR TITLE
add extension nimf for Nim

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3105,6 +3105,7 @@ Nim:
   - ".nimble"
   - ".nimrod"
   - ".nims"
+  - ".nimf"
   filenames:
   - nim.cfg
   ace_mode: text

--- a/samples/Nim/makefile.nimf
+++ b/samples/Nim/makefile.nimf
@@ -1,0 +1,181 @@
+#? stdtmpl(subsChar='?') | standard
+## from https://github.com/nim-lang/Nim/blob/devel/tools/niminst/makefile.nimf
+#proc generateMakefile(c: ConfigData): string =
+#  result = "# Generated from niminst\n" &
+#           "# Template is in tools/niminst/makefile.nimf\n" &
+#           "# To regenerate run ``niminst csource`` or ``koch csource``\n"
+
+CC ??= gcc
+LD ??= gcc
+CFLAGS += -Ic_code ?{c.ccompiler.flags}
+LDFLAGS += ?{c.linker.flags}
+binDir = ?{firstBinPath(c).toUnix}
+
+koch := $(shell sh -c 'test -s ../koch.nim && echo "yes"')
+ifeq ($(koch),yes)
+  binDir = ../bin
+endif
+
+ucpu := $(shell sh -c 'uname -m | tr "[:upper:]" "[:lower:]"')
+uos := $(shell sh -c 'uname | tr "[:upper:]" "[:lower:]"')
+
+ifeq ($(uos),linux)
+  myos = linux
+  LDFLAGS += -ldl -lm
+endif
+ifeq ($(uos),dragonfly)
+  myos = freebsd
+  LDFLAGS += -lm
+endif
+ifeq ($(uos),freebsd)
+  myos= freebsd
+  CC = clang
+  LD = clang
+  LDFLAGS += -lm
+endif
+ifeq ($(uos),openbsd)
+  myos = openbsd
+  LDFLAGS += -lm
+endif
+ifeq ($(uos),netbsd)
+  myos = netbsd
+  LDFLAGS += -lm
+endif
+ifeq ($(uos),darwin)
+  myos = macosx
+  CC = clang
+  LD = clang
+  LDFLAGS += -ldl -lm
+  ifeq ($(HOSTTYPE),x86_64)
+    ucpu = amd64
+  endif
+endif
+ifeq ($(uos),aix)
+  myos = aix
+  LDFLAGS += -dl -lm
+endif
+ifeq ($(uos),solaris)
+  myos = solaris
+  LDFLAGS += -ldl -lm -lsocket -lnsl
+endif
+ifeq ($(uos),sun)
+  myos = solaris
+  LDFLAGS += -ldl -lm -lsocket -lnsl
+endif
+ifeq ($(uos),haiku)
+  myos = haiku
+endif
+ifndef myos
+  $(error unknown operating system: $(uos))
+endif
+
+ifeq ($(ucpu),i386)
+  mycpu = i386
+endif
+ifeq ($(ucpu),i486)
+  mycpu = i386
+endif
+ifeq ($(ucpu),i586)
+  mycpu = i386
+endif
+ifeq ($(ucpu),i686)
+  mycpu = i386
+endif
+ifeq ($(ucpu),bepc)
+  mycpu = i386
+endif
+ifeq ($(ucpu),i86pc)
+  mycpu = i386
+endif
+ifeq ($(ucpu),amd64)
+  mycpu = amd64
+endif
+ifeq ($(ucpu),x86-64)
+  mycpu = amd64
+endif
+ifeq ($(ucpu),x86_64)
+  mycpu = amd64
+endif
+ifeq ($(ucpu),sparc)
+  mycpu = sparc
+endif
+ifeq ($(ucpu),sun)
+  mycpu = sparc
+endif
+ifeq ($(ucpu),ppc64le)
+  mycpu = powerpc64el
+endif
+ifeq ($(ucpu),ppc64)
+  mycpu = powerpc64
+  ifeq ($(myos),linux)
+    CFLAGS += -m64
+    LDFLAGS += -m64
+  endif
+endif
+ifeq ($(ucpu),powerpc)
+  mycpu = powerpc
+endif
+ifeq ($(ucpu),ppc)
+  mycpu = ppc
+endif
+ifneq (,$(filter $(ucpu), mips mips64))
+  mycpu = $(shell /bin/sh -c '"$(CC)" -dumpmachine | sed "s/-.*//"')
+  ifeq (,$(filter $(mycpu), mips mipsel mips64 mips64el))
+    $(error unknown MIPS target: $(mycpu))
+  endif
+endif
+ifeq ($(ucpu),arm)
+  mycpu = arm
+endif
+ifeq ($(ucpu),armeb)
+  mycpu = arm
+endif
+ifeq ($(ucpu),armel)
+  mycpu = arm
+endif
+ifeq ($(ucpu),armv6l)
+  mycpu = arm
+endif
+ifeq ($(ucpu),armv7l)
+  mycpu = arm
+endif
+ifeq ($(ucpu),armv7hl)
+  mycpu = arm
+endif
+ifeq ($(ucpu),aarch64)
+  mycpu = arm64
+endif
+ifeq ($(ucpu),riscv64)
+  mycpu = riscv64
+endif
+ifndef mycpu
+  $(error unknown processor: $(ucpu))
+endif
+
+# for osA in 1..c.oses.len:
+ifeq ($(myos),?{c.oses[osA-1]})
+#   for cpuA in 1..c.cpus.len:
+  ifeq ($(mycpu),?{c.cpus[cpuA-1]})
+#     var oFiles = ""
+#     for ff in c.cfiles[osA][cpuA].items:
+#       oFiles.add(" " & changeFileExt(ff.toUnix, "o"))
+#     end for
+    oFiles =?oFiles
+  endif
+#   end for
+endif
+# end for
+
+ifeq ($(strip $(oFiles)),)
+  $(error no C code generated for: [$(myos): $(mycpu)])
+endif
+
+?{"$(binDir)/" & toLowerAscii(c.name)}: $(oFiles)
+	@mkdir -p $(binDir)
+	$(LD) -o $@ $^ $(LDFLAGS)
+	@echo "SUCCESS"
+
+.PHONY: clean
+
+clean:
+	rm -f $(oFiles) ?{"$(binDir)/" & toLowerAscii(c.name)}


### PR DESCRIPTION
/cc @pchaigno

## Description
* hopefully the last followup on https://github.com/github/linguist/pull/4295
* adds nimf extension for Nim language

Note 1: the `nimf` extension (for source code filter Nim files) was previously called `tmpl` but that was causing confusion because the extension `tmpl` was too generic and also didn't match the other Nim extensions (nim, nims, nimble, nim.cfg), so https://github.com/nim-lang/Nim/pull/9658 was recently merged to change the `tmpl` extension to `nimf` (while retaining backward compatibility); note that currently `nimf` is only used here: https://github.com/search?q=extension%3Animf+stdtmpl&type=Code ; but the old extension `tmpl` (which fits the same purpose as `nimf`) is used in more places, see https://github.com/search?q=extension%3Atmpl+stdtmpl&type=Code ; the plan is to gradually migrate the files using `tmpl` extension to `nimf`, and having it supported in linguist will provide extra incentive for the migration (eg syntax highlight), although linguist integration wasn't the only reason for the tmpl=>nimf change.

Note 2: `nimf` doesn't look like it's being used for anything but Nim source code filters

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com (but, see note above)
    - Search results for each extension:
      https://github.com/search?q=extension%3Animf+stdtmpl&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/nim-lang/Nim/blob/devel/tools/niminst/makefile.nimf
    - Sample license(s): https://github.com/nim-lang/Nim/blob/devel/copying.txt
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.


