### PR TITLE
Heuristic rule for Hack .hh files

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -149,6 +149,10 @@ disambiguations:
     named_pattern: objectivec
   - language: C++
     named_pattern: cpp
+- extensions: ['.hh']
+  rules:
+  - language: Hack
+    pattern: '<\?hh'
 - extensions: ['.ice']
   rules:
   - language: Slice

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -181,6 +181,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  # Candidate languages = ["C++", "Hack"]
+  def test_hh_by_heuristics
+    assert_heuristics({
+      "Hack" => all_fixtures("Hack", "*.hh"),
+    })
+  end
+
   def test_ice_by_heuristics
     assert_heuristics({
       "Slice" => all_fixtures("Slice", "*.ice"),


### PR DESCRIPTION
This pull request adds a new heuristic rule for Hack `.hh` files.

## Description

Fixes #4346.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.