### PR TITLE
Add alias for HTML+Razor

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1918,6 +1918,8 @@ HTML+Razor:
   type: markup
   tm_scope: text.html.cshtml
   group: HTML
+  aliases:
+  - razor
   extensions:
   - ".cshtml"
   ace_mode: razor


### PR DESCRIPTION
I expect many people to refer to the [ASP.NET Razor](https://en.wikipedia.org/wiki/ASP.NET_Razor) ([here](https://github.com/github/linguist/tree/master/vendor) called as "HTML+Razor") simply as "Razor"

_Template removed as it doesn't apply._

