### PR TITLE
Enforce the "one sentence per line" rule in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,106 +1,157 @@
 # Contributing
 
-Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+Hi there!
+We're thrilled that you'd like to contribute to this project.
+Your help is essential for keeping it great.
 
 Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
-This project adheres to the [Contributor Covenant Code of Conduct](http://contributor-covenant.org/). By participating, you are expected to uphold this code.
+This project adheres to the [Contributor Covenant Code of Conduct](http://contributor-covenant.org/).
+By participating, you are expected to uphold this code.
 
 The majority of contributions won't need to touch any Ruby code at all.
 
 ## Getting started
 
-Before you can start contributing to Linguist, you'll need to set up your environment first. Clone the repo and run `script/bootstrap` to install its dependencies.
+Before you can start contributing to Linguist, you'll need to set up your environment first.
+Clone the repo and run `script/bootstrap` to install its dependencies.
 
-    git clone https://github.com/github/linguist.git
-    cd linguist/
-    script/bootstrap
+```console
+$ git clone https://github.com/github/linguist.git
+$ cd linguist/
+$ script/bootstrap
+```
 
 To run Linguist from the cloned repository, you will need to generate the code samples first:
 
-    bundle exec rake samples
+```console
+$ bundle exec rake samples
+```
 
 Run this command each time a [sample][samples] has been modified.
 
 To run Linguist from the cloned repository:
 
-    bundle exec bin/github-linguist --breakdown
+```console
+$ bundle exec bin/github-linguist --breakdown
+```
 
 ### Dependencies
 
-Linguist uses the [`charlock_holmes`](https://github.com/brianmario/charlock_holmes) character encoding detection library which in turn uses [ICU](http://site.icu-project.org/), and the libgit2 bindings for Ruby provided by [`rugged`](https://github.com/libgit2/rugged). [Docker](https://www.docker.com/) is also required when adding or updating grammars. These components have their own dependencies - `icu4c`, and `cmake` and `pkg-config` respectively - which you may need to install before you can install Linguist.
+Linguist uses the [`charlock_holmes`](https://github.com/brianmario/charlock_holmes) character encoding detection library which in turn uses [ICU](http://site.icu-project.org/), and the libgit2 bindings for Ruby provided by [`rugged`](https://github.com/libgit2/rugged).
+[Docker](https://www.docker.com/) is also required when adding or updating grammars.
+These components have their own dependencies - `icu4c`, and `cmake` and `pkg-config` respectively - which you may need to install before you can install Linguist.
 
-For example, on macOS with [Homebrew](http://brew.sh/): `brew install cmake pkg-config icu4c docker` and on Ubuntu: `apt-get install cmake pkg-config libicu-dev docker-ce`.
+For example, on macOS with [Homebrew](http://brew.sh/):
+
+```console
+$ brew install cmake pkg-config icu4c docker
+```
+
+On Ubuntu:
+
+```console
+$ apt-get install cmake pkg-config libicu-dev docker-ce
+```
 
 ## Adding an extension to a language
 
-We try only to add new extensions once they have some usage on GitHub. In most cases we prefer that extensions be in use in hundreds of repositories before supporting them in Linguist.
+We try only to add new extensions once they have some usage on GitHub.
+In most cases we prefer that extensions be in use in hundreds of repositories before supporting them in Linguist.
 
 To add support for a new extension:
 
-1. Add your extension to the language entry in [`languages.yml`][languages], keeping the extensions in alphabetical and case-sensitive (uppercase before lowercase) order, with the exception of the primary extension; the primary extension should be first.
-1. Add at least one sample for your extension to the [samples directory][samples] in the correct subdirectory. We'd prefer examples of real-world code showing common usage. The more representative of the structure of the language, the better.
-1. Open a pull request, linking to a [GitHub search result](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aboot+NOT+nothack&type=Code&ref=searchresults) showing in-the-wild usage.
-  If you are adding a sample, please state clearly the license covering the code in the sample, and if possible, link to the original source of the sample.
+1. Add your extension to the language entry in [`languages.yml`][languages].
+   Keep the extensions in alphabetical order, sorted case-sensitively (uppercase before lowercase).
+   The exception is the primary extension: it should always be first.
+1. Add at least one sample for your extension to the [samples directory][samples] in the correct subdirectory.
+   We prefer examples of real-world code showing common usage.
+   The more representative of the structure of the language, the better.
+1. Open a pull request, linking to a [GitHub search result][search-example] showing in-the-wild usage.
+   If you are adding a sample, please state clearly the license covering the code.
+   If possible, link to the original source of the sample.
 
 Additionally, if this extension is already listed in [`languages.yml`][languages] and associated with another language, then sometimes a few more steps will need to be taken:
 
 1. Make sure that example `.yourextension` files are present in the [samples directory][samples] for each language that uses `.yourextension`.
-1. Test the performance of the Bayesian classifier with a relatively large number (1000s) of sample `.yourextension` files. (ping **@lildude** to help with this) to ensure we're not misclassifying files.
-1. If the Bayesian classifier does a bad job with the sample `.yourextension` files then a [heuristic](https://github.com/github/linguist/blob/master/lib/linguist/heuristics.rb) may need to be written to help.
+1. Test the performance of the Bayesian classifier with a relatively large number (1000s) of sample `.yourextension` files (ping **@lildude** to help with this).
+   This ensures we're not misclassifying files.
+1. If the Bayesian classifier does a bad job with the sample `.yourextension` files then a [heuristic][] may need to be written to help.
 
 
 ## Adding a language
 
-We try only to add languages once they have some usage on GitHub. In most cases we prefer that each new file extension be in use in hundreds of repositories before supporting them in Linguist.
+We try only to add languages once they have some usage on GitHub.
+In most cases we prefer that each new file extension be in use in hundreds of repositories before supporting them in Linguist.
 
 To add support for a new language:
 
-1. Add an entry for your language to [`languages.yml`][languages]. Omit the `language_id` field for now.
-1. Add a syntax-highlighting grammar for your language using: `script/add-grammar https://github.com/JaneSmith/MyGrammar`
-  This command will analyze the grammar and, if no problems are found, add it to the repository. If problems are found, please report them to the grammar maintainer as you will not be able to add the grammar if problems are found.
-  **Please only add grammars that have [one of these licenses][licenses].**
+1. Add an entry for your language to [`languages.yml`][languages].
+   Omit the `language_id` field for now.
+1. Add a syntax-highlighting grammar for your language using:
+   ```console
+   $ script/add-grammar https://github.com/JaneSmith/MyGrammar
+   ```
+   This command will analyze the grammar and, if no problems are found, add it to the repository.
+   If problems are found, please report them to the grammar maintainer as you will otherwise be unable to add it.
+   **Please only add grammars that have [one of these licenses][licenses].**
 1. Add samples for your language to the [samples directory][samples] in the correct subdirectory.
 1. Generate a unique ID for your language by running `script/update-ids`.
-1. Open a pull request, linking to a [GitHub search results](https://github.com/search?utf8=%E2%9C%93&q=extension%3Aboot+NOT+nothack&type=Code&ref=searchresults) showing in-the-wild usage.
-  Please state clearly the license covering the code in the samples. Link directly to the original source if possible.
+1. Open a pull request, linking to [GitHub search results][search-example] showing in-the-wild usage.
+   Please state clearly the license covering the code in the samples.
+   Link directly to the original source if possible.
 
 In addition, if your new language defines an extension that's already listed in [`languages.yml`][languages] (such as `.foo`) then sometimes a few more steps will need to be taken:
 
 1. Make sure that example `.foo` files are present in the [samples directory][samples] for each language that uses `.foo`.
-1. Test the performance of the Bayesian classifier with a relatively large number (1000s) of sample `.foo` files. (ping **@lildude** to help with this) to ensure we're not misclassifying files.
-1. If the Bayesian classifier does a bad job with the sample `.foo` files then a [heuristic](https://github.com/github/linguist/blob/master/lib/linguist/heuristics.rb) may need to be written to help.
+1. Test the performance of the Bayesian classifier with a relatively large number (1000s) of sample `.foo` files (ping **@lildude** to help with this).
+   This ensures we're not misclassifying files.
+1. If the Bayesian classifier does a bad job with the sample `.foo` files, then a [heuristic][] may need to be written to help.
 
 Remember, the goal here is to try and avoid false positives!
 
 
 ## Fixing a misclassified language
 
-Most languages are detected by their file extension defined in [`languages.yml`][languages].  For disambiguating between files with common extensions, Linguist applies some [heuristics](/lib/linguist/heuristics.rb) and a [statistical classifier](lib/linguist/classifier.rb). This process can help differentiate between, for example, `.h` files which could be either C, C++, or Obj-C.
+Most languages are detected by their file extension defined in [`languages.yml`][languages].
+For disambiguating between files with common extensions, Linguist applies some [heuristics](/lib/linguist/heuristics.rb) and a [statistical classifier](lib/linguist/classifier.rb).
+This process can help differentiate between, for example, `.h` files which could be either C, C++, or Obj-C.
 
-Misclassifications can often be solved by either adding a new filename or extension for the language or adding more [samples][samples] to make the classifier smarter.
+Misclassifications can often be solved by either adding a new filename or extension for the language or adding more [samples][] to make the classifier smarter.
 
 
 ## Fixing syntax highlighting
 
-Syntax highlighting in GitHub is performed using TextMate-compatible grammars. These are the same grammars that TextMate, Sublime Text and Atom use. Every language in [`languages.yml`][languages] is mapped to its corresponding TextMate `scopeName`. This scope name will be used when picking up a grammar for highlighting.
+Syntax highlighting in GitHub is performed using TextMate-compatible grammars.
+These are the same grammars that TextMate, Sublime Text and Atom use.
+Every language in [`languages.yml`][languages] is mapped to its corresponding TextMate `scopeName`.
+This scope name will be used when picking up a grammar for highlighting.
 
-Assuming your code is being detected as the right language, in most cases syntax highlighting problems are due to a bug in the language grammar rather than a bug in Linguist. [`vendor/README.md`][grammars] lists all the grammars we use for syntax highlighting on GitHub.com. Find the one corresponding to your code's programming language and submit a bug report upstream. If you can, try to reproduce the highlighting problem in the text editor that the grammar is designed for (TextMate, Sublime Text, or Atom) and include that information in your bug report.
+Assuming your code is being detected as the right language, in most cases syntax highlighting problems are due to a bug in the language grammar rather than a bug in Linguist.
+[`vendor/README.md`][grammars] lists all the grammars we use for syntax highlighting on GitHub.com.
+Find the one corresponding to your code's programming language and submit a bug report upstream.
+If you can, try to reproduce the highlighting problem in the text editor that the grammar is designed for (TextMate, Sublime Text, or Atom) and include that information in your bug report.
 
-You can also try to fix the bug yourself and submit a Pull Request. [TextMate's documentation](https://manual.macromates.com/en/language_grammars) offers a good introduction on how to work with TextMate-compatible grammars. You can test grammars using [Lightshow](https://github-lightshow.herokuapp.com).
+You can also try to fix the bug yourself and submit a pull-request.
+[TextMate's documentation](https://manual.macromates.com/en/language_grammars) offers a good introduction on how to work with TextMate-compatible grammars.
+You can test grammars using [Lightshow](https://github-lightshow.herokuapp.com).
 
 Once the bug has been fixed upstream, we'll pick it up for GitHub in the next release of Linguist.
 
 
 ## Changing the source of a syntax highlighting grammar
 
-We'd like to ensure Linguist and GitHub.com are using the latest and greatest grammars that are consistent with the current usage but understand that sometimes a grammar can lag behind the evolution of a language or even stop being developed. This often results in someone grasping the opportunity to create a newer and better and more actively maintained grammar, and we'd love to use it and pass on it's functionality to our users.
+We'd like to ensure Linguist and GitHub.com are using the latest and greatest grammars that are consistent with the current usage but understand that sometimes a grammar can lag behind the evolution of a language or even stop being developed.
+This often results in someone grasping the opportunity to create a newer and better and more actively maintained grammar, and we'd love to use it and pass on it's functionality to our users.
 
 Switching the source of a grammar is really easy:
 
-    script/add-grammar --replace MyGrammar https://github.com/PeterPan/MyGrammar
+```console
+$ script/add-grammar --replace MyGrammar https://github.com/PeterPan/MyGrammar
+```
 
-This command will analyze the grammar and, if no problems are found, add it to the repository. If problems are found, please report these problems to the grammar maintainer as you will not be able to add the grammar if problems are found.
+This command will analyze the grammar and, if no problems are found, add it to the repository.
+If problems are found, please report these problems to the grammar maintainer as you will not be able to add the grammar if problems are found.
 
 **Please only add grammars that have [one of these licenses][licenses].**
 
@@ -111,11 +162,16 @@ Please then open a pull request for the updated grammar.
 
 You can run the tests locally with:
 
-    bundle exec rake test
+```console
+$ bundle exec rake test
+```
 
-Sometimes getting the tests running can be too much work, especially if you don't have much Ruby experience. It's okay: be lazy and let our build bot [Travis](https://travis-ci.org/#!/github/linguist) run the tests for you. Just open a pull request and the bot will start cranking away.
+Sometimes getting the tests running can be too much work, especially if you don't have much Ruby experience.
+It's okay: be lazy and let our build bot [Travis](https://travis-ci.org/#!/github/linguist) run the tests for you.
+Just open a pull request and the bot will start cranking away.
 
 Here's our current build status: [![Build Status](https://api.travis-ci.org/github/linguist.svg?branch=master)](https://travis-ci.org/github/linguist)
+
 
 ## Maintainers
 
@@ -136,24 +192,26 @@ As Linguist is a production dependency for GitHub we have a couple of workflow r
 - Anyone with commit rights can merge Pull Requests provided that there is a :+1: from a GitHub staff member.
 - Releases are performed by GitHub staff so we can ensure GitHub.com always stays up to date with the latest release of Linguist and there are no regressions in production.
 
+
 ### Releasing
 
 If you are the current maintainer of this gem:
 
 1. Create a branch for the release: `git checkout -b release-vxx.xx.xx`
 1. Make sure your local dependencies are up to date: `script/bootstrap`
-1. If grammar submodules have not been updated recently, update them: `git submodule update --remote`. If any submodules are updated,
-    1. update the license cache: `script/licensed`
-    1. double check no problems found: `script/licensed status`
-    1. verify and fix any problems identified
-    1. commit all changes: `git commit -a`
+1. If grammar submodules have not been updated recently, update them: `git submodule update --remote`.
+   If any submodules are updated,
+     1. Update the license cache: `script/licensed`
+     1. Double check no problems found: `script/licensed status`
+     1. Verify and fix any problems identified
+     1. Commit all changes: `git commit -a`
 1. Ensure that samples are updated: `bundle exec rake samples`
 1. Ensure that tests are green: `bundle exec rake test`
 1. Build a test gem `GEM_VERSION=$(git describe --tags 2>/dev/null | sed 's/-/./g' | sed 's/v//') bundle exec rake build_gem`
 1. Test the test gem:
-  1. Bump the Gemfile and Gemfile.lock versions for an app which relies on this gem
-  1. Install the new gem locally
-  1. Test behavior locally, branch deploy, whatever needs to happen
+   1. Bump the Gemfile and Gemfile.lock versions for an app which relies on this gem
+   1. Install the new gem locally
+   1. Test behavior locally, branch deploy, whatever needs to happen
 1. Bump gem version in `lib/linguist/VERSION`, [like this](https://github.com/github/linguist/commit/3212355400974ce5f7873a71eb8b85b1c5f4a6d2).
 1. Make a PR to github/linguist, [like this](https://github.com/github/linguist/pull/1238).
 1. Build a local gem: `bundle exec rake build_gem`
@@ -163,8 +221,11 @@ If you are the current maintainer of this gem:
 1. Build a grammars tarball (`./script/build-grammars-tarball`) and attach it to the GitHub release
 1. Push to rubygems.org -- `gem push github-linguist-3.0.0.gem`
 
+
 [grammars]: /vendor/README.md
+[heuristic]: https://github.com/github/linguist/blob/master/lib/linguist/heuristics.rb
 [languages]: /lib/linguist/languages.yml
 [licenses]: https://github.com/github/linguist/blob/257425141d4e2a5232786bf0b13c901ada075f93/vendor/licenses/config.yml#L2-L11
-[samples]: /samples
 [new-issue]: https://github.com/github/linguist/issues/new
+[samples]: /samples
+[search-example]: https://github.com/search?utf8=%E2%9C%93&q=extension%3Aboot+NOT+nothack&type=Code&ref=searchresults

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Misclassifications can often be solved by either adding a new filename or extens
 ## Fixing syntax highlighting
 
 Syntax highlighting in GitHub is performed using TextMate-compatible grammars.
-These are the same grammars that TextMate, Sublime Text and Atom use.
+These are the same grammars used by TextMate, Sublime Text, and Atom.
 Every language in [`languages.yml`][languages] is mapped to its corresponding TextMate `scopeName`.
 This scope name will be used when picking up a grammar for highlighting.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ If you are the current maintainer of this gem:
 1. Create a branch for the release: `git checkout -b release-vxx.xx.xx`
 1. Make sure your local dependencies are up to date: `script/bootstrap`
 1. If grammar submodules have not been updated recently, update them: `git submodule update --remote`.
-   If any submodules are updated,
+   If any submodules are updated:
      1. Update the license cache: `script/licensed`
      1. Double check no problems found: `script/licensed status`
      1. Verify and fix any problems identified

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,24 +16,24 @@ The majority of contributions won't need to touch any Ruby code at all.
 Before you can start contributing to Linguist, you'll need to set up your environment first.
 Clone the repo and run `script/bootstrap` to install its dependencies.
 
-```console
-$ git clone https://github.com/github/linguist.git
-$ cd linguist/
-$ script/bootstrap
+```bash
+git clone https://github.com/github/linguist.git
+cd linguist/
+script/bootstrap
 ```
 
 To run Linguist from the cloned repository, you will need to generate the code samples first:
 
-```console
-$ bundle exec rake samples
+```bash
+bundle exec rake samples
 ```
 
 Run this command each time a [sample][samples] has been modified.
 
 To run Linguist from the cloned repository:
 
-```console
-$ bundle exec bin/github-linguist --breakdown
+```bash
+bundle exec bin/github-linguist --breakdown
 ```
 
 ### Dependencies
@@ -44,14 +44,14 @@ These components have their own dependencies - `icu4c`, and `cmake` and `pkg-con
 
 For example, on macOS with [Homebrew](http://brew.sh/):
 
-```console
-$ brew install cmake pkg-config icu4c docker
+```bash
+brew install cmake pkg-config icu4c docker
 ```
 
 On Ubuntu:
 
-```console
-$ apt-get install cmake pkg-config libicu-dev docker-ce
+```bash
+apt-get install cmake pkg-config libicu-dev docker-ce
 ```
 
 ## Adding an extension to a language
@@ -89,8 +89,8 @@ To add support for a new language:
 1. Add an entry for your language to [`languages.yml`][languages].
    Omit the `language_id` field for now.
 1. Add a syntax-highlighting grammar for your language using:
-   ```console
-   $ script/add-grammar https://github.com/JaneSmith/MyGrammar
+   ```bash
+   script/add-grammar https://github.com/JaneSmith/MyGrammar
    ```
    This command will analyze the grammar and, if no problems are found, add it to the repository.
    If problems are found, please report them to the grammar maintainer as you will otherwise be unable to add it.
@@ -146,8 +146,8 @@ This often results in someone grasping the opportunity to create a newer and bet
 
 Switching the source of a grammar is really easy:
 
-```console
-$ script/add-grammar --replace MyGrammar https://github.com/PeterPan/MyGrammar
+```bash
+script/add-grammar --replace MyGrammar https://github.com/PeterPan/MyGrammar
 ```
 
 This command will analyze the grammar and, if no problems are found, add it to the repository.
@@ -162,8 +162,8 @@ Please then open a pull request for the updated grammar.
 
 You can run the tests locally with:
 
-```console
-$ bundle exec rake test
+```bash
+bundle exec rake test
 ```
 
 Sometimes getting the tests running can be too much work, especially if you don't have much Ruby experience.

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ project.languages      #=> { "Ruby" => 119387 }
 
 ### Command line usage
 
-A repository's languages stats can also be assessed from the command line using the `linguist` executable.
-Without any options, `linguist` will output the breakdown that correlates to what is shown in the language stats bar.
+A repository's languages stats can also be assessed from the command line using the `github-linguist` executable.
+Without any options, `github-linguist` will output the breakdown that correlates to what is shown in the language stats bar.
 The `--breakdown` flag will additionally show the breakdown of files by language.
 
 ```bash
@@ -99,7 +99,7 @@ cd /path-to-repository/
 github-linguist
 ```
 
-You can try running `linguist` on the root directory in this repository itself:
+You can try running `github-linguist` on the root directory in this repository itself:
 
 ```console
 $ bundle exec bin/github-linguist --breakdown

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Linguist takes the list of languages it knows from [`languages.yml`](/lib/lingui
 
 Linguist starts by going through all the files in a repository and excludes all files that it determines to be binary data, [vendored code](#vendored-code), [generated code](#generated-code), [documentation](#documentation), or are defined as `data` (e.g. SQL) or `prose` (e.g. Markdown) languages, whilst taking into account any [overrides](#overrides).
 
-If an [explicit language override](#using-gitattributes) has been used, that language is used for the matching files. The language of each remaining file is then determined using the following strategies, in order, with each step either identifying the precise language or reducing the number of likely languages passed down to the next strategy:
+If an [explicit language override](#using-gitattributes) has been used, that language is used for the matching files.
+The language of each remaining file is then determined using the following strategies, in order, with each step either identifying the precise language or reducing the number of likely languages passed down to the next strategy:
 
 - Vim or Emacs modeline,
 - commonly used filename,
@@ -25,13 +26,16 @@ If an [explicit language override](#using-gitattributes) has been used, that lan
 - heuristics,
 - naïve Bayesian classification
 
-The result of this analysis is used to produce the language stats bar which displays the languages percentages for the files in the repository. The percentages are calculated based on the bytes of code for each language as reported by the [List Languages](https://developer.github.com/v3/repos/#list-languages) API.
+The result of this analysis is used to produce the language stats bar which displays the languages percentages for the files in the repository.
+The percentages are calculated based on the bytes of code for each language as reported by the [List Languages](https://developer.github.com/v3/repos/#list-languages) API.
 
 ![language stats bar](https://user-images.githubusercontent.com/2346707/50930521-52f57e80-14b4-11e9-92de-0ee9c768ae46.png)
 
 ### How Linguist works on GitHub.com
 
-When you push changes to a repository on GitHub.com, a low priority background job is enqueued to analyze your repository as explained above. The results of this analysis are cached for the lifetime of your repository and are only updated when the repository is updated. As this analysis is performed by a low priority background job, it can take a while, particularly during busy periods, for your language statistics bar to reflect your changes.
+When you push changes to a repository on GitHub.com, a low priority background job is enqueued to analyze your repository as explained above.
+The results of this analysis are cached for the lifetime of your repository and are only updated when the repository is updated.
+As this analysis is performed by a low priority background job, it can take a while, particularly during busy periods, for your language statistics bar to reflect your changes.
 
 
 ## Usage
@@ -46,7 +50,8 @@ $ gem install github-linguist
 
 #### Dependencies
 
-Linguist uses [`charlock_holmes`](https://github.com/brianmario/charlock_holmes) for character encoding and [`rugged`](https://github.com/libgit2/rugged) for libgit2 bindings for Ruby. These components have their own dependencies.
+Linguist uses [`charlock_holmes`](https://github.com/brianmario/charlock_holmes) for character encoding and [`rugged`](https://github.com/libgit2/rugged) for libgit2 bindings for Ruby.
+These components have their own dependencies.
 1. charlock_holmes
     * cmake
     * pkg-config
@@ -56,7 +61,18 @@ Linguist uses [`charlock_holmes`](https://github.com/brianmario/charlock_holmes)
     * [libcurl](https://curl.haxx.se/libcurl/)
     * [OpenSSL](https://www.openssl.org)
 
-You may need to install missing dependencies before you can install Linguist. For example, on macOS with [Homebrew](http://brew.sh/): `brew install cmake pkg-config icu4c` and on Ubuntu: `sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev`.
+You may need to install missing dependencies before you can install Linguist.
+For example, on macOS with [Homebrew](http://brew.sh/):
+
+```console
+$ brew install cmake pkg-config icu4c
+```
+
+On Ubuntu:
+
+```console
+$ sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev
+```
 
 ### Application usage
 
@@ -74,7 +90,9 @@ project.languages      #=> { "Ruby" => 119387 }
 
 ### Command line usage
 
-A repository's languages stats can also be assessed from the command line using the `linguist` executable. Without any options, `linguist` will output the breakdown that correlates to what is shown in the language stats bar. The `--breakdown` flag will additionally show the breakdown of files by language.
+A repository's languages stats can also be assessed from the command line using the `linguist` executable.
+Without any options, `linguist` will output the breakdown that correlates to what is shown in the language stats bar.
+The `--breakdown` flag will additionally show the breakdown of files by language.
 
 ```console
 $ cd /path-to-repository/
@@ -110,12 +128,18 @@ lib/linguist.rb
 If the language stats bar is reporting a language that you don't expect:
 
 1. Click on the name of the language in the stats bar to see a list of the files that are identified as that language.  
-  Keep in mind this performs a search so the [code search restrictions](https://help.github.com/articles/searching-code/#considerations-for-code-search) may result in files identified in the language statistics not appearing in the search results. [Installing Linguist locally](#usage) and running it from the [command line](#command-line-usage) will give you accurate results.
+   Keep in mind this performs a search so the [code search restrictions][search-limits] may result in files identified in the language statistics not appearing in the search results.
+   [Installing Linguist locally](#usage) and running it from the [command line](#command-line-usage) will give you accurate results.
 1. If you see files that you didn't write in the search results, consider moving the files into one of the [paths for vendored code](/lib/linguist/vendor.yml), or use the [manual overrides](#overrides) feature to ignore them.
-1. If the files are misclassified, search for [open issues][issues] to see if anyone else has already reported the issue. Any information you can add, especially links to public repositories, is helpful. You can also use the [manual overrides](#overrides) feature to correctly classify them in your repository.
+1. If the files are misclassified, search for [open issues][issues] to see if anyone else has already reported the issue.
+   Any information you can add, especially links to public repositories, is helpful.
+   You can also use the [manual overrides](#overrides) feature to correctly classify them in your repository.
 1. If there are no reported issues of this misclassification, [open an issue][new-issue] and include a link to the repository or a sample of the code that is being misclassified.
 
-Keep in mind that the repository language stats are only [updated when you push changes](#how-linguist-works-on-githubcom), and the results are cached for the lifetime of your repository. If you have not made any changes to your repository in a while, you may find pushing another change will correct the stats.
+[search-limits]: https://help.github.com/articles/searching-code/#considerations-for-code-search
+
+Keep in mind that the repository language stats are only [updated when you push changes](#how-linguist-works-on-githubcom), and the results are cached for the lifetime of your repository.
+If you have not made any changes to your repository in a while, you may find pushing another change will correct the stats.
 
 ### My repository isn't showing my language
 
@@ -127,13 +151,15 @@ If the language statistics bar is not showing your language at all, it could be 
 1. The extension you have chosen is not associated with your language in [`languages.yml`](/lib/linguist/languages.yml).
 1. All the files in your repository fall into one of the categories listed above that Linguist excludes by default.
 
-If Linguist doesn't know about the language or the extension you're using, consider [contributing](CONTRIBUTING.md) to Linguist by opening a pull request to add support for your language or extension. For everything else, you can use the [manual overrides](#overrides) feature to tell Linguist to include your files in the language statistics.
+If Linguist doesn't know about the language or the extension you're using, consider [contributing](CONTRIBUTING.md) to Linguist by opening a pull request to add support for your language or extension.
+For everything else, you can use the [manual overrides](#overrides) feature to tell Linguist to include your files in the language statistics.
 
 ### There's a problem with the syntax highlighting of a file
 
 Linguist detects the language of a file but the actual syntax-highlighting is powered by a set of language grammars which are included in this project as a set of submodules [as listed here](/vendor/README.md).
 
-If you experience an issue with the syntax-highlighting on GitHub, **please report the issue to the upstream grammar repository, not here.** Grammars are updated every time we build the Linguist gem so upstream bug fixes are automatically incorporated as they are fixed.
+If you experience an issue with the syntax-highlighting on GitHub, **please report the issue to the upstream grammar repository, not here.**
+Grammars are updated every time we build the Linguist gem so upstream bug fixes are automatically incorporated as they are fixed.
 
 
 ## Overrides
@@ -142,7 +168,9 @@ Linguist supports a number of different custom override strategies for language 
 
 ### Using gitattributes
 
-Add a `.gitattributes` file to your project and use standard git-style path matchers for the files you want to override using the `linguist-documentation`, `linguist-language`, `linguist-vendored`, `linguist-generated`  and `linguist-detectable` attributes. `.gitattributes` will be used to determine language statistics and will be used to syntax highlight files. You can also manually set syntax highlighting using [Vim or Emacs modelines](#using-emacs-or-vim-modelines).
+Add a `.gitattributes` file to your project and use standard git-style path matchers for the files you want to override using the `linguist-documentation`, `linguist-language`, `linguist-vendored`, `linguist-generated`  and `linguist-detectable` attributes.
+`.gitattributes` will be used to determine language statistics and will be used to syntax highlight files.
+You can also manually set syntax highlighting using [Vim or Emacs modelines](#using-emacs-or-vim-modelines).
 
 When testing with a local installation of Linguist, take note that the added attributes will not take effect until the `.gitattributes` file is committed to your repository.
 
@@ -155,7 +183,8 @@ File and folder paths inside `.gitattributes` are calculated relative to the pos
 
 #### Vendored code
 
-Checking code you didn't write, such as JavaScript libraries, into your git repo is a common practice, but this often inflates your project's language stats and may even cause your project to be labeled as another language. By default, Linguist treats all of the paths defined in [`vendor.yml`](/lib/linguist/vendor.yml) as vendored and therefore doesn't include them in the language statistics for a repository.
+Checking code you didn't write, such as JavaScript libraries, into your git repo is a common practice, but this often inflates your project's language stats and may even cause your project to be labeled as another language.
+By default, Linguist treats all of the paths defined in [`vendor.yml`](/lib/linguist/vendor.yml) as vendored and therefore doesn't include them in the language statistics for a repository.
 
 Use the `linguist-vendored` attribute to vendor or un-vendor paths:
 
@@ -166,7 +195,8 @@ jquery.js linguist-vendored=false
 
 #### Documentation
 
-Just like vendored files, Linguist excludes documentation files from your project's language stats. [`documentation.yml`](/lib/linguist/documentation.yml) lists common documentation paths and excludes them from the language statistics for your repository.
+Just like vendored files, Linguist excludes documentation files from your project's language stats.
+[`documentation.yml`](/lib/linguist/documentation.yml) lists common documentation paths and excludes them from the language statistics for your repository.
 
 Use the `linguist-documentation` attribute to mark or unmark paths as documentation:
 
@@ -177,7 +207,10 @@ docs/formatter.rb linguist-documentation=false
 
 #### Generated code
 
-Not all plain text files are true source files. Generated files like minified JavaScript and compiled CoffeeScript can be detected and excluded from language stats. As an added bonus, unlike vendored and documentation files, these files are suppressed in diffs. [`generated.rb`](/lib/linguist/generated.rb) lists common generated paths and excludes them from the language statistics of your repository.
+Not all plain text files are true source files.
+Generated files like minified JavaScript and compiled CoffeeScript can be detected and excluded from language stats.
+As an added bonus, unlike vendored and documentation files, these files are suppressed in diffs.
+[`generated.rb`](/lib/linguist/generated.rb) lists common generated paths and excludes them from the language statistics of your repository.
 
 Use the `linguist-generated` attribute to mark or unmark paths as generated.
 
@@ -187,7 +220,8 @@ Api.elm linguist-generated=true
 
 #### Detectable
 
-Only programming languages are included in the language statistics. Languages of a different type (as defined in [`languages.yml`](/lib/linguist/languages.yml)) are not "detectable" causing them not to be included in the language statistics.
+Only programming languages are included in the language statistics.
+Languages of a different type (as defined in [`languages.yml`](/lib/linguist/languages.yml)) are not "detectable" causing them not to be included in the language statistics.
 
 Use the `linguist-detectable` attribute to mark or unmark paths as detectable:
 
@@ -199,7 +233,8 @@ tools/export_bom.py linguist-detectable=false
 
 ### Using Emacs or Vim modelines
 
-If you do not want to use `.gitattributes` to override the syntax highlighting used on GitHub.com, you can use Vim or Emacs style modelines to set the language for a single file. Modelines can be placed anywhere within a file and are respected when determining how to syntax-highlight a file on GitHub.com
+If you do not want to use `.gitattributes` to override the syntax highlighting used on GitHub.com, you can use Vim or Emacs style modelines to set the language for a single file.
+Modelines can be placed anywhere within a file and are respected when determining how to syntax-highlight a file on GitHub.com
 
 ##### Vim
 ```
@@ -224,7 +259,7 @@ Please check out our [contributing guidelines](CONTRIBUTING.md).
 
 ## License
 
-The language grammars included in this gem are covered by their repositories'
-respective licenses. [`vendor/README.md`](/vendor/README.md) lists the repository for each grammar.
+The language grammars included in this gem are covered by their repositories' respective licenses.
+[`vendor/README.md`](/vendor/README.md) lists the repository for each grammar.
 
-All other files are covered by the MIT license, see `LICENSE`.
+All other files are covered by the MIT license, see [`LICENSE`][/LICENSE].

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ As this analysis is performed by a low priority background job, it can take a wh
 
 Install the gem:
 
-```console
-$ gem install github-linguist
+```bash
+gem install github-linguist
 ```
 
 #### Dependencies
@@ -64,14 +64,14 @@ These components have their own dependencies.
 You may need to install missing dependencies before you can install Linguist.
 For example, on macOS with [Homebrew](http://brew.sh/):
 
-```console
-$ brew install cmake pkg-config icu4c
+```bash
+brew install cmake pkg-config icu4c
 ```
 
 On Ubuntu:
 
-```console
-$ sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev
+```bash
+sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev
 ```
 
 ### Application usage
@@ -94,9 +94,9 @@ A repository's languages stats can also be assessed from the command line using 
 Without any options, `linguist` will output the breakdown that correlates to what is shown in the language stats bar.
 The `--breakdown` flag will additionally show the breakdown of files by language.
 
-```console
-$ cd /path-to-repository/
-$ github-linguist
+```bash
+cd /path-to-repository/
+github-linguist
 ```
 
 You can try running `linguist` on the root directory in this repository itself:


### PR DESCRIPTION
To make diffs easier to review, I've refactored `README.md` and `CONTRIBUTING.md` to limit lines to no more than one sentence.

In addition, I fixed a few typos, made more optimal use of reference links, and made shell-commands tagged code-blocks to enable highlighting.

**Refs:** https://github.com/github/linguist/pull/4271#issuecomment-435312347

/cc @pchaigno because this will probably break his pull-request