### PR TITLE
Add Open Policy Agent as a new language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -971,6 +971,9 @@
 [submodule "vendor/grammars/vscode-lean"]
 	path = vendor/grammars/vscode-lean
 	url = https://github.com/leanprover/vscode-lean
+[submodule "vendor/grammars/vscode-opa"]
+	path = vendor/grammars/vscode-opa
+	url = https://github.com/tsandall/vscode-opa
 [submodule "vendor/grammars/vscode-scala-syntax"]
 	path = vendor/grammars/vscode-scala-syntax
 	url = https://github.com/scala/vscode-scala-syntax

--- a/grammars.yml
+++ b/grammars.yml
@@ -826,6 +826,8 @@ vendor/grammars/vscode-hack:
 - source.hack
 vendor/grammars/vscode-lean:
 - source.lean
+vendor/grammars/vscode-opa:
+- source.rego
 vendor/grammars/vscode-scala-syntax:
 - source.scala
 vendor/grammars/vscode-slice:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3514,6 +3514,13 @@ Opal:
   tm_scope: source.opal
   ace_mode: text
   language_id: 262
+Open Policy Agent:
+  type: programming
+  ace_mode: text
+  extensions:
+  - ".rego"
+  language_id: 840483232
+  tm_scope: source.rego
 OpenCL:
   type: programming
   group: C

--- a/samples/Open Policy Agent/httpapi.rego
+++ b/samples/Open Policy Agent/httpapi.rego
@@ -1,0 +1,23 @@
+package httpapi.authz
+
+# bob is alice's manager, and betty is charlie's.
+subordinates = {"alice": [], "charlie": [], "bob": ["alice"], "betty": ["charlie"]}
+
+# HTTP API request
+import input as http_api
+
+default allow = false
+
+# Allow users to get their own salaries.
+allow {
+  http_api.method = "GET"
+  http_api.path = ["finance", "salary", username]
+  username = http_api.user
+}
+
+# Allow managers to get their subordinates' salaries.
+allow {
+  http_api.method = "GET"
+  http_api.path = ["finance", "salary", username]
+  subordinates[http_api.user][_] = username
+}

--- a/samples/Open Policy Agent/kafka.rego
+++ b/samples/Open Policy Agent/kafka.rego
@@ -1,0 +1,77 @@
+#-----------------------------------------------------------------------------
+# High level policy for controlling access to Kafka.
+#
+# * Deny operations by default.
+# * Allow operations if no explicit denial.
+#
+# The kafka-authorizer-opa plugin will query OPA for decisions at
+# /kafka/authz/allow. If the policy decision is _true_ the request is allowed.
+# If the policy decision is _false_ the request is denied.
+#-----------------------------------------------------------------------------
+package kafka.authz
+
+default allow = false
+
+allow {
+    not deny
+}
+
+deny {
+    is_read_operation
+    topic_contains_pii
+    not consumer_is_whitelisted_for_pii
+}
+
+#-----------------------------------------------------------------------------
+# Data structures for controlling access to topics. In real-world deployments,
+# these data structures could be loaded into OPA as raw JSON data. The JSON
+# data could be pulled from external sources like AD, Git, etc.
+#-----------------------------------------------------------------------------
+
+consumer_whitelist = {"pii": {"pii_consumer"}}
+
+topic_metadata = {"credit-scores": {"tags": ["pii"]}}
+
+#-----------------------------------
+# Helpers for checking topic access.
+#-----------------------------------
+
+topic_contains_pii {
+    topic_metadata[topic_name].tags[_] == "pii"
+}
+
+consumer_is_whitelisted_for_pii {
+    consumer_whitelist.pii[_] == principal.name
+}
+
+#-----------------------------------------------------------------------------
+# Helpers for processing Kafka operation input. This logic could be split out
+# into a separate file and shared. For conciseness, we have kept it all in one
+# place.
+#-----------------------------------------------------------------------------
+
+is_write_operation {
+    input.operation.name == "Write"
+}
+
+is_read_operation {
+    input.operation.name == "Read"
+}
+
+is_topic_resource {
+    input.resource.resourceType.name == "Topic"
+}
+
+topic_name = input.resource.name {
+    is_topic_resource
+}
+
+principal = {"fqn": parsed.CN, "name": cn_parts[0]} {
+    parsed := parse_user(urlquery.decode(input.session.sanitizedUser))
+    cn_parts := split(parsed.CN, ".")
+}
+
+parse_user(user) = {key: value |
+    parts := split(user, ",")
+    [key, value] := split(parts[_], "=")
+}

--- a/samples/Open Policy Agent/kubernetes_admission.rego
+++ b/samples/Open Policy Agent/kubernetes_admission.rego
@@ -1,0 +1,8 @@
+package kubernetes.admission                                                # line 1
+
+deny[msg] {                                                                 # line 2
+  input.request.kind.kind == "Pod"                                          # line 3
+  image := input.request.object.spec.containers[_].image                    # line 4
+  not startswith(image, "hooli.com/")                                       # line 5
+  msg := sprintf("image fails to come from trusted registry: %v", [image])  # line 6
+}

--- a/samples/Open Policy Agent/ssh.rego
+++ b/samples/Open Policy Agent/ssh.rego
@@ -1,0 +1,32 @@
+package sshd.authz
+
+import input.pull_responses
+import input.sysinfo
+
+import data.hosts
+
+# By default, users are not authorized.
+default allow = false
+
+# Allow access to any user that has the "admin" role.
+allow {
+    data.roles["admin"][_] = input.sysinfo.pam_username
+}
+
+# Allow access to any user who contributed to the code running on the host.
+#
+# This rule gets the `host_id` value from the file `/etc/host_identity.json`.
+# It is available in the input under `pull_responses` because we
+# asked for it in our pull policy above.
+#
+# It then compares all the contributors for that host against the username
+# that is asking for authorization.
+allow {
+    hosts[pull_responses.files["/etc/host_identity.json"].host_id].contributors[_] = sysinfo.pam_username
+}
+
+
+# If the user is not authorized, then include an error message in the response.
+errors["Request denied by administrative policy"] {
+    not allow
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -278,6 +278,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Objective-J:** [textmate/javascript-objective-j.tmbundle](https://github.com/textmate/javascript-objective-j.tmbundle)
 - **Opa:** [mads379/opa.tmbundle](https://github.com/mads379/opa.tmbundle)
 - **Opal:** [artifactz/sublime-opal](https://github.com/artifactz/sublime-opal)
+- **Open Policy Agent:** [tsandall/vscode-opa](https://github.com/tsandall/vscode-opa)
 - **OpenCL:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **OpenEdge ABL:** [jfairbank/Sublime-Text-2-OpenEdge-ABL](https://github.com/jfairbank/Sublime-Text-2-OpenEdge-ABL)
 - **OpenRC runscript:** [atom/language-shellscript](https://github.com/atom/language-shellscript)

--- a/vendor/licenses/grammar/vscode-opa.txt
+++ b/vendor/licenses/grammar/vscode-opa.txt
@@ -1,0 +1,207 @@
+---
+type: grammar
+name: vscode-opa
+version: 6b19c501fef4232ad00a7e0f76b337b86e07015a
+license: apache-2.0
+---
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
:wave: hello!

I'd like to add syntax support for the [Open Policy Agent (OPA)](https://openpolicyagent.org) project. OPA is hosted by the Cloud Native Compute Foundation (CNCF). OPA implements a domain-agnostic policy language. It embodies policy-as-code, which means organizations often store, review, test, and revise their policies on GitHub.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - I ran the harvester tool and found Rego files in ~79~ 252 public repositories (as of this PR).
    - Search results for each extension:
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Arego+package+NOT+nothack
     - OPA policies start with a "package" directive that namespaces the rules (hence the search term above)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - The sample sources come from the OPA documentation. OPA is ALv2. They come come [here (HTTP)](https://github.com/open-policy-agent/opa/blob/master/docs/content/http-api-authorization.md#2-load-a-policy-into-opa), [here (Kafka)](https://github.com/open-policy-agent/opa/blob/master/docs/content/kafka-authorization.md#2-define-a-policy-to-restrict-consumer-access-to-topics-containing-personally-identifiable-information-pii), [here (SSH)](https://github.com/open-policy-agent/opa/blob/master/docs/content/ssh-and-sudo-authorization.md#2-load-policies-and-data-into-opa), and [here (K8s)](https://github.com/open-policy-agent/opa/blob/master/docs/content/kubernetes-primer.md#writing-policies).
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftsandall%2Fvscode-opa%2Fmaster%2Fsyntaxes%2FRego.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fopen-policy-agent%2Flibrary%2Fblob%2Fmaster%2Fterraform%2Fexample.rego&code=
  - There are no other languages with the same extension (.rego) in languages.yml.