### PR TITLE
Add Carp language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -473,6 +473,9 @@
 [submodule "vendor/grammars/language-blade"]
 	path = vendor/grammars/language-blade
 	url = https://github.com/jawee/language-blade
+[submodule "vendor/grammars/language-carp"]
+	path = vendor/grammars/language-carp
+	url = https://github.com/GrayJack/language-carp
 [submodule "vendor/grammars/language-click"]
 	path = vendor/grammars/language-click
 	url = https://github.com/stenverbois/language-click.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -389,6 +389,8 @@ vendor/grammars/language-batchfile:
 - source.batchfile
 vendor/grammars/language-blade:
 - text.html.php.blade
+vendor/grammars/language-carp:
+- source.carp
 vendor/grammars/language-click:
 - source.click
 vendor/grammars/language-clojure:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -654,7 +654,7 @@ Cap'n Proto:
   language_id: 52
 Carp:
   type: programming
-  color: "#ef7f75"
+  color: "#ac330f"
   extensions:
   - ".carp"
   tm_scope: source.carp

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -559,6 +559,14 @@ C2hs Haskell:
   codemirror_mode: haskell
   codemirror_mime_type: text/x-haskell
   language_id: 45
+Carp:
+  type: programming
+  color: "#ef7f75"
+  extensions:
+  - ".carp"
+  tm_scope: source.carp
+  ace_mode: text
+  language_id: 1020101850
 CLIPS:
   type: programming
   extensions:
@@ -4518,12 +4526,12 @@ SSH Config:
   type: data
   group: INI
   filenames:
-  - "ssh-config"
-  - "ssh_config"
-  - "sshconfig"
-  - "sshconfig.snip"
-  - "sshd-config"
-  - "sshd_config"
+  - ssh-config
+  - ssh_config
+  - sshconfig
+  - sshconfig.snip
+  - sshd-config
+  - sshd_config
   ace_mode: text
   tm_scope: source.ssh-config
   language_id: 554920715

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -559,14 +559,6 @@ C2hs Haskell:
   codemirror_mode: haskell
   codemirror_mime_type: text/x-haskell
   language_id: 45
-Carp:
-  type: programming
-  color: "#ef7f75"
-  extensions:
-  - ".carp"
-  tm_scope: source.carp
-  ace_mode: text
-  language_id: 1020101850
 CLIPS:
   type: programming
   extensions:
@@ -660,6 +652,14 @@ Cap'n Proto:
   - ".capnp"
   ace_mode: text
   language_id: 52
+Carp:
+  type: programming
+  color: "#ef7f75"
+  extensions:
+  - ".carp"
+  tm_scope: source.carp
+  ace_mode: text
+  language_id: 1020101850
 CartoCSS:
   type: programming
   aliases:

--- a/samples/Carp/guessing.carp
+++ b/samples/Carp/guessing.carp
@@ -1,0 +1,51 @@
+;; The number guessing game
+
+(use IO)
+(use Int)
+(use String)
+
+(Project.config "title" "Guessing")
+
+(def guessing true)
+(def answer 0)
+
+(defn start-new-game! []
+  (do (println "~ The Number Guessing Game ~")
+      (println "(Enter q to quit.)\n")
+
+      (set! guessing true)
+      (set! answer (random-between 1 100))
+
+      (print "Please enter a number between 1 - 99: ")))
+
+(defn exit! []
+  (do (println "Good bye...")
+      (set! guessing false)))
+
+(defn play-again? [user-input]
+  (if (= user-input "y\n") true false))
+
+(defn correct! []
+  (do (println "Correct!\n")
+      (print "Play again? (y/n): ")
+      (let [user-input (get-line)]
+        (if (play-again? &user-input)
+          (start-new-game!)
+          (exit!)))))
+
+(defn guess-again [low-or-high]
+  (do (println &(str* @"Too " @low-or-high @"."))
+      (print "\nPlease guess again: ")))
+
+(defn main []
+  (do (println "Seeding random number generator...\n")
+      (Random.seed-from (Double.from-int (System.time)))
+      (start-new-game!)
+      (while guessing
+        (let [user-input (get-line)
+              guessed-num (from-string &user-input)]
+          (if (= &user-input "q\n")
+            (exit!)
+            (cond (< guessed-num answer) (guess-again "low")
+                  (> guessed-num answer) (guess-again "high")
+                  (correct!)))))))

--- a/samples/Carp/hello.carp
+++ b/samples/Carp/hello.carp
@@ -1,0 +1,2 @@
+(defn main []
+  (IO.println "Hello World!"))

--- a/samples/Carp/reptile.carp
+++ b/samples/Carp/reptile.carp
@@ -1,0 +1,185 @@
+(use Int)
+(use Double)
+(use Array)
+
+(load "SDL.carp")
+(load "SDL_image.carp")
+
+(load "Vector.carp")
+(use Vector2)
+
+(Project.config "title" "Reptile")
+
+(deftype Snake
+    [body (Array (Vector2 Double))
+     dir SDL_Keycode
+     freeze Int
+     ])
+
+(use Snake)
+
+(deftype World
+    [snake Snake
+     human (Vector2 Double)
+     dead Bool])
+
+(use World)
+
+(def bg-col 120)
+(def grid-size 32)
+
+(defn draw-snake [rend snake]
+  (let [body-length (length (body snake))]
+    (for [i 0 body-length]
+      (let [part (nth (body snake) i)
+            x (* grid-size (to-int @(Vector2.x part)))
+            y (* grid-size (to-int @(Vector2.y part)))]
+        (if (= i 0)
+          (do
+            (SDL.set-render-draw-color rend 200 255 (+ 100 (* body-length 10)) 255)
+            (SDL.render-fill-rect rend (address (SDL.rect x y grid-size grid-size))))
+          (do
+            (SDL.set-render-draw-color rend 200 (+ 50 (* i (/ 200 body-length))) 100 255)
+            (SDL.render-fill-rect rend (address (SDL.rect x y grid-size grid-size)))))))))
+
+(defn draw-human [rend human]
+  (do
+    (SDL.set-render-draw-color rend 100 100 250 255)
+    (let [x (* grid-size (to-int @(Vector2.x human)))
+          y (* grid-size (to-int @(Vector2.y human)))]
+      (SDL.render-fill-rect rend (address (SDL.rect x y grid-size grid-size))))))
+
+(defn draw [rend world]
+  (do
+    (SDL.set-render-draw-blend-mode rend SDL.blend-mode-add)
+    (SDL.set-render-draw-color rend (- bg-col @(Snake.freeze (World.snake world))) bg-col bg-col 255)
+    (SDL.render-clear rend)
+    (draw-snake rend (snake world))
+    (draw-human rend (World.human world))
+    (SDL.render-present rend)
+    ))
+
+(def input-dir SDL.Keycode.down)
+(def reset false)
+
+(defn handle-events [app rend world]
+  (let [event (SDL.Event.init)]
+    (while (SDL.Event.poll (address event))
+      (let [et (SDL.Event.type &event)]
+        (cond (= et SDL.Event.quit) (SDLApp.stop app)
+              (= et SDL.Event.key-down) (let [key (SDL.Event.keycode &event)]
+                                          (cond
+                                            (or (= key SDL.Keycode.right)
+                                                (or (= key SDL.Keycode.up)
+                                                    (or (= key SDL.Keycode.left) (= key SDL.Keycode.down))))
+                                            (set! input-dir key)
+                                            (= key SDL.Keycode.return) (set! reset true)
+                                            (= key SDL.Keycode.escape) (SDLApp.stop app)
+                                            ()))
+              ()
+              )))))
+
+(defn move [vec dir]
+  (cond
+    (= SDL.Keycode.right dir) (add &vec &(Vector2.init 1.0 0.0))
+    (= SDL.Keycode.up dir)    (add &vec &(Vector2.init 0.0 -1.0))
+    (= SDL.Keycode.left dir)  (add &vec &(Vector2.init -1.0 0.0))
+    (= SDL.Keycode.down dir)  (add &vec &(Vector2.init 0.0 1.0))
+    vec))
+
+(defn shift-body [body]
+  (do
+     (let [i (- (length body) 2)]
+       (while (> i -1)
+         (do
+           (aset! body (inc i) @(nth body i))
+           (set! i (dec i)))))
+    @body))
+
+(defn create-human []
+  (Vector2.init (from-int (random-between 0 26))
+                (from-int (random-between 0 20))))
+
+(defn kill-human [world]
+  (let [new-human (create-human)]
+    (World.set-human world new-human)))
+
+(defn inc2 [i]
+  (+ i 2))
+
+(defn grow [snake]
+  (let [new-snake (Snake.update-freeze snake &inc2)
+        b (Snake.body &new-snake)]
+    (Snake.set-body new-snake (push-back @b (unsafe-last b)))))
+
+(defn update-after-kill [world]
+  (let [s (World.snake &world)
+        new-world (kill-human world)]
+    (World.set-snake new-world (grow @s))))
+
+(defn check-for-kill [world]
+  (let [s (World.snake world)
+        h (World.human world)
+        b (Snake.body s)
+        head &(unsafe-first b)]
+    (if (= head h)
+      (update-after-kill @world)
+      @world)))
+
+(defn check-world [world]
+  (let [snake (World.snake world)
+        b (Snake.body snake)
+        head &(unsafe-first b)
+        x @(Vector2.x head)
+        y @(Vector2.y head)]
+    (World.set-dead @world (or (< x 0.0)
+                           (or (> x 26.0)
+                           (or (< y 0.0) (> y 24.0)))))))
+
+(defn tick [world]
+  (let [s (Snake.set-dir @(World.snake world) input-dir)
+        b (Snake.body &s)
+        new-head (move @(nth b 0) @(dir &s))
+        new-body (aset (shift-body b) 0 new-head)
+        new-snake (Snake.set-body s new-body)
+        world-after-snake-move (World.set-snake @world new-snake)
+        world-checked (check-world &world-after-snake-move)]
+    (check-for-kill &world-checked)))
+
+(defn create-world []
+  (World.init (Snake.init [(Vector2.init 10.0 10.0)
+                           (Vector2.init 9.0 10.0)
+                           (Vector2.init 8.0 10.0)
+                           (Vector2.init 7.0 10.0)]
+                          SDL.Keycode.down
+                          0)
+               (create-human)
+               false))
+
+(defn render-dead [rend]
+  (do
+    (SDL.set-render-draw-blend-mode rend SDL.blend-mode-add)
+    (SDL.set-render-draw-color rend 200 90 90 255)
+    (SDL.render-clear rend)
+    (SDL.render-present rend)
+    (SDL.delay 2000)
+  ))
+
+(defn main []
+  (let [app (SDLApp.create "R E P T I L E" 832 640)
+        rend @(SDLApp.renderer &app)
+        world (create-world)]
+    (do
+      (while (not @(World.dead &world))
+        (if reset
+          (do
+            (set! input-dir SDL.Keycode.right)
+            (set! world (create-world))
+            (set! reset false))
+          (do
+            (let [new-world (tick &world)]
+              (set! world new-world))
+            (handle-events &app rend &world)
+            (draw rend &world)
+            (SDL.delay 50))))
+       (render-dead rend))))

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -58,6 +58,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **CSS:** [atom/language-css](https://github.com/atom/language-css)
 - **Cabal Config:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
 - **Cap'n Proto:** [textmate/capnproto.tmbundle](https://github.com/textmate/capnproto.tmbundle)
+- **Carp:** [GrayJack/language-carp](https://github.com/GrayJack/language-carp)
 - **CartoCSS:** [yohanboniface/carto-atom](https://github.com/yohanboniface/carto-atom)
 - **Ceylon:** [jeancharles-roger/ceylon-sublimetext](https://github.com/jeancharles-roger/ceylon-sublimetext)
 - **Chapel:** [chapel-lang/chapel-tmbundle](https://github.com/chapel-lang/chapel-tmbundle)

--- a/vendor/licenses/grammar/language-carp.txt
+++ b/vendor/licenses/grammar/language-carp.txt
@@ -1,0 +1,27 @@
+---
+type: grammar
+name: language-carp
+version: 1842e4b505fe66f1a7d4638f758930a804ebe05b
+license: mit
+---
+MIT License
+
+Copyright (c) 2019 GrayJack
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR adds syntax support for the [Carp programming language](https://github.com/carp-lang/carp/)!

I’m guessing Carp is not popular enough as of yet (Harvest shows a measly 63 unique repositories by just 23 people); people seem to be excited about the language, but not using it enough just yet! I’ve done the work for adding the language anyway, understanding that you’ll defer merging this.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Acarp+KEYWORDS+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): [from the Carp compiler source](https://github.com/carp-lang/Carp/tree/master/examples)
    - Sample license(s): APache
  - [x] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

Cheers