### PR TITLE
Add the 'constexpr' keyword to C++ named patterns

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -456,11 +456,10 @@ named_patterns:
   cpp:
   - '^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>'
   - '^\s*template\s*<'
-  - '^[ \t]*try'
+  - '^[ \t]*(try|constexpr)'
   - '^[ \t]*catch\s*\('
   - '^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+'
   - '^[ \t]*(private|public|protected):$'
-  - '^[ \t]*constexpr'
   - 'std::\w+'
   fortran: '^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)'
   key_equals_value: '^[^#!;][^=]*='

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -460,6 +460,7 @@ named_patterns:
   - '^[ \t]*catch\s*\('
   - '^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+'
   - '^[ \t]*(private|public|protected):$'
+  - '^[ \t]*constexpr'
   - 'std::\w+'
   fortran: '^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)'
   key_equals_value: '^[^#!;][^=]*='

--- a/samples/C++/constexpr_header.h
+++ b/samples/C++/constexpr_header.h
@@ -1,0 +1,4 @@
+constexpr double VERSION_NUMBER {1.2};
+
+constexpr int FRAME_RATE {60};
+constexpr int MIN_FRAME_RATE {30};


### PR DESCRIPTION
## Description
A header file in my repo was misclassified as C instead of C++:
https://github.com/M4444/TMatrix/search?l=c
https://github.com/M4444/TMatrix/blob/43cd9ce1830bb7e78b7746972296cd3fc368b1e9/include/tmatrix.h

The file contains the `constexpr` keyword which only exists in C++.
This change is the simplest one that fixes the problem.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.