### PR TITLE
Adding Wollok educational language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -956,6 +956,9 @@
 [submodule "vendor/grammars/wdl-sublime-syntax-highlighter"]
 	path = vendor/grammars/wdl-sublime-syntax-highlighter
 	url = https://github.com/broadinstitute/wdl-sublime-syntax-highlighter
+[submodule "vendor/grammars/wollok-sublime"]
+	path = vendor/grammars/wollok-sublime
+	url = https://github.com/uqbar-project/wollok-sublime
 [submodule "vendor/grammars/xc.tmbundle"]
 	path = vendor/grammars/xc.tmbundle
 	url = https://github.com/graymalkin/xc.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -800,6 +800,8 @@ vendor/grammars/vue-syntax-highlight:
 - text.html.vue
 vendor/grammars/wdl-sublime-syntax-highlighter:
 - source.wdl
+vendor/grammars/wollok-sublime:
+- source.wollok
 vendor/grammars/xc.tmbundle:
 - source.xc
 vendor/grammars/xml.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5317,6 +5317,14 @@ Windows Registry Entries:
   codemirror_mode: properties
   codemirror_mime_type: text/x-properties
   language_id: 969674868
+Wollok:
+  type: programming
+  color: "#a23738"
+  extensions:
+  - ".wlk"
+  ace_mode: text
+  tm_scope: source.wollok
+  language_id: 632745969
 World of Warcraft Addon Data:
   type: data
   extensions:

--- a/samples/Wollok/pepita.wlk
+++ b/samples/Wollok/pepita.wlk
@@ -1,0 +1,41 @@
+object pepita {
+	var energia = 100
+	var ubicacion = 0
+
+	method energia() = energia
+
+	method volar(km) {
+		console.println("")
+		energia -= (2 * km) + 10
+	}
+
+	method comer(comida) {
+		energia += comida.energia()
+	}
+
+	method ubicacion() = ubicacion
+
+	method volarA(lugar) {
+		energia -= ubicacion - lugar.ubicacion()
+		ubicacion = lugar.ubicacion()
+	}
+
+	method puedeIrA(lugar) {
+
+	}
+
+}
+
+object alpiste {
+	const energia = 10
+
+	method energia() = energia
+}
+
+object pepona {
+	var property energia = 50
+
+	method comer(comida) {
+		energia += comida.energia()
+	}
+}

--- a/samples/Wollok/piratas.wlk
+++ b/samples/Wollok/piratas.wlk
@@ -1,0 +1,63 @@
+class Pirata {
+	const items = []
+	var dinero
+	var nivelEbriedad
+
+	constructor(itemsPirata) {
+		items = itemsPirata
+	}
+
+	method items() {
+		return items
+	}
+
+	method dinero() {
+		return dinero
+	}
+
+	method nivelEbriedad() {
+		return nivelEbriedad
+	}
+}
+
+class PirataAbstemio inherits Pirata {
+  override method nivelEbriedad() = 0
+}
+
+object buscarTesoro {
+	method puedeSerCumplidaPor(pirata) {
+		return (pirata.items().contains("brujula") || pirata.items().contains("mapa") || pirata.items().contains("botellaGrogXD")) &&
+			(pirata.dinero() <= 5) && (pirata.nivelEbriedad() < 3)
+	}
+}
+
+object serLeyenda {
+	const itemObligatorio = "dienteDeOro"
+
+	method puedeSerCumplidaPor(pirata) {
+		return pirata.items().size() == 7 && pirata.items().contains(itemObligatorio)
+	}
+
+}
+
+object saquear {
+	//var victima = barcoPirata
+	//var saqueador = barcoPirata2
+	var cantidadDeDineroMaxima = 5
+
+	method puedeSerCumplidaPor(pirata) {
+		//return pirata.dinero() < cantidadDeDineroMaxima && victima.esVulnerablePara(pirata)
+	}
+}
+
+object main {
+
+	var p = new Pirata(["brujula", "cuchillo", "cuchillo"])
+	//var barco = new Barco()
+
+	method p() {
+		return p
+	}
+
+
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -410,6 +410,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **WebAssembly:** [Alhadis/language-webassembly](https://github.com/Alhadis/language-webassembly)
 - **WebIDL:** [andik/IDL-Syntax](https://github.com/andik/IDL-Syntax)
 - **Windows Registry Entries:** [bsara/language-reg](https://github.com/bsara/language-reg)
+- **Wollok:** [uqbar-project/wollok-sublime](https://github.com/uqbar-project/wollok-sublime)
 - **World of Warcraft Addon Data:** [nebularg/language-toc-wow](https://github.com/nebularg/language-toc-wow)
 - **X BitMap:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **X Font Directory Index:** [Alhadis/language-fontforge](https://github.com/Alhadis/language-fontforge)

--- a/vendor/licenses/grammar/wollok-sublime.txt
+++ b/vendor/licenses/grammar/wollok-sublime.txt
@@ -1,0 +1,27 @@
+---
+type: grammar
+name: wollok-sublime
+version: ea080619a46d08759e1cce7536c1019e031ed754
+license: mit
+---
+MIT License
+
+Copyright (c) 2019 Uqbar Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Two years after the last try (https://github.com/github/linguist/pull/3764), a new attempt to add Wollok as a language, honoring @pchaigno's and @lildude's suggestions.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension: [.wlk](https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Awlk+method+NOT+nothack)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      * https://github.com/wollok/multipepita
      * https://github.com/wollok/yaaar
    - Sample license(s): MIT
  - [x] I have included a syntax highlighting grammar: [example](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fuqbar-project%2Fwollok-sublime%2Fmaster%2Fwollok.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fwollok%2Fyaaar%2Fmaster%2Fyaaar%2Fsrc%2Fmisiones.wlk&code=)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.