### PR TITLE
Improve Golang color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1649,7 +1649,7 @@ Gnuplot:
   language_id: 131
 Go:
   type: programming
-  color: "#375eab"
+  color: "#5FC9D8"
   aliases:
   - golang
   extensions:


### PR DESCRIPTION
The actual color of Go doesn't looks like the color of the official Gopher mascot.

`#5FC9D8` fits more to the mascot which is a bright and joyful blue turquoise.

Also the actual deep blue color (`#375EAB`) looks a lot like PHP (`#4F5D95`) & Python (`#3572A5`) ones.