### PR TITLE
Better handle shebangs with = after the interpreter

### DIFF
--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -39,7 +39,7 @@ module Linguist
       # if /usr/bin/env type shebang then walk the string
       if script == 'env'
         s.scan(/\s+/)
-        s.scan(/.*=[^\s]+\s+/) # skip over variable arguments e.g. foo=bar
+        s.scan(/([^\s]+=[^\s]+\s+)*/) # skip over variable arguments e.g. foo=bar
         script = s.scan(/\S+/)
       end
 

--- a/test/test_strategies.rb
+++ b/test/test_strategies.rb
@@ -134,6 +134,7 @@ class TestStrategies < Minitest::Test
     assert_interpreter "ruby", "#!/bin/sh\n\n\nexec ruby $0 $@"
 
     assert_interpreter "sh", "#! /usr/bin/env A=003 B=149 C=150 D=xzd E=base64 F=tar G=gz H=head I=tail sh"
+    assert_interpreter "python", "#!/usr/bin/env foo=bar bar=foo python -cos=__import__(\"os\");"
   end
 
   def test_xml


### PR DESCRIPTION
<!--- Briefly describe what you're changing. -->

## Description
As pointed out in https://github.com/github/linguist/issues/4447, the shebang strategy is a little over enthusiastic when it comes to parsing the shebang in a file if that shebang contains `=` after the interpreter resulting in the interpreter being completely missed and the file marked as plain text:

```console
$ /bin/cat ~/tmp/trash/verbose-enigma/info
#!/usr/bin/env python -cos=__import__("os");sys=__import__("sys");python=os.path.join(os.path.dirname(sys.argv[1]),".lifx/bin/python");os.execv(python,sys.argv)

$
$ bundle exec github-linguist ~/tmp/trash/verbose-enigma/info
info: 2 lines (1 sloc)
  type:      Text
  mime type: text/plain
  language:

$
```

This PR addresses that by making the match for the preceding env vars tighter and then iterating over that match to catch them all, before moving onto the interpreter. 

Now the same check gives us the correct interpreter:

```console
$ /bin/cat ~/tmp/trash/verbose-enigma/info
#!/usr/bin/env python -cos=__import__("os");sys=__import__("sys");python=os.path.join(os.path.dirname(sys.argv[1]),".lifx/bin/python");os.execv(python,sys.argv)

$
$ bundle exec github-linguist ~/tmp/trash/verbose-enigma/info
info: 2 lines (1 sloc)
  type:      Text
  mime type: text/plain
  language:  Python
$
```

... and works if we put env vars before the interpreter too:

```console
$ /bin/cat ~/tmp/trash/verbose-enigma/info
#!/usr/bin/env foo=bar bar=foo python -cos=__import__("os");sys=__import__("sys");python=os.path.join(os.path.dirname(sys.argv[1]),".lifx/bin/python");os.execv(python,sys.argv)

$
$ bundle exec github-linguist ~/tmp/trash/verbose-enigma/info
info: 2 lines (1 sloc)
  type:      Text
  mime type: text/plain
  language:  Python
$
```

Kudos to @pchaigno for the simple solution. 🙇 

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.

Fixes https://github.com/github/linguist/issues/4447