### PR TITLE
add .p extension to Gnuplot

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -284,6 +284,7 @@ disambiguations:
     - '^s?plot\b'
     - '^set\s+(term|terminal|out|output|[xy]tics|[xy]label|[xy]range|style)\b'
   - language: OpenEdge ABL
+    pattern: '^\s*(?i:(DEFINE|FOR|PROCEDURE|MESSAGE|RUN|ASSIGN|REPEAT|CLASS|METHOD|&SCOPED-DEFINE|&MESSAGE|&GLOBAL-DEFINE))'
 - extensions: ['.php']
   rules:
   - language: Hack

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -277,6 +277,13 @@ disambiguations:
   - language: NL
     pattern: '^(b|g)[0-9]+ '
   - language: NewLisp
+- extensions: ['.p']
+  rules:
+  - language: Gnuplot
+    pattern:
+    - '^s?plot\b'
+    - '^set\s+(term|terminal|out|output|[xy]tics|[xy]label|[xy]range|style)\b'
+  - language: OpenEdge ABL
 - extensions: ['.php']
   rules:
   - language: Hack

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1679,6 +1679,7 @@ Gnuplot:
   - ".gp"
   - ".gnu"
   - ".gnuplot"
+  - ".p"
   - ".plot"
   - ".plt"
   interpreters:


### PR DESCRIPTION
add .p extension to Gnuplot

Fixes https://github.com/github/linguist/issues/4388

## Description
- add .p extension to Gnuplot
- add disambiguation rule for Gnuplot and OpenEdge ABL


## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?p=90&q=extension%3Ap+plot+set+output&type=Code
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - No. Simulated with fake extension.
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
