### PR TITLE
Sever relationships between CSON/JSON and parent languages

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2194,10 +2194,12 @@ JSON5:
   language_id: 175
 JSONLD:
   type: data
-  ace_mode: javascript
   extensions:
   - ".jsonld"
   tm_scope: source.js
+  ace_mode: javascript
+  codemirror_mode: javascript
+  codemirror_mime_type: application/json
   language_id: 176
 JSONiq:
   color: "#40d47e"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -594,12 +594,10 @@ COLLADA:
   language_id: 49
 CSON:
   type: data
-  group: CoffeeScript
   tm_scope: source.coffee
   ace_mode: coffee
   codemirror_mode: coffeescript
   codemirror_mime_type: text/x-coffeescript
-  searchable: false
   extensions:
   - ".cson"
   language_id: 424
@@ -2128,7 +2126,6 @@ JFlex:
 JSON:
   type: data
   tm_scope: source.json
-  group: JavaScript
   ace_mode: json
   codemirror_mode: javascript
   codemirror_mime_type: application/json
@@ -2197,7 +2194,6 @@ JSON5:
   language_id: 175
 JSONLD:
   type: data
-  group: JavaScript
   ace_mode: javascript
   extensions:
   - ".jsonld"


### PR DESCRIPTION
Quick fix to decouple CSON and JSON from CoffeeScript and JavaScript, respectively. They're `data`-type languages anyway, so they won't affect repository statistics. More importantly, this is part of a long-term cleanup on how we handle language "groups" (see #4291). The reaction I expressed in #4344 at seeing CoffeeScript instead of CSON is as good an indication as any that we're doing the right thing by degrouping them. 👍

**Fixes:** github/linguist#4344

**References:** github/linguist#4291

*Template removed as the issue is predominantly about semantics*