### PR TITLE
Terraform alias for HCL language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1799,6 +1799,8 @@ HCL:
   - ".tf"
   - ".tfvars"
   - ".workflow"
+  aliases:
+  - terraform
   ace_mode: ruby
   codemirror_mode: ruby
   codemirror_mime_type: text/x-ruby


### PR DESCRIPTION
I expect many people to refer to the HashiCorp Language (HCL) simply as Terraform, or the Terraform language.

Fixes #4360.

*Template removed as it doesn't apply.*