### PR TITLE
Grammar compiler tweaks and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/fixtures/ace_modes.json
 /tmp
 *.bundle
 *.so
+linguist-grammars*

--- a/script/grammar-compiler
+++ b/script/grammar-compiler
@@ -6,9 +6,15 @@ cd "$(dirname "$0")/.."
 image="linguist/grammar-compiler:latest"
 mkdir -p grammars
 
-docker pull $image
+if [ -z "$REBUILD" ]; then
+    docker pull $image
+else
+    cd tools/grammars
+    image=$(docker build -q .)
+    cd "../.."
+fi
 
 exec docker run --rm \
-    -u $(id -u $USER):$(id -g $USER) \
-    -v $PWD:/src/linguist \
-    -w /src/linguist $image "$@"
+    -u "$(id -u "$USER")":"$(id -g "$USER")" \
+    -v "$PWD:/src/linguist" \
+    -w /src/linguist "$image" "$@"

--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -35,3 +35,15 @@ var KnownFields = map[string]bool{
 	"backgroundColor":       true,
 	"increaseIndentPattern": true,
 }
+
+// GrammarsInNonStdPath is a list of grammars known to have their syntax .cson or .json files in non-standard directories.
+var GrammarsInNonStdPath = []string{
+	"conllu-linguist-grammar",
+	"hy.tmLanguage",
+}
+
+// IgnoredFiles is a list of files that look like syntax files but aren't, or are known to be broken and never likely to be fixed.
+var IgnoredFiles = []string{
+	"syntaxes/ballerina.monarch.json",
+	"Originals/Oz.tmLanguage",
+}

--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -12,6 +12,7 @@ var GrammarAliases = map[string]string{
 	"source.perl6":       "source.perl6fe",
 	"source.css.scss":    "source.scss",
 	"source.git-config":  "source.gitconfig",
+	"source.smarty":      "text.html.smarty",
 }
 
 var KnownFields = map[string]bool{

--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -40,13 +40,13 @@ var KnownFields = map[string]bool{
 }
 
 // GrammarsInNonStdPath is a list of grammars known to have their syntax .cson or .json files in non-standard directories.
-var GrammarsInNonStdPath = []string{
-	"conllu-linguist-grammar",
-	"hy.tmLanguage",
+var GrammarsInNonStdPath = map[string]bool{
+	"conllu-linguist-grammar": true,
+	"hy.tmLanguage":           true,
 }
 
 // IgnoredFiles is a list of files that look like syntax files but aren't, or are known to be broken and never likely to be fixed.
-var IgnoredFiles = []string{
-	"syntaxes/ballerina.monarch.json",
-	"Originals/Oz.tmLanguage",
+var IgnoredFiles = map[string]bool{
+	"ballerina-grammar/syntaxes/ballerina.monarch.json": true,
+	"oz-tmbundle/Originals/Oz.tmLanguage":               true,
 }

--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -11,6 +11,7 @@ var GrammarAliases = map[string]string{
 	"source.asciidoc":    "text.html.asciidoc",
 	"source.perl6":       "source.perl6fe",
 	"source.css.scss":    "source.scss",
+	"source.git-config":  "source.gitconfig",
 }
 
 var KnownFields = map[string]bool{

--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -14,6 +14,7 @@ var GrammarAliases = map[string]string{
 	"source.git-config":  "source.gitconfig",
 	"source.smarty":      "text.html.smarty",
 	"text.slm":           "text.slim",
+	"text.pug":           "text.jade",
 }
 
 var KnownFields = map[string]bool{

--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -13,6 +13,7 @@ var GrammarAliases = map[string]string{
 	"source.css.scss":    "source.scss",
 	"source.git-config":  "source.gitconfig",
 	"source.smarty":      "text.html.smarty",
+	"text.slm":           "text.slim",
 }
 
 var KnownFields = map[string]bool{

--- a/tools/grammars/compiler/loader.go
+++ b/tools/grammars/compiler/loader.go
@@ -65,6 +65,15 @@ func toMap(slice []string) map[string]bool {
 	return m
 }
 
+func hasStringInArray(str string, arr []string) bool {
+	for _, s := range arr {
+		if strings.Contains(str, s) {
+			return true
+		}
+	}
+	return false
+}
+
 func (repo *Repository) CompareScopes(scopes []string) {
 	expected := toMap(scopes)
 
@@ -122,7 +131,7 @@ func isValidGrammar(path string, info os.FileInfo) bool {
 	case ".tmlanguage", ".yaml-tmlanguage":
 		return true
 	case ".cson", ".json":
-		return strings.HasSuffix(dir, "/grammars") || strings.HasSuffix(dir, "/syntaxes")
+		return strings.HasSuffix(dir, "/grammars") || strings.HasSuffix(dir, "/syntaxes") || hasStringInArray(dir, GrammarsInNonStdPath)
 	default:
 		return false
 	}

--- a/tools/grammars/compiler/loader.go
+++ b/tools/grammars/compiler/loader.go
@@ -65,15 +65,6 @@ func toMap(slice []string) map[string]bool {
 	return m
 }
 
-func hasStringInArray(str string, arr []string) bool {
-	for _, s := range arr {
-		if strings.Contains(str, s) {
-			return true
-		}
-	}
-	return false
-}
-
 func (repo *Repository) CompareScopes(scopes []string) {
 	expected := toMap(scopes)
 
@@ -131,7 +122,7 @@ func isValidGrammar(path string, info os.FileInfo) bool {
 	case ".tmlanguage", ".yaml-tmlanguage":
 		return true
 	case ".cson", ".json":
-		return strings.HasSuffix(dir, "/grammars") || strings.HasSuffix(dir, "/syntaxes") || hasStringInArray(dir, GrammarsInNonStdPath)
+		return strings.HasSuffix(dir, "/grammars") || strings.HasSuffix(dir, "/syntaxes") || GrammarsInNonStdPath[filepath.Base(dir)]
 	default:
 		return false
 	}

--- a/tools/grammars/compiler/loader_fs.go
+++ b/tools/grammars/compiler/loader_fs.go
@@ -63,6 +63,10 @@ func (l *fsLoader) load() {
 	}
 
 	for _, path := range grammars {
+		if hasStringInArray(path, IgnoredFiles) {
+			continue
+		}
+
 		data, err := ioutil.ReadFile(path)
 		if err != nil {
 			l.Fail(err)

--- a/tools/grammars/compiler/loader_fs.go
+++ b/tools/grammars/compiler/loader_fs.go
@@ -63,7 +63,8 @@ func (l *fsLoader) load() {
 	}
 
 	for _, path := range grammars {
-		if hasStringInArray(path, IgnoredFiles) {
+		rel, _ := filepath.Rel("/src/linguist/vendor/grammars/", path)
+		if IgnoredFiles[rel] {
 			continue
 		}
 

--- a/tools/grammars/compiler/loader_fs.go
+++ b/tools/grammars/compiler/loader_fs.go
@@ -63,7 +63,12 @@ func (l *fsLoader) load() {
 	}
 
 	for _, path := range grammars {
-		rel, _ := filepath.Rel("/src/linguist/vendor/grammars/", path)
+		rel, err := filepath.Rel("/src/linguist/vendor/grammars/", path)
+		if err != nil {
+			l.Fail(err)
+			return
+		}
+
 		if IgnoredFiles[rel] {
 			continue
 		}


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description

In a bid to reduce the chances of missing a grammar going MIA during an update as I did with the Solidity grammar mentioned at https://github.com/github/linguist/pull/3973#issuecomment-461802620, I've made a few changes to reduce unnecessary noise that can be easily rectified from the compiler without any changes to the grammars.

Changes include:

- Adding more grammar aliases for known and easily identifiable grammars, thus clearing out a few of these errors:
  ```
  Missing include in grammar: <FILENAME> (in <PATH/TO/GRAMMAR>) attempts to include <SCOPE> but the scope cannot be found
  ```
- Adding handling for grammars that don't use standard paths for their grammars. This is mostly for very old grammars in particular hy and conllu, both of which have regularly get missed from updates without anyone noticing 😱 because I regularly miss:
  ```
  - [ ] repository `vendor/grammars/conllu-linguist-grammar` (from https://github.com/odanoburu/conllu-linguist-grammar) (1 errors)
      - [ ] Missing scope in repository: `text.conllu` is listed in grammars.yml but cannot be found
  - [ ] repository `vendor/grammars/hy.tmLanguage` (from https://github.com/Slowki/hy.tmLanguage.git) (1 errors)
      - [ ] Missing scope in repository: `source.hy` is listed in grammars.yml but cannot be found
  ```

- Adding handling for known rubbish files that the compiler picks up as grammar files and can't process:
  ```
  - [ ] repository `vendor/grammars/ballerina-grammar` (from https://github.com/ballerina-platform/ballerina-grammar) (2 errors)
      - [ ] Unknown keys in grammar: `source.ballerina` (in `syntaxes/ballerina.tmLanguage`) contains invalid keys (`monarchVariables`, `tmlVariables`)
      - [ ] Grammar conversion failed. File `syntaxes/ballerina.monarch.json` failed to parse: Undeclared scope in grammar: `syntaxes/ballerina.monarch.json` has no scope name
  - [ ] repository `vendor/grammars/oz-tmbundle` (from https://github.com/eregon/oz-tmbundle) (1 errors)
      - [ ] Grammar conversion failed. File `Originals/Oz.tmLanguage` failed to parse: XML syntax error on line 23: expected element name after <
  ```

- Adding the ability to quickly and easily rebuild and test the grammar-compiler docker container locally with a single command by setting the `REBUILD` env var, eg:
  ```
  $ REBUILD=1 script/grammar-compiler compile -o linguist-grammars
  ```

- Adding `linguist-grammars*` to the ignore list so the files created by the above command that I run for each release are ignored.

So all in all, the output from `script/grammar-compiler compile -o linguist-grammars` has gone from [48 outstanding issues](https://gist.github.com/lildude/d0c05ca13cfcf38d8860019b0df09b44#file-before-md) to [37 outstanding issues](https://gist.github.com/lildude/d0c05ca13cfcf38d8860019b0df09b44#file-after-md).

@vmg & @kivikakk the current grammar-compiler image is a little out of date and will need updating once this PR has been merged. I'm happy to do this myself, however I don't have access to push the new image. Would one of you be able to grant me access?

Your 👀 would be greatly appreciated on this PR too.

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
