### PR TITLE
improve GLSL classification

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -169,6 +169,8 @@ disambiguations:
   - language: Game Maker Language
 - extensions: ['.gs']
   rules:
+  - language: GLSL
+    pattern: '^#version\s+[0-9]+\b'
   - language: Gosu
     pattern: '^uses java\.'
 - extensions: ['.h']

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1500,6 +1500,9 @@ GLSL:
   type: programming
   extensions:
   - ".glsl"
+  # .comp disabled because of too many conflicts that we are not
+  # able to disambiguate yet.
+  # - ".comp"
   - ".fp"
   - ".frag"
   - ".frg"
@@ -1508,7 +1511,9 @@ GLSL:
   - ".fshader"
   - ".geo"
   - ".geom"
+  - ".glslf"
   - ".glslv"
+  - ".gs"
   - ".gshader"
   - ".shader"
   - ".tesc"

--- a/samples/GLSL/blend_120.glslf
+++ b/samples/GLSL/blend_120.glslf
@@ -1,0 +1,53 @@
+#version 120
+
+#define SCREEN 0
+#define DODGE 1
+#define BURN 2
+#define OVERLAY 3
+#define MULTIPLY 4
+#define ADD 5
+#define DIVIDE 6
+#define GRAIN_EXTRACT 7
+#define GRAIN_MERGE 8
+
+// grayscale
+uniform sampler2D t_Lena;
+// rgba
+uniform sampler2D t_Tint;
+
+uniform int i_Blend;
+
+varying vec2 v_Uv;
+
+void main() {
+    // we sample from both textures using the same uv coordinates. since our
+    // lena image is grayscale, we only get the first component.
+    vec3 lena = vec3(texture2D(t_Lena, v_Uv).r);
+    vec3 tint = texture2D(t_Tint, v_Uv).rgb;
+   
+    vec3 result = vec3(0.0);
+
+    // normally you'd have a shader program per technique, but for the sake of
+    // simplicity we'll just branch on it here.
+    if (i_Blend == SCREEN) {
+        result = vec3(1.0) - ((vec3(1.0) - lena) * (vec3(1.0) - tint));
+    } else if (i_Blend == DODGE) {
+        result = lena / (vec3(1.0) - tint);
+    } else if (i_Blend == BURN) {
+        result = vec3(1.0) - ((vec3(1.0) - lena) / lena);
+    } else if (i_Blend == OVERLAY) {
+        result = lena * (lena + (tint * 2) * (vec3(1.0) - lena));
+    } else if (i_Blend == MULTIPLY) {
+        result = lena * tint;
+    } else if (i_Blend == ADD) {
+        result = lena + tint;
+    } else if (i_Blend == DIVIDE) {
+        result = lena / tint;
+    } else if (i_Blend == GRAIN_EXTRACT) {
+        result = lena - tint + 0.5;
+    } else if (i_Blend == GRAIN_MERGE) {
+        result = lena + tint - 0.5;
+    }
+
+    gl_FragColor = vec4(result, 1.0);
+}

--- a/samples/GLSL/extrude_normals.gs
+++ b/samples/GLSL/extrude_normals.gs
@@ -1,0 +1,27 @@
+#version 330 core
+layout(triangles) in;
+layout (line_strip, max_vertices = 6) out;
+
+in VS_OUT
+{
+   vec3 normal;
+}gs_in[];
+
+const float MAGNITUDE = 0.025f;
+
+void GenerateLine(int index)
+{
+    gl_Position = gl_in[index].gl_Position;
+    EmitVertex();
+    gl_Position = gl_in[index].gl_Position + vec4(gs_in[index].normal, 0.0f) * MAGNITUDE;
+    EmitVertex();
+    EndPrimitive();
+}
+
+void main()
+{
+   GenerateLine(0);
+   GenerateLine(1);
+   GenerateLine(2);
+}
+

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -7,9 +7,13 @@ class TestHeuristics < Minitest::Test
     File.read(File.join(samples_path, name))
   end
 
-  def file_blob(name)
+  def file_blob(name, alt_name=nil)
     path = File.exist?(name) ? name : File.join(samples_path, name)
-    FileBlob.new(path)
+    blob = FileBlob.new(path)
+    if !alt_name.nil?
+      blob.instance_variable_set("@path", alt_name)
+    end
+    blob
   end
 
   def all_fixtures(language_name, file="*")
@@ -28,12 +32,12 @@ class TestHeuristics < Minitest::Test
     assert_equal [], Heuristics.call(file_blob("Markdown/symlink.md"), [Language["Markdown"]])
   end
 
-  def assert_heuristics(hash)
+  def assert_heuristics(hash, alt_name=nil)
     candidates = hash.keys.map { |l| Language[l] }
 
     hash.each do |language, blobs|
       Array(blobs).each do |blob|
-        result = Heuristics.call(file_blob(blob), candidates)
+        result = Heuristics.call(file_blob(blob, alt_name), candidates)
         if language.nil?
           expected = []
         elsif language.is_a?(Array)
@@ -179,10 +183,15 @@ class TestHeuristics < Minitest::Test
       })
   end
 
+  # Candidate languages = ["Genie", "GLSL", "Gosu", "JavaScript"]
   def test_gs_by_heuristics
     assert_heuristics({
-      "Gosu" => all_fixtures("Gosu", "*.gs")
+      "GLSL" => all_fixtures("GLSL", "*.gs"),
+      "Gosu" => all_fixtures("Gosu", "*.gs"),
     })
+    assert_heuristics({
+      nil => all_fixtures("Genie", "*.gs") + all_fixtures("JavaScript")
+    }, alt_name="test.gs")
   end
 
   # Candidate languages = ["C++", "Objective-C"]


### PR DESCRIPTION
improve GLSL classification

## Description
* added extensions .gs, .comp and .glslf.
  See: https://stackoverflow.com/q/6432838

* add disambiguation rule for .gs files:
  if it starts with `#version <number>`, it's GLSL.
  This seems to work for most GLSL files with few exceptions
  that are catched by the classifier.

* added sample extrude_normal.gs from kyle-piddington/ShaderTool
  (licensed under MIT):
  https://github.com/kyle-piddington/ShaderTool/blob/c753a53bde6eab942da617adab9483c945f27f51/assets/shaders/extrude_normals.gs

* added sample blend_120.glslf from gfx-rs/gfx (licensed under
  Apache 2.0):
  https://github.com/gfx-rs/gfx/blob/7b084cfbb95e3e4d1ea51e91746fc75b2efb3be3/examples/blend/shader/blend_120.glslf

* test_heuristics.rb now supports alt_name to ake a different file name
for a fixture.

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?l=JavaScript&q=extension%3Ags+version+void+layout&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/kyle-piddington/ShaderTool/blob/c753a53bde6eab942da617adab9483c945f27f51/assets/shaders/extrude_normals.gs
      - https://github.com/gfx-rs/gfx/blob/7b084cfbb95e3e4d1ea51e91746fc75b2efb3be3/examples/blend/shader/blend_120.glslf
    - Sample license(s): MIT, Apache 2.0
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
