### PR TITLE
Heuristic to disambiguate GAP and GDScript

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -137,6 +137,7 @@ disambiguations:
   - language: GAP
     pattern: '\s*Declare'
   - language: GDScript
+    pattern: '\s*(extends|var|const|enum|func|class|signal|tool|yield|assert|onready)'
 - extensions: ['.gml']
   rules:
   - language: XML

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -132,6 +132,11 @@ disambiguations:
     pattern: '^\s*(#version|precision|uniform|varying|vec[234])'
   - language: Filterscript
     pattern: '#include|#pragma\s+(rs|version)|__attribute__'
+- extensions: ['.gd']
+  rules:
+  - language: GAP
+    pattern: 'gap> '
+  - language: GDScript
 - extensions: ['.gml']
   rules:
   - language: XML

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -135,7 +135,7 @@ disambiguations:
 - extensions: ['.gd']
   rules:
   - language: GAP
-    pattern: 'gap> '
+    pattern: '\s*Declare'
   - language: GDScript
 - extensions: ['.gml']
   rules:

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -135,7 +135,7 @@ disambiguations:
 - extensions: ['.gd']
   rules:
   - language: GAP
-    pattern: '\s*Declare'
+    pattern: '\s*(Declare|BindGlobal|KeyDependentOperation)'
   - language: GDScript
     pattern: '\s*(extends|var|const|enum|func|class|signal|tool|yield|assert|onready)'
 - extensions: ['.gml']

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -157,6 +157,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_gd_by_heuristics
+    assert_heuristics({
+      "GAP" => all_fixtures("GAP", "*.gd"),
+      "GDScript" => all_fixtures("GDScript", "*.gd")
+    })
+  end
+
   def test_gml_by_heuristics
       assert_heuristics({
         "Game Maker Language" => all_fixtures("Game Maker Language", "*.gml"),


### PR DESCRIPTION
GDScript files (.gd) are often misclassified as GAP code on Github.

## Description
This rule updates classification of .gd files as either GAP or GDScript. Currently, several GDScript files are misclassified as GAP on Github (example search: https://github.com/search?q=language%3AGAP+game&type=Repositories)

## Checklist:
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.