### PR TITLE
Lock Linguist to Bundler 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - libicu52
 
 before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem uninstall -v '>= 2' -ax bundler || true
   - gem install bundler -v '< 2'
   - script/travis/before_install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ addons:
     - libicu-dev
     - libicu52
 
-before_install: script/travis/before_install
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+  - script/travis/before_install
 
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ addons:
     - libicu-dev
     - libicu52
 
-before_install:
-  - gem uninstall -v '>= 2' -ax bundler || true
-  - gem install bundler -v '< 2'
-  - script/travis/before_install
+before_install: script/travis/before_install
 
 script:
   - bundle exec rake

--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'escape_utils',    '~> 1.2.0'
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '>= 0.25.1'
-  s.add_dependency 'bundler',         '~> 1.10'
 
   s.add_development_dependency 'minitest', '>= 5.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
@@ -30,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'color-proximity', '~> 0.2.1'
   s.add_development_dependency 'licensed', '~> 1.3.0'
   s.add_development_dependency 'licensee'
+  s.add_development_dependency 'bundler', '~> 1.10'
 end

--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'escape_utils',    '~> 1.2.0'
   s.add_dependency 'mime-types',      '>= 1.19'
   s.add_dependency 'rugged',          '>= 0.25.1'
+  s.add_dependency 'bundler',         '~> 1.10'
 
   s.add_development_dependency 'minitest', '>= 5.0'
   s.add_development_dependency 'rake-compiler', '~> 0.9'

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -2,6 +2,11 @@
 
 set -ex
 
+# As of 3 Jan 2019, Travis defaults to bundler 2.0 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+# Linguist still requires Bundler 1.x due to Licensed.
+gem uninstall -v '>= 2' -ax bundler || true
+gem install bundler -v '< 2'
+
 # Fetch all commits/refs needed to run our tests.
 git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
 

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -4,8 +4,8 @@ set -ex
 
 # As of 3 Jan 2019, Travis defaults to bundler 2.0 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
 # Linguist still requires Bundler 1.x due to Licensed.
-gem uninstall -v '>= 2' -i @global -ax bundler || true
-gem install bundler -v '< 2'
+rvm @global gem uninstall -v '>= 2' -ax bundler || true
+rvm @global gem install bundler -v '< 2'
 
 # Fetch all commits/refs needed to run our tests.
 git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -2,11 +2,6 @@
 
 set -ex
 
-# As of 3 Jan 2019, Travis defaults to bundler 2.0 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
-# Linguist still requires Bundler 1.x due to Licensed.
-rvm @global do gem uninstall -v '>= 2' -ax bundler || true
-rvm @global do gem install bundler -v '< 2'
-
 # Fetch all commits/refs needed to run our tests.
 git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
 

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -4,8 +4,8 @@ set -ex
 
 # As of 3 Jan 2019, Travis defaults to bundler 2.0 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
 # Linguist still requires Bundler 1.x due to Licensed.
-rvm @global gem uninstall -v '>= 2' -ax bundler || true
-rvm @global gem install bundler -v '< 2'
+rvm @global do gem uninstall -v '>= 2' -ax bundler || true
+rvm @global do gem install bundler -v '< 2'
 
 # Fetch all commits/refs needed to run our tests.
 git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -2,6 +2,11 @@
 
 set -ex
 
+# As of 3 Jan 2019, Travis defaults to bundler 2.0 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
+# Linguist still requires Bundler 1.x due to Licensed.
+gem uninstall -v '>= 2' -i "$(rvm gemdir)@global" -ax bundler || true
+gem install bundler -v '< 2'
+
 # Fetch all commits/refs needed to run our tests.
 git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
 

--- a/script/travis/before_install
+++ b/script/travis/before_install
@@ -4,7 +4,7 @@ set -ex
 
 # As of 3 Jan 2019, Travis defaults to bundler 2.0 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20
 # Linguist still requires Bundler 1.x due to Licensed.
-gem uninstall -v '>= 2' -i "$(rvm gemdir)@global" -ax bundler || true
+gem uninstall -v '>= 2' -i @global -ax bundler || true
 gem install bundler -v '< 2'
 
 # Fetch all commits/refs needed to run our tests.


### PR DESCRIPTION
As seen in https://github.com/github/linguist/pull/4340, tests are starting to fail because Travis has decided to switch to Bundler 2.x by default as of 3 Jan 2019 - https://docs.travis-ci.com/user/languages/ruby/#bundler-20 - and this is clashing with Licensed which expressly requires `~>1.10` due to it using some internal bundler functionality. 

This PR locks us to bundler `~>1.10` too.

It took a few attempts for me to get Travis to actually do what I want it to do as the documented method wasn't working 😞 but I got there in the end.

_Template removed as it's not relevant_