### PR TITLE
Add .bash_aliases to shell language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4579,6 +4579,7 @@ Shell:
   - ".zshrc"
   - 9fs
   - PKGBUILD
+  - bash_aliases
   - bash_logout
   - bash_profile
   - bashrc

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4564,6 +4564,7 @@ Shell:
   - ".tool"
   - ".zsh"
   filenames:
+  - ".bash_aliases"
   - ".bash_history"
   - ".bash_logout"
   - ".bash_profile"

--- a/samples/Shell/filenames/.bash_aliases
+++ b/samples/Shell/filenames/.bash_aliases
@@ -1,0 +1,15 @@
+# Read shared alias
+test -f $HOME/.common-alias && source $HOME/.common-alias
+test -f $HOME/.custom-alias && source $HOME/.custom-alias
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    alias dir='dir --color=auto'
+    alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi

--- a/samples/Shell/filenames/bash_aliases
+++ b/samples/Shell/filenames/bash_aliases
@@ -1,0 +1,15 @@
+# Read shared alias
+test -f $HOME/.common-alias && source $HOME/.common-alias
+test -f $HOME/.custom-alias && source $HOME/.custom-alias
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    alias dir='dir --color=auto'
+    alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Add `bash_aliases` to Shell highlighted filenames

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file filename.**
  - [x] The new filename is used in hundreds of repositories on GitHub.com
      - [~16,198 code results](https://github.com/search?q=filename%3Abash_aliases+-language%3Ashell+NOT+nothack&type=Code)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/hivetech/dna/blob/50ad00031be29765b2576fa407d35a36e0608de9/shell/bash/bash_aliases
    - Sample license(s): [Apache](https://github.com/hivetech/dna/blob/develop/LICENSE)
