### PR TITLE
add vvvv as new language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5581,7 +5581,7 @@ sed:
   tm_scope: source.sed
   language_id: 847830017
 vvvv:
-  type: data
+  type: programming
   color: "#C0C0C0"
   extensions:
   - ".v4p"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5087,6 +5087,13 @@ Vue:
   tm_scope: text.html.vue
   ace_mode: html
   language_id: 391
+vvvv:
+  type: markup
+  color: "#e6e6e6"
+  extensions:
+  - ".v4p"
+  - ".vl"
+  language_id: 315707027
 Wavefront Material:
   type: data
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5581,12 +5581,11 @@ sed:
   tm_scope: source.sed
   language_id: 847830017
 vvvv:
-  type: markup
+  type: data
   color: "#C0C0C0"
   extensions:
   - ".v4p"
-  - ".vl"
-  tm_scope: none
+  tm_scope: text.xml
   ace_mode: xml
   language_id: 315707027
 wdl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5087,13 +5087,6 @@ Vue:
   tm_scope: text.html.vue
   ace_mode: html
   language_id: 391
-vvvv:
-  type: markup
-  color: "#e6e6e6"
-  extensions:
-  - ".v4p"
-  - ".vl"
-  language_id: 315707027
 Wavefront Material:
   type: data
   extensions:
@@ -5587,6 +5580,15 @@ sed:
   ace_mode: text
   tm_scope: source.sed
   language_id: 847830017
+vvvv:
+  type: markup
+  color: "#C0C0C0"
+  extensions:
+  - ".v4p"
+  - ".vl"
+  tm_scope: none
+  ace_mode: xml
+  language_id: 315707027
 wdl:
   type: programming
   color: "#42f1f4"

--- a/samples/vvvv/add.v4p
+++ b/samples/vvvv/add.v4p
@@ -1,0 +1,101 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta37.dtd" >
+
+   <PATCH nodename="C:\Users\case-12345\Desktop\example.v4p" scrollx="30" scrolly="0" systemname="example" filename="C:\Users\case-12345\Desktop\example.v4p">
+
+   <BOUNDS type="Window" left="3975" top="6540" width="9000" height="6000">
+
+   </BOUNDS>
+
+   <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="0">
+
+   <BOUNDS type="Node" left="1410" top="795" width="100" height="100">
+
+   </BOUNDS>
+
+   <BOUNDS type="Box" left="1410" top="795" width="795" height="240">
+
+   </BOUNDS>
+
+   <PIN pinname="Y Input Value" slicecount="1" values="9">
+
+   </PIN>
+
+   <PIN pinname="Y Output Value" visible="1">
+
+   </PIN>
+
+   </NODE>
+
+   <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="1">
+
+   <BOUNDS type="Node" left="3180" top="960" width="100" height="100">
+
+   </BOUNDS>
+
+   <BOUNDS type="Box" left="3180" top="960" width="795" height="240">
+
+   </BOUNDS>
+
+   <PIN pinname="Y Input Value" slicecount="1" values="12">
+
+   </PIN>
+
+   <PIN pinname="Y Output Value" visible="1">
+
+   </PIN>
+
+   </NODE>
+
+   <NODE systemname="Add (Value)" nodename="Add (Value)" componentmode="Hidden" id="2">
+
+   <BOUNDS type="Node" left="2490" top="1665" width="100" height="100">
+
+   </BOUNDS>
+
+   <PIN pinname="Input 1" visible="1">
+
+   </PIN>
+
+   <PIN pinname="Input 2" visible="1">
+
+   </PIN>
+
+   <PIN pinname="Output" visible="1">
+
+   </PIN>
+
+   </NODE>
+
+   <LINK srcnodeid="0" srcpinname="Y Output Value" dstnodeid="2" dstpinname="Input 1">
+
+   </LINK>
+
+   <LINK srcnodeid="1" srcpinname="Y Output Value" dstnodeid="2" dstpinname="Input 2">
+
+   </LINK>
+
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="3" systemname="IOBox (Value Advanced)">
+
+   <BOUNDS type="Box" left="2265" top="2775" width="795" height="240">
+
+   </BOUNDS>
+
+   <BOUNDS type="Node" left="2265" top="2775" width="0" height="0">
+
+   </BOUNDS>
+
+   <PIN pinname="Units" slicecount="1" values="||">
+
+   </PIN>
+
+   <PIN pinname="Precision" slicecount="1" values="4">
+
+   </PIN>
+
+   </NODE>
+
+   <LINK srcnodeid="2" srcpinname="Output" dstnodeid="3" dstpinname="Y Input Value">
+
+   </LINK>
+
+   </PATCH> 

--- a/samples/vvvv/teapot.v4p
+++ b/samples/vvvv/teapot.v4p
@@ -1,0 +1,113 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta37.dtd" >
+   <PATCH nodename="C:\Users\case-12345\Desktop\yeswekann.v4p" systemname="yeswekann" filename="C:\Users\case-12345\Desktop\yeswekann.v4p" scrollx="15" scrolly="0">
+   <BOUNDS type="Window" left="12060" top="6630" width="11175" height="7605">
+   </BOUNDS>
+   <NODE systemname="Renderer (EX9)" nodename="Renderer (EX9)" componentmode="InAWindow" id="1">
+   <BOUNDS type="Node" left="2700" top="3615" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2700" top="3615" width="2400" height="1800">
+   </BOUNDS>
+   <BOUNDS type="Window" left="27180" top="8070" width="6240" height="5085">
+   </BOUNDS>
+   <PIN pinname="Layers" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="X" visible="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   <PIN pinname="Windowed Depthbuffer Format" slicecount="1" values="D24X8">
+   </PIN>
+   <PIN pinname="Windowed Antialiasing Quality Level" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Teapot (EX9.Geometry)" nodename="Teapot (EX9.Geometry)" componentmode="Hidden" id="2">
+   <BOUNDS type="Node" left="1770" top="2265" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Mesh" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="PhongDirectional (EX9.Effect)" filename="%VVVV%\lib\nodes\effects\PhongDirectional.fx" nodename="PhongDirectional (EX9.Effect)" componentmode="Hidden" id="3">
+   <BOUNDS type="Node" left="2685" top="2790" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Mesh" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Diffuse Color" visible="1" slicecount="1" values="|0.10427,0.24912,0.72851,0.99854|">
+   </PIN>
+   <PIN pinname="Transform" visible="1">
+   </PIN>
+   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="2" srcpinname="Mesh" dstnodeid="3" dstpinname="Mesh">
+   </LINK>
+   <NODE nodename="IOBox (Color)" componentmode="InABox" id="4" systemname="IOBox (Color)">
+   <BOUNDS type="Box" left="3765" top="1965" width="2250" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3765" top="1965" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Color Input" slicecount="1" visible="1" values="|0.10427,0.24912,0.72851,0.99854|">
+   </PIN>
+   <PIN pinname="Color Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Rotate (Transform)" nodename="Rotate (Transform)" componentmode="Hidden" id="5">
+   <BOUNDS type="Node" left="2475" top="1755" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="X" visible="1" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   <PIN pinname="Z" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="3" dstpinname="Transform">
+   </LINK>
+   <NODE systemname="LFO (Animation)" nodename="LFO (Animation)" componentmode="Hidden" id="6">
+   <BOUNDS type="Node" left="3090" top="705" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Period" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Output" dstnodeid="5" dstpinname="Y">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="7" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="3105" top="240" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3105" top="240" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="2">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="s">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="7" srcpinname="Y Output Value" dstnodeid="6" dstpinname="Period">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="8">
+   <BOUNDS type="Box" left="1965" top="1080" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1965" top="1080" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0.9">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="8" srcpinname="Y Output Value" dstnodeid="5" dstpinname="X">
+   </LINK>
+   <LINK srcnodeid="3" srcpinname="Layer" dstnodeid="1" dstpinname="Layers">
+   </LINK>
+   <LINK srcnodeid="4" srcpinname="Color Output" dstnodeid="3" dstpinname="Diffuse Color">
+   </LINK>
+   <PACK Name="addonpack" Version="36.0.0">
+   </PACK>
+   </PATCH> 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -403,6 +403,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Visual Basic:** [angryant0007/VBDotNetSyntax](https://github.com/angryant0007/VBDotNetSyntax)
 - **Volt:** [textmate/d.tmbundle](https://github.com/textmate/d.tmbundle)
 - **Vue:** [vuejs/vue-syntax-highlight](https://github.com/vuejs/vue-syntax-highlight)
+- **vvvv:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)
 - **Wavefront Material:** [Alhadis/language-wavefront](https://github.com/Alhadis/language-wavefront)
 - **Wavefront Object:** [Alhadis/language-wavefront](https://github.com/Alhadis/language-wavefront)
 - **wdl:** [broadinstitute/wdl-sublime-syntax-highlighter](https://github.com/broadinstitute/wdl-sublime-syntax-highlighter)


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->


## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
I'm adding vvvv as a new language. vvvv is a visual programming language that has been around since 1998 and stores its projects (also called _Patches_) in `v4p` files, which internally use XML. Since vvvv is programmed completely through a graphical interface, there is no 'code' as such; for that reason, no grammar is included.

~~The chosen gray (#e6e6e6) is vvvv's characteristic background color.~~
The color, #C0C0C0, is that of a vvvv node. The originally chosen color conflicted with another one already in use.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  `v4p`: https://github.com/search?q=extension%3Av4p+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/colorchestra/vvvv-add-sample
    - Sample license(s): MIT
