### PR TITLE
Add comment highlighting to VSCode language configs

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2285,6 +2285,7 @@ JSON with Comments:
   - ".jshintrc"
   - ".jslintrc"
   - jsconfig.json
+  - language-configuration.json
   - tsconfig.json
   language_id: 423
 JSON5:

--- a/samples/JSON with Comments/filenames/language-configuration.json
+++ b/samples/JSON with Comments/filenames/language-configuration.json
@@ -1,0 +1,28 @@
+{
+	"comments": {
+		// symbol used for single line comment. Remove this entry if your language does not support line comments
+		"lineComment": "#"
+	},
+	// symbols used as brackets
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	// symbols that are auto closed when typing
+	"autoClosingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""],
+		["'", "'"]
+	],
+	// symbols that that can be used to surround a selection
+	"surroundingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""],
+		["'", "'"]
+	]
+}


### PR DESCRIPTION
Low-hanging fruit. Registers `language-configuration.json` as a "JSON with Comments" format, fixing the glaring error highlighting in many VSCode grammar packages. E.g., [stuff like this](https://github.com/hfinkel/llvm-bgq/blob/a5dd1e88977fddcd302c99d139ca9f812d2781e4/utils/vscode/tablegen/language-configuration.json).



## Checklist:
- [x] **I am associating a language with a new file extension.**
	- [x] The new extension is used in hundreds of repositories on GitHub.com
		- [~10,356 results](https://github.com/search?q=filename%3Alanguage-configuration.json+NOT+nothack&type=Code)
	- [x] I have included a real-world usage sample for all extensions added in this PR:
		- Sample source(s):
			- [`Arcensoth/language-mcfunction`](https://github.com/Arcensoth/language-mcfunction/tree/d6ab120d9b1ab344a60b83698d5fe2d0dc900649)  
			This repo is already in-use by Linguist for `.mcfunction` highlighting.
		- Sample license(s): [MIT](https://github.com/Arcensoth/language-mcfunction/blob/150bdc7eb51adf5bbd7de073b25c4fcf86912b3e/LICENSE)

/cc @pchaigno for quick review.