### PR TITLE
Revisiting #3815 (Update Racket color)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4079,7 +4079,7 @@ RUNOFF:
   language_id: 315
 Racket:
   type: programming
-  color: "#22228f"
+  color: "#3c5caa"
   extensions:
   - ".rkt"
   - ".rktd"


### PR DESCRIPTION
In #3815, I wanted to update the Racket color to match the blue color used in the logo. Unfortunately, Go was very close in the colorspace. In #4331, Go was changed to a lighter blue. Now, with a minor tweak, the Racket color can be successfully updated from `#22228f` to `#3c5caa`.

This won't turn out like the #4319 (Rust) debacle for the following reasons:
- The blue color is official, not just a random opinion.
- We are going from a dark and not easily visible shade of blue to a lighter shade of the same color.
- Racket is not as popular as Rust, so an army of Reddit users will not show up armed with negative emojis.

Of course, if a Racket developer shows up and explains why this is a disaster, it will be easy enough to revert. But I think a nicer color will help Racket, an underappreciated Lisp dialect, look more attractive.