### PR TITLE
add disambiguation for .v (Coq, Verilog)

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -426,6 +426,19 @@ disambiguations:
     pattern: '^\s*(import.+(from\s+|require\()[''"]react|\/\/\/\s*<reference\s)'
   - language: XML
     pattern: '(?i:^\s*<\?xml\s+version)'
+- extensions: ['.v']
+  rules:
+  - language: Coq
+    pattern:
+    - '^(Proof\.|Qed\.$|Theorem\s+[\w'']+:|Inductive\s+\w+)'
+    - '^Require\s+(Import|Export)(\s+("\w+"|\w+))+\.'
+    - '(?m:^Module\s+\w+\..*?End\s+\w+\.)'
+  - language: Verilog
+    pattern:
+    - '^\s*module\s+\w+(\(|;$)'
+    - '^\s*endmodule\s*(//.*)?$'
+    - '^\s*endfunction\s*(//.*)?$'
+    - '^`define\s+\w+\s+[\w'']+\s*$'
 - extensions: ['.w']
   rules:
   - language: OpenEdge ABL

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -475,6 +475,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_v_by_heuristics
+    assert_heuristics({
+      "Coq" => all_fixtures("Coq", "*.v"),
+      "Verilog" => all_fixtures("Verilog", "*.v")
+    })
+  end
+
   def test_w_by_heuristics
     assert_heuristics({
       "CWeb" => all_fixtures("CWeb", "*.w"),


### PR DESCRIPTION
## Description
add disambiguation for .v (Coq, Verilog), which are often misclassified.

- https://github.com/search?q=language%3ACoq+endmodule&type=Code
- https://github.com/search?q=language%3AVerilog+proof+qed&type=Code

## Checklist:
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/
  
- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
