### PR TITLE
Removed 'TRANSACTION' from the PLpgSQL heuristics regex to prevent misidentification

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -359,7 +359,7 @@ disambiguations:
   rules:
    # Postgres
   - language: PLpgSQL
-    pattern: '(?i:^\\i\b|AS \$\$|LANGUAGE ''?plpgsql''?|SECURITY (DEFINER|INVOKER)|BEGIN( WORK| TRANSACTION)?;)'
+    pattern: '(?i:^\\i\b|AS \$\$|LANGUAGE ''?plpgsql''?|SECURITY (DEFINER|INVOKER)|BEGIN WORK;)'
   # IBM db2
   - language: SQLPL
     pattern: "(?i:(alter module)|(language sql)|(begin( NOT)+ atomic)|signal SQLSTATE '[0-9]+')"


### PR DESCRIPTION
## Description
It simply removes "TRANSACTION" from the regex for PLpgSQL since it's not unique to PostgreSQL. This fixes issue #4386.

## Checklist:
- [ X] **I am fixing a misclassified language**
  - [ X] I have included a new sample for the misclassified language:
    - Sample source(s):
      - https://github.com/github/linguist/issues/4386 bug reported
      - https://gist.github.com/mooseous/f03de680679031640b6e3e88da865ab0 sample content
    - Sample license(s): MIT License