### PR TITLE
detect Vimball (.vba, .vmb) files as Vim script

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -426,6 +426,11 @@ disambiguations:
     pattern: '^\s*(import.+(from\s+|require\()[''"]react|\/\/\/\s*<reference\s)'
   - language: XML
     pattern: '(?i:^\s*<\?xml\s+version)'
+- extensions: ['.vba']
+  rules:
+  - language: Vim script
+    pattern: '^UseVimball'
+  - language: Visual Basic
 - extensions: ['.w']
   rules:
   - language: OpenEdge ABL

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5170,6 +5170,8 @@ Vim script:
   - nvim
   extensions:
   - ".vim"
+  - ".vba"
+  - ".vmb"
   filenames:
   - ".gvimrc"
   - ".nvimrc"

--- a/samples/Vim script/textobj-rubyblock.vba
+++ b/samples/Vim script/textobj-rubyblock.vba
@@ -1,0 +1,216 @@
+" Vimball Archiver by Charles E. Campbell, Jr., Ph.D.
+UseVimball
+finish
+plugin/textobj/rubyblock.vim	[[[1
+58
+if exists('g:loaded_textobj_rubyblock')  "{{{1
+  finish
+endif
+
+" Interface  "{{{1
+call textobj#user#plugin('rubyblock', {
+\      '-': {
+\        '*sfile*': expand('<sfile>:p'),
+\        'select-a': 'ar',  '*select-a-function*': 's:select_a',
+\        'select-i': 'ir',  '*select-i-function*': 's:select_i'
+\      }
+\    })
+
+" Misc.  "{{{1
+let s:comment_escape = '\v^[^#]*'
+let s:block_openers = '\zs(<def>|<if>|<do>|<module>|<class>)'
+let s:start_pattern = s:comment_escape . s:block_openers
+let s:end_pattern = s:comment_escape . '\zs<end>'
+let s:skip_pattern = 'getline(".") =~ "\\w\\s\\+if"'
+
+function! s:select_a()
+  let s:flags = 'W'
+
+  call searchpair(s:start_pattern,'',s:end_pattern, s:flags, s:skip_pattern)
+  let end_pos = getpos('.')
+
+  " Jump to match
+  normal %
+  let start_pos = getpos('.')
+
+  return ['V', start_pos, end_pos]
+endfunction
+
+function! s:select_i()
+  let s:flags = 'W'
+  if expand('<cword>') == 'end'
+    let s:flags = 'cW'
+  endif
+
+  call searchpair(s:start_pattern,'',s:end_pattern, s:flags, s:skip_pattern)
+
+  " Move up one line, and save position
+  normal k^
+  let end_pos = getpos('.')
+
+  " Move down again, jump to match, then down one line and save position
+  normal j^%j
+  let start_pos = getpos('.')
+
+  return ['V', start_pos, end_pos]
+endfunction
+
+" Fin.  "{{{1
+
+let g:loaded_textobj_rubyblock = 1
+
+" __END__
+" vim: foldmethod=marker
+doc/textobj-rubyblock.txt	[[[1
+151
+*textobj-rubyblock.txt*	Text objects for ruby blocks
+
+Version 0.0.1
+
+CONTENTS					*textobj-rubyblock-contents*
+
+Introduction		|textobj-rubyblock-introduction|
+Interface		|textobj-rubyblock-interface|
+Mappings		|textobj-rubyblock-mappings|
+Examples		|textobj-rubyblock-examples|
+Bugs			|textobj-rubyblock-bugs|
+Changelog		|textobj-rubyblock-changelog|
+
+
+==============================================================================
+INTRODUCTION					*textobj-rubyblock-introduction*
+
+The *textobj-rubyblock* plugin provides two new |text-objects| which are
+triggered by `ar` and `ir` respectively. These follow Vim convention, so that
+`ar` selects _all_ of a ruby block, and `ir` selects the _inner_ portion of a
+rubyblock.
+
+In ruby, a block is always closed with the `end` keyword. Ruby blocks may be
+opened using one of several keywords, including `module`, `class`, `def` `if`
+and `do`. This example demonstrates a few of these:
+>
+	module Foo
+	  class Bar
+	    def Baz
+	      [1,2,3].each do |i|
+	        i + 1
+	      end
+	    end
+	  end
+	end
+<
+Suppose your cursor was positioned on the word `def` in this snippet. Typing
+`var` would enable visual mode selecting _all_ of the method definition. Your
+selection would comprise the following lines:
+>
+	def Baz
+	  [1,2,3].each do |i|
+	    i + 1
+	  end
+	end
+<
+Whereas if you typed `vir`, you would select everything _inside_ of the method
+definition, which looks like this:
+>
+	[1,2,3].each do |i|
+	  i + 1
+	end
+<
+Note that the `ar` and `ir` text objects always enable _visual line_ mode,
+even if you were in visual character or block mode before you triggered the
+rubyblock text object.
+
+Note too that the `ar` and `ir` text objects always position your cursor on
+the `end` keyword. If you want to move to the top of the selection, you can do
+so with the `o` key.
+
+# Limitations #
+
+Some text objects in Vim respond to a count. For example, the `a{` text object
+will select _all_ of the current `{}` delimited block, but if you prefix it
+with the number 2 (e.g. `v2i{`) then it will select all of the block that
+contains the current block. The rubyblock text object does not respond in this
+way if you prefix a count. This is due to a limitation in vimscript #2100.
+
+However, you can achieve a similar effect by repeating the rubyblock
+text-object manually. So if you press `var` to select the current ruby block,
+you can expand your selection outwards by repeating `ar`, or contract your
+selection inwards by repeating `ir`.
+
+
+# Requirements: #
+
+- Vim 7.2 or later
+- |textobj-user| 0.3.7 or later (vimscript#2100)
+- |matchit.vim|
+
+Matchit.vim is distributed with Vim, but is not enabled by default. If you add
+the following line to your vimrc file, then it will enable matchit.vim each
+time Vim starts up:
+>
+    runtime macros/matchit.vim
+<
+Latest version:
+http://github.com/nelstrom/vim-textobj-rubyblock
+
+
+==============================================================================
+INTERFACE					*textobj-rubyblock-interface*
+
+------------------------------------------------------------------------------
+MAPPINGS					*textobj-rubyblock-mappings*
+
+These key mappings are defined in Visual mode and Operator-pending mode.
+
+<Plug>(textobj-rubyblock-a)			*<Plug>(textobj-rubyblock-a)*
+	Select the ruby block including the opening and closing lines.
+
+<Plug>(textobj-rubyblock-i)			*<Plug>(textobj-rubyblock-i)*
+	Select the inner lines of a ruby block. The opening and closing
+	lines are not included.
+
+==============================================================================
+CUSTOMIZING					*textobj-rubyblock-customizing*
+
+				*g:textobj_rubyblock_no_default_key_mappings*
+					*:TextobjRubyblockDefaultKeyMappings*
+
+	This plugin will define the following key mappings in Visual mode and
+	Operator-pending mode automatically.  If you don't want these key
+	mappings, define |g:textobj_rubyblock_no_default_key_mappings| before
+	this plugin is loaded (e.g. in your |vimrc|).  You can also use
+	|:TextobjRubyblockDefaultKeyMappings| to redefine these key mappings.
+	This command doesn't override existing {lhs}s unless [!] is given.
+
+	{lhs}	{rhs}			~
+	-----	----------------------	~
+	ar	<Plug>(textobj-rubyblock-a)
+	ir	<Plug>(textobj-rubyblock-i)
+
+	Suppose that you didn't like using `ar` and `ir` to trigger the
+	rubyblock text objects, and instead wanted to map them to `ae` and
+	`ie`. You could achieve this by placing the following in your vimrc
+	file:
+
+	let g:textobj_rubyblock_no_default_key_mappings = 1
+	xmap ae  <Plug>(textobj-rubyblock-a)
+	omap ae  <Plug>(textobj-rubyblock-a)
+	xmap ie  <Plug>(textobj-rubyblock-i)
+	omap ie  <Plug>(textobj-rubyblock-i)
+
+==============================================================================
+BUGS						*textobj-rubyblock-bugs*
+
+- [count] is just ignored.
+
+- See |textobj-user-bugs| for further information.
+
+==============================================================================
+CHANGELOG					*textobj-rubyblock-changelog*
+
+0.0.1	2010-12-27
+	- First release.
+
+==============================================================================
+vim:tw=78:ts=8:ft=help:norl:fen:fdl=0:fdm=marker:
+

--- a/samples/Vim script/todo.vmb
+++ b/samples/Vim script/todo.vmb
@@ -1,0 +1,189 @@
+" Vimball Archiver by Charles E. Campbell, Jr., Ph.D.
+UseVimball
+finish
+doc/todo.txt	[[[1
+50
+Todo plugin for Vim:
+
+This Vim plugin is based on vim-task (github.com/samsonw/vim-task).
+It helps managing todo lists within Vim in a very basic but efficient way.
+
+The latest version of todo can be found here: cdsoft.fr/todo
+
+Contributions are possible on GitHub: https://github.com/CDSoft.fr/todo
+
+Installation:
+
+    Todo is distributed as a Vimball archive.
+    + download todo.vmb
+    + open this file with vim and type « :so % »
+
+Usage:
+
+    File type:
+
+    ✓ file named *.todo or *todo.txt are open with the todo plugin.
+
+    Syntax:
+
+    ✓ lines ending with ':' are project titles
+    + lines starting with '+' are urgent tasks
+    - lines starting with '-' are pending tasks (less urgent)
+    ✓ lines starting with '✓' are completed tasks
+    ? lines starting with '?' are questions
+    Some "todo" words are highlighted
+    Other lines remain unformated
+
+    Shortcuts:
+
+    Shortcuts are key sequences starting with <Leader>. The <Leader> key is
+    '\' by default but I personnally prefer '²' which makes Todo shortcuts
+    easier to type on a french keyboard.
+    You can add « let mapleader="²" » to the .vimrc file or define any
+    other key that suits you best.
+
+    ✓ \TAB toggles the line status between "pending" and "completed"
+    ✓ \& toggles the line status between "urgent" and "completed"
+    ✓ \q toggles the line status between "question" and "unformated"
+
+License:
+
+    Copyright © 2013, 2016 Christophe Delord (cdsoft.fr)
+    This work is free. You can redistribute it and/or modify it under the
+    terms of the Do What The Fuck You Want To Public License, Version 2,
+    as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+
+syntax/todo.vim	[[[1
+46
+" Copyright © 2013, 2016 Christophe Delord (cdsoft.fr)
+" This work is free. You can redistribute it and/or modify it under the
+" terms of the Do What The Fuck You Want To Public License, Version 2,
+" as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syntax keyword taskKeyword New new Working working Done done Todo TODO todo bug Bug TBC TBD
+
+syntax match taskWorkingIcon "^-" contained
+syntax match taskWorkingIcon "^\s*-" contained
+syntax match taskUrgentIcon "^+" contained
+syntax match taskUrgentIcon "^\s*+" contained
+syntax match taskDoneIcon "^✓" contained
+syntax match taskDoneIcon "^\s*✓" contained
+syntax match taskQuestionIcon "^?" contained
+syntax match taskQuestionIcon "^\s*?" contained
+
+syntax match taskWorkingItem "^-.*" contains=taskWorkingIcon,taskKeyword
+syntax match taskWorkingItem "^\s*-.*" contains=taskWorkingIcon,taskKeyword
+syntax match taskUrgentItem "^+.*" contains=taskUrgentIcon,taskKeyword
+syntax match taskUrgentItem "^\s*+.*" contains=taskUrgentIcon,taskKeyword
+syntax match taskDoneItem "^✓.*" contains=taskDoneIcon,taskKeyword
+syntax match taskDoneItem "^\s*✓.*" contains=taskDoneIcon,taskKeyword
+syntax match taskQuestionItem "^?.*" contains=taskQuestionIcon,taskKeyword
+syntax match taskQuestionItem "^\s*?.*" contains=taskQuestionIcon,taskKeyword
+
+highlight taskKeyword guifg=black guibg=yellow gui=NONE ctermfg=black ctermbg=yellow cterm=NONE
+
+highlight taskWorkingItem guifg=red guibg=NONE gui=NONE ctermfg=red ctermbg=NONE cterm=NONE
+highlight taskUrgentItem guifg=red guibg=NONE gui=bold ctermfg=red ctermbg=NONE cterm=bold
+highlight taskDoneItem guifg=green guibg=NONE gui=NONE ctermfg=green ctermbg=NONE cterm=NONE
+highlight taskQuestionItem guifg=black guibg=yellow gui=NONE ctermfg=black ctermbg=yellow cterm=NONE
+
+highlight taskWorkingIcon guifg=red guibg=NONE gui=bold ctermfg=red ctermbg=NONE cterm=bold
+highlight taskUrgentIcon guifg=red guibg=NONE gui=bold ctermfg=red ctermbg=NONE cterm=bold
+highlight taskDoneIcon guifg=green guibg=NONE gui=bold ctermfg=green ctermbg=NONE cterm=bold
+highlight taskQuestionIcon guifg=black guibg=NONE gui=bold ctermfg=black ctermbg=NONE cterm=bold
+
+syntax match sectionTitleLine "^.*:\s*$" contains=sectionTitle
+syntax match sectionTitle "\S.*:\s*$"
+highlight sectionTitle guifg=blue guibg=NONE gui=bold,underline ctermfg=blue ctermbg=NONE cterm=bold,underline
+
+let b:current_syntax = "todo"
+plugin/todo.vim	[[[1
+73
+" Copyright © 2013, 2016 Christophe Delord (cdsoft.fr)
+" This work is free. You can redistribute it and/or modify it under the
+" terms of the Do What The Fuck You Want To Public License, Version 2,
+" as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+
+if (exists("g:loaded_todo"))
+  finish
+endif
+let g:loaded_todo = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! Toggle_task_status()
+  let line = getline('.')
+  if match(line, '^\(\s*\)-') == 0
+    let line = substitute(line, '^\(\s*\)-', '\1✓', '')
+  elseif match(line, '^\(\s*\)+') == 0
+    let line = substitute(line, '^\(\s*\)+', '\1-', '')
+  elseif match(line, '^\(\s*\)✓') == 0
+    let line = substitute(line, '^\(\s*\)✓', '\1-', '')
+  elseif match(line, '^\(\s*\)?') == 0
+    let line = substitute(line, '^\(\s*\)?', '\1-', '')
+  else
+    let line = substitute(line, '^\(\s\{-}\)\(\s\=\)\<', '\2\1- ', '')
+  endif
+  call setline('.', line)
+endfunction
+
+function! Toggle_urgent_task_status()
+  let line = getline('.')
+  if match(line, '^\(\s*\)+') == 0
+    let line = substitute(line, '^\(\s*\)+', '\1✓', '')
+  elseif match(line, '^\(\s*\)-') == 0
+    let line = substitute(line, '^\(\s*\)-', '\1+', '')
+  elseif match(line, '^\(\s*\)✓') == 0
+    let line = substitute(line, '^\(\s*\)✓', '\1+', '')
+  elseif match(line, '^\(\s*\)?') == 0
+    let line = substitute(line, '^\(\s*\)?', '\1+', '')
+  else
+    let line = substitute(line, '^\(\s\{-}\)\(\s\=\)\<', '\2\1+ ', '')
+  endif
+  call setline('.', line)
+endfunction
+
+function! Toggle_question()
+  let line = getline('.')
+  if match(line, '^\(\s*\)-') == 0
+    let line = substitute(line, '^\(\s*\)-', '\1?', '')
+  elseif match(line, '^\(\s*\)+') == 0
+    let line = substitute(line, '^\(\s*\)-', '\1?', '')
+  elseif match(line, '^\(\s*\)✓') == 0
+    let line = substitute(line, '^\(\s*\)✓', '\1?', '')
+  elseif match(line, '^\(\s*\)?') == 0
+    let line = substitute(line, '^\(\s*\)?\s*', '\1', '')
+  else
+    let line = substitute(line, '^\(\s\{-}\)\(\s\=\)\<', '\2\1? ', '')
+  endif
+  call setline('.', line)
+endfunction
+
+function SetupTodo()
+    inoremap <silent> <buffer> <Leader><TAB> <ESC>:call Toggle_task_status()<CR>i
+    noremap <silent> <buffer> <Leader><TAB> :call Toggle_task_status()<CR>
+    inoremap <silent> <buffer> <Leader>& <ESC>:call Toggle_urgent_task_status()<CR>i
+    noremap <silent> <buffer> <Leader>& :call Toggle_urgent_task_status()<CR>
+    inoremap <silent> <buffer> <Leader>q <ESC>:call Toggle_question()<CR>i
+    noremap <silent> <buffer> <Leader>q :call Toggle_question()<CR>
+endfunction
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+ftdetect/todo.vim	[[[1
+9
+" Copyright © 2013, 2016 Christophe Delord (cdsoft.fr)
+" This work is free. You can redistribute it and/or modify it under the
+" terms of the Do What The Fuck You Want To Public License, Version 2,
+" as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+
+autocmd BufRead,BufNewFile *.todo,*todo.txt set filetype=todo | call SetupTodo()
+augroup filetypedetect
+  au BufRead,BufNewFile *.todo,*todo.txt setfiletype todo | call SetupTodo()
+augroup END

--- a/samples/Visual Basic/procedures.vba
+++ b/samples/Visual Basic/procedures.vba
@@ -1,0 +1,217 @@
+' ------------------------------------------------------------------------------
+' Settings
+' ------------------------------------------------------------------------------
+Option Explicit
+' ------------------------------------------------------------------------------
+' Procedures
+' ------------------------------------------------------------------------------
+Public Sub consolidate()
+  ' Variables
+  Dim btmRow As Long
+  Dim check As String
+  Dim colOffset As Long
+  Dim column As Long
+  Dim counter As Long
+  Dim dialog As Integer
+  Dim file As Long
+  Dim filename As String
+  Dim files() As String
+  Dim fso As New FileSystemObject
+  Dim header As Long
+  Dim leftCol As Long
+  Dim name As String
+  Dim namecheck As String
+  Dim newfile As String
+  Dim path As String
+  Dim rightCol As Long
+  Dim row As Long
+  Dim rowOffset As Long
+  Dim source As Range
+  Dim target As Range
+  Dim topRow As Long
+  Dim twb As Workbook
+  Dim tws As Worksheet
+  Dim version As Integer
+  Dim wb As Workbook
+  Dim ws As Worksheet
+  ' Workbook variables
+  Set twb       = Application.ThisWorkbook                                      ' Select workbook
+  Let filename  = fso.GetBaseName(twb.FullName)                                 ' Get file fullname
+  Set tws       = twb.Sheets(1)                                                 ' Select worksheet
+  Let header    = 1                                                             ' Header size
+  Let rowOffset = 0                                                             ' Row offset
+  Let topRow    = 1 + rowOffset + header                                        ' First row with data
+  Let colOffset = 1                                                             ' Column offset (modify according to use cases)
+  Let leftCol   = 1 + colOffset                                                 ' First column with data
+  ' Start
+  GoTo start
+quit:
+  Let dialog = MsgBox( _
+    prompt:="Are you sure you want to quit?", _
+    Buttons:=vbExclamation + vbYesNo, _
+    Title:=filename)                                                            ' Quit validation message
+  If dialog = vbYes Then                                                        ' If user confirms
+    twb.Close SaveChanges:=False                                                ' Close the workbook
+    If Application.Workbooks.Count = 0 Then                                     ' If only this workbook was open
+      Application.quit                                                          ' Quit the application
+    End If
+  ElseIf dialog = vbNo Then                                                     ' Else
+    GoTo start                                                                  ' Go back to start
+  End If
+start:
+  ' User interaction
+  Let dialog = MsgBox( _
+    prompt:="Are the files in the same folder as this document?", _
+    Buttons:=vbQuestion + vbYesNo, _
+    Title:=filename)                                                            ' Ask if files are in the current folder
+  If dialog = vbYes Then                                                        ' If it is true
+    Let path = twb.path                                                         ' Set path to current repository
+  ElseIf dialog = vbNo Then                                                     ' If not
+    If path = "False" Then Let path = ""                                        ' Reset path if action has been cancelled
+    Let path = Application.InputBox( _
+      prompt:="Enter the path to the repository containing the files to consolidate:", _
+      Title:=filename, _
+      Default:=path, _
+      Type:=2)                                                                  ' Input source repository path
+    ' Check input
+    If StrPtr(path) = 0 Or path = "False" Then                                  ' If user cancels action
+      GoTo quit                                                                 ' Quit application
+    ElseIf path = "" Then                                                       ' If user provided no value
+      Let dialog = MsgBox( _
+        prompt:="Please provide a valid path.", _
+        Buttons:=vbExclamation + vbRetryCancel, _
+        Title:=filename)                                                        ' Throw error message
+      If dialog = vbRetry Then                                                  ' If user wants to retry
+        GoTo start                                                              ' Go back to the beginning
+      Else: GoTo quit                                                           ' Else close application
+      End If
+    End If
+  End If
+  If Right(path, 1) <> "\" Then                                                 ' If closing backslash is missing
+    Let path = path & "\"                                                       ' Add it to the end of the path
+  End If
+  ' Check if files are found in the repository
+  Let check = Dir(path & "*.xl*")                                               ' Check for Excel files and store its name
+  If (check = "") Then                                                          ' If no Excel files are found
+    Let dialog = MsgBox( _
+      prompt:="No files were found.", _
+      Buttons:=vbExclamation + vbRetryCancel, _
+      Title:=filename)                                                          ' Throw error message
+    If dialog = vbRetry Then                                                    ' If user wants to retry
+      GoTo start                                                                ' Go back to the beginning
+    Else: GoTo quit                                                             ' Else close application
+    End If
+  End If
+version:
+  ' Version check
+  Let dialog = MsgBox( _
+    prompt:="The file will be generated for the year " & Year(Date) & "." & Chr(13) & Chr(13) & "Is this the correct date?", _
+    Buttons:=vbQuestion + vbYesNo, _
+    Title:=filename)                                                            ' Ask if year is current
+  If dialog = vbNo Then                                                         ' If version is not valid
+    Let version = Application.InputBox( _
+      prompt:="Please enter the correct year:", _
+      Title:=filename, _
+      Type:=1)                                                                  ' Ask for correct year
+    If version = 0 Then                                                         ' If user cancels
+      GoTo version                                                              ' Go back to previous step
+    End If
+  Else
+    Let version = Year(Date)                                                    ' Version (year)
+  End If
+  Let tws.name  = version                                                       ' Rename worksheet
+  Let newfile   = filename & " - " & version                                    ' Add version to filename
+  ' Iterate on files list
+  Let counter = 0                                                               ' Initialise counter
+  Do While check <> ""                                                          ' As long are files are found
+    Let name = Split(check, ".xl")(0)                                           ' Store workbook name
+    If name <> filename And name <> newfile Then                                ' Skip current workbook or consolidated one
+      If InStr(name, CStr(version)) > 0 Then                                    ' If files are from the corresponding year
+        Let counter = counter + 1                                               ' Increment counter
+        ReDim Preserve files(counter)                                           ' Redimension array
+        Let files(counter) = check                                              ' Assign document
+      End If
+    End If
+    Let check = Dir()                                                           ' Get next entry
+  Loop                                                                          ' Iterate
+  If counter = 0 Then                                                           ' If no source files are found for the corresponding year
+    Let dialog = MsgBox( _
+      prompt:="No Excel files were found for the year " & version & ".", _
+      Buttons:=vbExclamation + vbRetryCancel, _
+      Title:=filename)                                                          ' Throw error message
+    If dialog = vbRetry Then                                                    ' If user wants to retry
+      GoTo start                                                                ' Go back to the beginning
+    Else: GoTo quit                                                             ' Else close application
+    End If
+  Else
+    ' Settings
+    Application.Calculation     = xlCalculationManual                           ' Disable auto-processing
+    Application.DisplayAlerts   = False                                         ' Disable alerts
+    Application.EnableEvents    = False                                         ' Disable events
+    Application.ScreenUpdating  = False                                         ' Disable display updates
+    ' Import data
+    Let dialog = MsgBox( _
+      prompt:="Excel will now consolidate each files found in the repository " & path & " for the year " & version & "." & Chr(13) & Chr(13) & "Please wait until the process is complete.", _
+      Buttons:=vbInformation + vbOKCancel, _
+      Title:=filename)                                                          ' Start message
+    If dialog = vbCancel Then GoTo quit                                         ' If user cancels, go back to quit
+    window.Show                                                                 ' Display progress bar
+    progress (5)                                                                ' Update progress bar
+    ' Import headers
+    Set wb        = Workbooks.Open(path & files(1))                             ' Select and open first workbook
+    Set ws        = wb.Worksheets(1)                                            ' Select worksheet
+    Let column    = getLastColIndex(ws, 1 + rowOffset)                          ' Get column index
+    Let topRow    = 1                                                           ' Target first row by default (adjust if needed)
+    Let leftCol   = 1                                                           ' Target first column by default (adjust if needed)
+    Let rightCol  = column - colOffset                                          ' Adjust for column offset
+    Set source    = ws.Range(ws.Cells(1 + rowOffset, leftCol + colOffset), ws.Cells(header + rowOffset, column))  ' Select header
+    Set target    = tws.Range(tws.Cells(topRow, leftCol), tws.Cells(header, rightCol))  ' Target cell
+    Call copyData(source, target)                                               ' Copy values
+    wb.Close SaveChanges:=False                                                 ' Exit source workbook
+    Let topRow    = topRow + header                                             ' Reposition row index
+    progress (10)                                                               ' Update progress bar
+    ' Import values
+    For file = LBound(files) To UBound(files)                                   ' Iterate over files list
+      Set wb = Nothing                                                          ' Reset pointer
+      On Error Resume Next
+      Set wb = Workbooks.Open(path & files(file + 1))                           ' Select and open source workbook
+      On Error GoTo 0
+      If Not wb Is Nothing Then                                                 ' Check that workbook is selected
+        On Error Resume Next
+        Let namecheck = fso.GetBaseName(wb.FullName)                            ' Get workbook name
+        If (namecheck <> filename And namecheck <> newfile) Then                ' Skip current workbook or consolidated one
+          Set ws = wb.Worksheets(1)                                             ' Select worksheet
+          Let column = getLastColIndex(ws, 1 + rowOffset)                       ' Get column index
+          Let rightCol = column - colOffset                                     ' Adjust for column offset
+          Let row = getLastRowIndex(ws, 1 + colOffset)                          ' Get row index
+          ' Check if file is not empty
+          If (row > 1) Then                                                     ' If data is found
+            Let btmRow = topRow - 1 - header + row - rowOffset                  ' Adjust for row offsets due to header and/or previous data
+            Set source = ws.Range(ws.Cells(1 + header + rowOffset, leftCol + colOffset), ws.Cells(row, column)) ' Source range
+            Set target = tws.Range(tws.Cells(topRow, leftCol), tws.Cells(btmRow, rightCol)) ' Target cell
+            Call copyData(source, target)                                       ' Copy values
+            Let topRow = btmRow + 1                                             ' Reposition top row
+            End If
+        End If
+        wb.Close SaveChanges:=False                                             ' Exit source workbook
+      End If
+      progress (Round((1 + file) / counter * 80) + 10)                          ' Update progress bar
+    Next file                                                                   ' Next file
+    progress (90)                                                               ' Update progress bar
+    tws.Columns.AutoFit                                                         ' Resize columns width
+    ' Let newfile = path & newfile                                                ' Add path to filename
+    twb.SaveAs filename:=path & newfile, FileFormat:=xlOpenXMLWorkbook            ' Save as new workbook
+    ' Reset settings
+    Application.Calculation     = xlCalculationAutomatic
+    Application.DisplayAlerts   = True
+    Application.EnableEvents    = True
+    Application.ScreenUpdating  = True
+    ' End
+    twb.Save                                                                    ' Save workbook
+    window.Hide                                                                 ' Hide progress bar
+    Let dialog = MsgBox( _
+      prompt:="Files consolidation done." & Chr(13) & Chr(13) & "The file " & newfile & ".xlsx has been generated at location " & path & ".", _
+      Buttons:=vbInformation + vbOKOnly, _
+      Title:=filename)                                                          ' Notify user of end of process
+  End If
+End Sub

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -475,6 +475,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_vba_by_heuristics
+    assert_heuristics({
+      "Visual Basic" => all_fixtures("Visual Basic", "*.vba"),
+      "Vim script" => all_fixtures("Vim script", "*.vba")
+    })
+  end
+
   def test_w_by_heuristics
     assert_heuristics({
       "CWeb" => all_fixtures("CWeb", "*.w"),


### PR DESCRIPTION
Fixes #501

## Description

- added .vba and .vmb extensions to Vim script
- added .vba disambiguation
- added Vimball sample with .vba extension (Vim license) from https://github.com/nelstrom/vim-textobj-rubyblock/blob/master/textobj-rubyblock.vba
- added Vimball sample with .vmb extension (WTFPL) from https://github.com/CDSoft/todo/blob/master/todo.vmb
- added Visual Basic sample with .vba extension (MIT license) from https://github.com/Akaizoku/concatenate/blob/master/procedures.vba

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?q=extension%3Avba+usevimball+NOT+nothack&type=Code
      - https://github.com/search?q=extension%3Avmb+usevimball+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/nelstrom/vim-textobj-rubyblock/blob/master/textobj-rubyblock.vba
    - Sample license(s): Vim License
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
