### PR TITLE
Language recognition with file path pattern (regex)

### DIFF
--- a/lib/linguist.rb
+++ b/lib/linguist.rb
@@ -61,6 +61,7 @@ class << Linguist
   STRATEGIES = [
     Linguist::Strategy::Modeline,
     Linguist::Strategy::Filename,
+    Linguist::Strategy::FilePathPattern,
     Linguist::Shebang,
     Linguist::Strategy::Extension,
     Linguist::Strategy::XML,

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2254,6 +2254,8 @@ JSON with Comments:
   - ".jshintrc"
   - ".jslintrc"
   - tsconfig.json
+  filepath_patterns:
+  - '\.vscode\/.*\.json$'
   language_id: 423
 JSON5:
   type: data

--- a/lib/linguist/samples.rb
+++ b/lib/linguist/samples.rb
@@ -38,7 +38,7 @@ module Linguist
         Dir.entries(dirname).each do |filename|
           next if filename == '.' || filename == '..'
 
-          if filename == 'filenames'
+          if filename == 'filenames' || filename == '.vscode'
             Dir.entries(File.join(dirname, filename)).each do |subfilename|
               next if subfilename == '.' || subfilename == '..'
 

--- a/lib/linguist/strategy/file_path_pattern.rb
+++ b/lib/linguist/strategy/file_path_pattern.rb
@@ -1,0 +1,24 @@
+module Linguist
+  module Strategy
+    # Detects language based on File Path Pattern
+    class FilePathPattern
+      # Public: Use the filename to detect the blob's language.
+      #
+      # blob               - An object that quacks like a blob.
+      # candidates         - A list of candidate languages.
+      #
+      # Examples
+      #
+      #   FilePathPattern.call(FileBlob.new("path/to/file"))
+      #
+      # Returns an array of languages with a associated blob's file Path pattern.
+      # Selected languages must be in the candidate list, except if it's empty,
+      # in which case any language is a valid candidate.
+      def self.call(blob, candidates)
+        path = blob.path.to_s
+        languages = Language.find_by_filepath_pattern(path)
+        candidates.any? ? candidates & languages : languages
+      end
+    end
+  end
+end

--- a/samples/JSON with Comments/.vscode/launch.json
+++ b/samples/JSON with Comments/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "program1",
+      "program": "${workspaceFolder}/program1.js"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "program2",
+      "program": "${workspaceFolder}/program2.js"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "program3",
+      "program": "${workspaceFolder}/program3.js"
+    }
+  ],
+  "compounds": [
+      {
+          "name": "Programs 1, 2 and 3", // launch/debug all - FTW!
+          "configurations": ["program1", "program2", "program3"]
+      }
+  ]
+}

--- a/samples/JSON with Comments/.vscode/settings.json
+++ b/samples/JSON with Comments/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "debug.node.autoAttach": "on"
+}

--- a/test/test_samples.rb
+++ b/test/test_samples.rb
@@ -42,11 +42,21 @@ class TestSamples < Minitest::Test
     end
   end
 
-  def test_filename_listed
+  def test_filename_or_regexpath_listed
     Samples.each do |sample|
       if sample[:filename]
         listed_filenames = Language[sample[:language]].filenames
-        assert_includes listed_filenames, sample[:filename], "#{sample[:path]} isn't listed as a filename for #{sample[:language]} in languages.yml"
+        listed_filepath_patterns = Language[sample[:language]].filepath_patterns
+        skip_loop = false
+        listed_filepath_patterns.each do |pattern|
+          if sample[:path] =~ Regexp.new(pattern)
+            skip_loop = true
+            break
+          end
+        end
+        next if skip_loop
+
+        assert_includes(listed_filenames, sample[:filename], "#{sample[:path]} isn't listed as a filename for #{sample[:language]} in languages.yml")
       end
     end
   end


### PR DESCRIPTION
Fixes vscode config json files on github. Github shows errors for comments in vscode files. This can be fixed by classifying them as jsonc. broken vscode config files are included.

## Description
Added a feature for language recognition with file path pattern (regex). example pattern: `'\.vscode\/.*\.json$'`

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.