### PR TITLE
Add HAR extension to JSON language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2192,6 +2192,7 @@ JSON:
   - ".avsc"
   - ".geojson"
   - ".gltf"
+  - ".har"
   - ".JSON-tmLanguage"
   - ".jsonl"
   - ".tfstate"

--- a/samples/JSON/recording.har
+++ b/samples/JSON/recording.har
@@ -1,0 +1,79 @@
+{
+  "log": {
+    "_recordingName": "@pollyjs/adapter-xhr/Integration | XHR Adapter/should be able to abort from an intercept",
+    "browser": {
+      "name": "Chrome",
+      "version": "67.0"
+    },
+    "creator": {
+      "comment": "persister:rest",
+      "name": "Polly.JS",
+      "version": "0.5.0"
+    },
+    "entries": [
+      {
+        "_id": "a59c75974571204bf8035e70d5ce252a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 182,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://localhost:7357/api/db/-pollyjs_2160168770%2Fadapter-xhr_1803529635%2FIntegration-XHR-Adapter_4095563232%2Fshould-be-able-to-abort-from-an-intercept_68559697"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "date",
+              "value": "Mon, 16 Jul 2018 22"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "Express"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            }
+          ],
+          "headersSize": 122,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2018-07-16T22:55:22.554Z",
+        "time": 33,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 33
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Add [HTTP archive](https://w3c.github.io/web-performance/specs/HAR/Overview.html#sec-har) extension to JSON language

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Ahar+%22name%3A+firefox%22
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/Netflix/pollyjs/blob/19fee5a63949af4e8b4e1dbcbf900eb6396d954b/tests/recordings/-pollyjs_2160168770/adapter-xhr_1803529635/Integration-XHR-Adapter_4095563232/should-be-able-to-abort-from-an-intercept_68559697/recording.har
    - Sample license(s): Apache
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
