### PR TITLE
Made '-' in font-awesome optional in vendor.yml

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -60,17 +60,10 @@
 # Bootstrap css and js
 - (^|/)bootstrap([^.]*)\.(js|css|less|scss|styl)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
-# Bootstrap with a directory between the files and the main folder like bootstrap/css/bootstrap.css
-- (^|/)bootstrap/(css|js)/.*\.(js|css|less|scss|styl)$
 
 # Font Awesome
-- (^|/)font-awesome\.(css|less|scss|styl)$
-- (^|/)font-awesome/.*\.(css|less|scss|styl)$
-- (^|/)fontawesome\.(css|less|scss|styl)$
-- (^|/)fontawesome/.*\.(css|less|scss|styl)$
-# Font Awesome with a directory between the files and the main folder like fontawesome/css/fontawesome.all.css
-- (^|/)font-awesome/.*/.*\.(js|css|less|scss|styl)$
-- (^|/)fontawesome/.*/.*\.(js|css|less|scss|styl)$
+- (^|/)font-?awesome\.(css|less|scss|styl)$
+- (^|/)font-?awesome/.*\.(css|less|scss|styl)$
 
 # Foundation css
 - (^|/)foundation\.(css|less|scss|styl)$
@@ -283,9 +276,6 @@
 - (^|/)gradle/wrapper/
 
 ## Java ##
-# Java with maven based directory structure
-- /src/main/resources/static/vendor/.*
-- /src/test/resources/static/vendor/.*
 
 # Maven
 - (^|/)mvnw$

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -60,10 +60,17 @@
 # Bootstrap css and js
 - (^|/)bootstrap([^.]*)\.(js|css|less|scss|styl)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
+# Bootstrap with a directory between the files and the main folder like bootstrap/css/bootstrap.css
+- (^|/)bootstrap/(css|js)/.*\.(js|css|less|scss|styl)$
 
 # Font Awesome
 - (^|/)font-awesome\.(css|less|scss|styl)$
 - (^|/)font-awesome/.*\.(css|less|scss|styl)$
+- (^|/)fontawesome\.(css|less|scss|styl)$
+- (^|/)fontawesome/.*\.(css|less|scss|styl)$
+# Font Awesome with a directory between the files and the main folder like fontawesome/css/fontawesome.all.css
+- (^|/)font-awesome/.*/.*\.(js|css|less|scss|styl)$
+- (^|/)fontawesome/.*/.*\.(js|css|less|scss|styl)$
 
 # Foundation css
 - (^|/)foundation\.(css|less|scss|styl)$
@@ -276,6 +283,9 @@
 - (^|/)gradle/wrapper/
 
 ## Java ##
+# Java with maven based directory structure
+- /src/main/resources/static/vendor/.*
+- /src/test/resources/static/vendor/.*
 
 # Maven
 - (^|/)mvnw$


### PR DESCRIPTION


<!--- Briefly describe what you're changing. -->

## Description
Added different configuration for font-awesome and bootstrap.
Added directory convention for vendor files in Java maven based directory structure.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding vendor file locations to ignore.**
  