### PR TITLE
ensure 1+ sample for each heuristics test

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -110,7 +110,7 @@ disambiguations:
     # target : \
     #  : dependency
     # path/file.ext1 : some/path/../file.ext2
-    pattern: '([\/\\].*:\s+.*\s\\$|: \\$|^ : |^[\w\s\/\\.]+\w+\.\w+\s*:\s+[\w\s\/\\.]+\w+\.\w+)'
+    pattern: '([\/\\].*:\s+.*\s\\$|: \\$|^[ %]:|^[\w\s\/\\.]+\w+\.\w+\s*:\s+[\w\s\/\\.]+\w+\.\w+)'
 - extensions: ['.ecl']
   rules:
   - language: ECLiPSe
@@ -297,7 +297,7 @@ disambiguations:
     named_pattern: perl5
   - language: Perl 6
     named_pattern: perl6
-  - language: XPM
+  - language: X PixMap
     pattern: '^\s*\/\* XPM \*\/'
 - extensions: ['.pod']
   rules:
@@ -339,7 +339,7 @@ disambiguations:
 - extensions: ['.props']
   rules:
   - language: XML
-    pattern: '^(\s*)(?i:<Project|<Import|<Property|<?xml|xmlns)'
+    pattern: '^(\s*)(?i:<Project|<Import|<Property|<\?xml|xmlns)'
   - language: INI
     pattern: '(?i:\w+\s*=\s*)'
 - extensions: ['.q']
@@ -438,7 +438,7 @@ disambiguations:
     pattern: '\b(program|version)\s+\w+\s*{|\bunion\s+\w+\s+switch\s*\('
   - language: Logos
     pattern: '^%(end|ctor|hook|group)\b'
-  - language: Linked Script
+  - language: Linker Script
     pattern: 'OUTPUT_ARCH\(|OUTPUT_FORMAT\(|SECTIONS'
 - extensions: ['.yy']
   rules:

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -7,15 +7,21 @@ class TestHeuristics < Minitest::Test
     File.read(File.join(samples_path, name))
   end
 
-  def file_blob(name)
+  def file_blob(name, alt_name=nil)
     path = File.exist?(name) ? name : File.join(samples_path, name)
-    FileBlob.new(path)
+    blob = FileBlob.new(path)
+    if !alt_name.nil?
+      blob.instance_variable_set("@path", alt_name)
+    end
+    blob
   end
 
   def all_fixtures(language_name, file="*")
     fixs = Dir.glob("#{samples_path}/#{language_name}/#{file}") -
              ["#{samples_path}/#{language_name}/filenames"]
-    fixs.reject { |f| File.symlink?(f) }
+    fixs = fixs.reject { |f| File.symlink?(f) }
+    assert !fixs.empty?, "no fixtures for #{language_name} #{file}"
+    fixs
   end
 
   def test_no_match
@@ -28,12 +34,15 @@ class TestHeuristics < Minitest::Test
     assert_equal [], Heuristics.call(file_blob("Markdown/symlink.md"), [Language["Markdown"]])
   end
 
-  def assert_heuristics(hash)
+  # alt_name is a file name that will be used instead of the file name of the
+  # original sample. This is used to force a sample to go through a specific
+  # heuristic even if it's extension doesn't match.
+  def assert_heuristics(hash, alt_name=nil)
     candidates = hash.keys.map { |l| Language[l] }
 
     hash.each do |language, blobs|
       Array(blobs).each do |blob|
-        result = Heuristics.call(file_blob(blob), candidates)
+        result = Heuristics.call(file_blob(blob, alt_name), candidates)
         if language.nil?
           expected = []
         elsif language.is_a?(Array)
@@ -59,13 +68,12 @@ class TestHeuristics < Minitest::Test
     })
   end
 
-  # Candidate languages = ["AGS Script", "AsciiDoc", "Public Key"]
   def test_asc_by_heuristics
     assert_heuristics({
-      "AsciiDoc" => all_fixtures("AsciiDoc", "*.asc"),
-      "AGS Script" => all_fixtures("AGS Script", "*.asc"),
-      "Public Key" => all_fixtures("Public Key", "*.asc")
-    })
+      "AsciiDoc" => all_fixtures("AsciiDoc"),
+      "AGS Script" => all_fixtures("AGS Script"),
+      "Public Key" => all_fixtures("Public Key")
+    }, alt_name="test.asc")
   end
 
   def test_asy_by_heuristics
@@ -84,14 +92,16 @@ class TestHeuristics < Minitest::Test
 
   def test_builds_by_heuristics
     assert_heuristics({
-      "Text" => all_fixtures("Text", "*.builds"),
+      "Text" => all_fixtures("Text"),
       "XML" => all_fixtures("XML", "*.builds")
-    })
+    }, alt_name="test.builds")
   end
 
   def test_ch_by_heuristics
     assert_heuristics({
-      "xBase" => all_fixtures("xBase", ".ch")
+      "xBase" => all_fixtures("xBase", "*.ch"),
+      # Missing heuristic for Charity
+      nil => all_fixtures("Charity", "*.ch")
     })
   end
 
@@ -105,9 +115,8 @@ class TestHeuristics < Minitest::Test
   def test_cls_by_heuristics
     assert_heuristics({
       "TeX" => all_fixtures("TeX", "*.cls"),
-      nil => all_fixtures("Apex", "*.cls"),
-      nil => all_fixtures("OpenEdge ABL", "*.cls"),
-      nil => all_fixtures("Visual Basic", "*.cls"),
+      # Missing heuristics
+      nil => all_fixtures("Apex", "*.cls") + all_fixtures("OpenEdge ABL", "*.cls") + all_fixtures("Visual Basic", "*.cls"),
     })
   end
 
@@ -120,13 +129,12 @@ class TestHeuristics < Minitest::Test
 
   def test_d_by_heuristics
     assert_heuristics({
-      "D" => all_fixtures("D", "*.d"),
-      "DTrace" => all_fixtures("DTrace", "*.d"),
-      "Makefile" => all_fixtures("Makefile", "*.d"),
-    })
+      "D" => all_fixtures("D"),
+      "DTrace" => all_fixtures("DTrace"),
+      "Makefile" => all_fixtures("Makefile"),
+    }, alt_name="test.d")
   end
 
-  # Candidate languages = ["ECL", "ECLiPSe"]
   def test_ecl_by_heuristics
     assert_heuristics({
       "ECL" => all_fixtures("ECL", "*.ecl"),
@@ -242,15 +250,16 @@ class TestHeuristics < Minitest::Test
   end
 
   def test_m_by_heuristics
+    ambiguous = all_fixtures("Objective-C", "cocoa_monitor.m")
     assert_heuristics({
-      "Objective-C" => all_fixtures("Objective-C", "*.m") - all_fixtures("Objective-C", "cocoa_monitor.m"),
+      "Objective-C" => all_fixtures("Objective-C", "*.m") - ambiguous,
       "Mercury" => all_fixtures("Mercury", "*.m"),
       "MUF" => all_fixtures("MUF", "*.m"),
       "M" => all_fixtures("M", "MDB.m"),
       "Mathematica" => all_fixtures("Mathematica", "*.m") - all_fixtures("Mathematica", "Problem12.m"),
       "MATLAB" => all_fixtures("MATLAB", "create_ieee_paper_plots.m"),
       "Limbo" => all_fixtures("Limbo", "*.m"),
-      nil => ["Objective-C/cocoa_monitor.m"]
+      nil => ambiguous
     })
   end
 
@@ -266,12 +275,13 @@ class TestHeuristics < Minitest::Test
       "#{samples_path}/OCaml/date.ml",
       "#{samples_path}/OCaml/common.ml",
       "#{samples_path}/OCaml/sigset.ml",
+      "#{samples_path}/Standard ML/Foo.sig",
     ]
     assert_heuristics({
-      "OCaml" => all_fixtures("OCaml", "*.ml") - ambiguous,
-      "Standard ML" => all_fixtures("Standard ML", "*.ml") - ambiguous,
+      "OCaml" => all_fixtures("OCaml") - ambiguous,
+      "Standard ML" => all_fixtures("Standard ML") - ambiguous,
       nil => ambiguous
-    })
+    }, alt_name="test.ml")
   end
 
   def test_mod_by_heuristics
@@ -303,10 +313,10 @@ class TestHeuristics < Minitest::Test
       "#{samples_path}/Text/LIDARLite.ncl"
     ]
     assert_heuristics({
-      "NCL" => all_fixtures("Roff", "*.ncl"),
-      "XML" => all_fixtures("XML", "*.ncl"),
+      "XML" => all_fixtures("XML", "*.ncl") - ambiguous,
       "Text" => all_fixtures("Text", "*.ncl") - ambiguous,
-      nil => ambiguous
+      # Missing heuristic for NCL
+      nil => all_fixtures("NCL", "*.ncl") + ambiguous
     })
   end
 
@@ -339,8 +349,8 @@ class TestHeuristics < Minitest::Test
     assert_heuristics({
       "Perl" => all_fixtures("Perl", "*.pm"),
       "Perl 6" => all_fixtures("Perl 6", "*.pm"),
-      "XPM" => all_fixtures("XPM", "*.pm")
-    })
+      "X PixMap" => all_fixtures("X PixMap")
+    }, alt_name="test.pm")
   end
 
   # Candidate languages = ["Pascal", "Puppet"]
@@ -371,9 +381,9 @@ class TestHeuristics < Minitest::Test
 
   def test_props_by_heuristics
     assert_heuristics({
-      "INI" => all_fixtures("INI", "*.props"),
+      "INI" => all_fixtures("INI"),
       "XML" => all_fixtures("XML", "*.props")
-    })
+    }, alt_name="test.props")
   end
 
   def test_q_by_heuristics
@@ -485,7 +495,7 @@ class TestHeuristics < Minitest::Test
   def test_x_by_heuristics
     # Logos not fully covered
     assert_heuristics({
-      "Linked Script" => all_fixtures("Linked Script", "*.x"),
+      "Linker Script" => all_fixtures("Linker Script", "*.x"),
       "RPC" => all_fixtures("RPC", "*.x")
     })
   end


### PR DESCRIPTION
Fixes #4391

## Description

- ensure 1+ sample for each heuristics test, now assert_heuristics fails
if there is no matching sample

-  add alt_name to test_heuristics to fake sample file name

- Added alt_name argument to helper functions in test_heuristics to fake
sample file name when there is no sample with the given the tested
extension but other samples are valid.

- Fix XPM disambiguation (wrong language name).

- Fixed XML rule for .props disambiguation (missing escape for ? in
regex)

- Fixed Linker Script disambiguation (typo in language name)

- Fixed Makefile disambiguation for .d extension

- Fixed test for xBase disambiguation for .ch extension

## Checklist:
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/
  
- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [x] **I am adding new or changing current functionality**
  - [x] I have added or updated the tests for the new or changed functionality.
