### PR TITLE
Add '.mcmeta' to JSON extensions.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2237,6 +2237,7 @@ JSON:
   - ".ice"
   - ".JSON-tmLanguage"
   - ".jsonl"
+  - ".mcmeta"
   - ".tfstate"
   - ".tfstate.backup"
   - ".topojson"

--- a/samples/JSON/pack.mcmeta
+++ b/samples/JSON/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "pack_format": 4,
+        "description": "§e更好的钓鱼§r(§kSPGoding§r)"
+    }
+}


### PR DESCRIPTION
This Pull Request adds `.mcmeta` to JSON extensions.

## Description
MCMETA (`.mcmeta`) is used by Minecraft to identify resource packs or data packs and to describe animation textures:
- https://minecraft.gamepedia.com/Resource_pack#Contents
- https://minecraft.gamepedia.com/Data_pack#pack.mcmeta
- https://minecraft.gamepedia.com/Resource_pack#Animation

All these MCMETA files are in JSON format.

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Amcmeta+{+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/SPGoding/datapack-better_fishing/blob/master/BetterFishing/pack.mcmeta
    - Sample license(s):
      - https://github.com/SPGoding/datapack-better_fishing/blob/master/LICENSE
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
