### PR TITLE
Add .inc heuristic for SourcePawn

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -190,6 +190,8 @@ disambiguations:
   rules:
   - language: PHP
     pattern: '^<\?(?:php)?'
+  - language: SourcePawn
+    pattern: '^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\))'
   - language: POV-Ray SDL
     pattern: '^\s*#(declare|local|macro|while)\s'
 - extensions: ['.l']

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -191,7 +191,7 @@ disambiguations:
   - language: PHP
     pattern: '^<\?(?:php)?'
   - language: SourcePawn
-    pattern: '^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\))'
+    pattern: '^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\)(?:\s*{)?)'
   - language: POV-Ray SDL
     pattern: '^\s*#(declare|local|macro|while)\s'
 - extensions: ['.l']


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Adds another heuristic to the `.inc` extension for SourcePawn. I wasn't sure how to order them but I figure this pattern is more specific than the POV-Ray SDL one. It needs to match the following lines (with and without trailing white-space.
```sourcepawn
public SharedPlugin:__pl_x=
public SharedPlugin:__pl_x =
public SharedPlugin:__pl_x={
public SharedPlugin:__pl_x= {
public SharedPlugin:__pl_x ={
public SharedPlugin:__pl_x = {
public SharedPlugin __pl_x=
public SharedPlugin __pl_x =
public SharedPlugin __pl_x={
public SharedPlugin __pl_x= {
public SharedPlugin __pl_x ={
public SharedPlugin __pl_x = {
public __pl_x_SetNTVOptional()
public __pl_x_SetNTVOptional(){
public __pl_x_SetNTVOptional() {
public void __pl_x_SetNTVOptional()
public void __pl_x_SetNTVOptional(){
public void __pl_x_SetNTVOptional() {
```

Little bit of discussion in #3156.