### PR TITLE
Add support for WebVTT files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -638,6 +638,9 @@
 [submodule "vendor/grammars/language-viml"]
 	path = vendor/grammars/language-viml
 	url = https://github.com/Alhadis/language-viml
+[submodule "vendor/grammars/language-vtt"]
+	path = vendor/grammars/language-vtt
+	url = https://github.com/weizhenye/language-vtt
 [submodule "vendor/grammars/language-wavefront"]
 	path = vendor/grammars/language-wavefront
 	url = https://github.com/Alhadis/language-wavefront

--- a/grammars.yml
+++ b/grammars.yml
@@ -558,6 +558,8 @@ vendor/grammars/language-typelanguage:
 - source.tl
 vendor/grammars/language-viml:
 - source.viml
+vendor/grammars/language-vtt:
+- source.vtt
 vendor/grammars/language-wavefront:
 - source.wavefront.mtl
 - source.wavefront.obj

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4520,12 +4520,12 @@ SSH Config:
   type: data
   group: INI
   filenames:
-  - "ssh-config"
-  - "ssh_config"
-  - "sshconfig"
-  - "sshconfig.snip"
-  - "sshd-config"
-  - "sshd_config"
+  - ssh-config
+  - ssh_config
+  - sshconfig
+  - sshconfig.snip
+  - sshd-config
+  - sshd_config
   ace_mode: text
   tm_scope: source.ssh-config
   language_id: 554920715
@@ -5349,6 +5349,14 @@ WebIDL:
   codemirror_mode: webidl
   codemirror_mime_type: text/x-webidl
   language_id: 395
+WebVTT:
+  type: data
+  wrap: true
+  extensions:
+  - ".vtt"
+  tm_scope: source.vtt
+  ace_mode: text
+  language_id: 658679714
 Windows Registry Entries:
   type: data
   extensions:

--- a/samples/WebVTT/Godfather-Restaurant-Scene.vtt
+++ b/samples/WebVTT/Godfather-Restaurant-Scene.vtt
@@ -1,0 +1,159 @@
+WEBVTT Language: en-US
+
+01:20:37.600 --> 01:20:39.764
+<v McCluskey>How's the Italian food in this restaurant?
+
+01:20:39.804 --> 01:20:41.386
+<v Sollozzo>Good. Try the veal.
+
+01:20:41.427 --> 01:20:44.032
+- <v Sollozzo>It's the best in the city.</v>
+- <v McCluskey>I'll have it.</v>
+
+01:20:45.809 --> 01:20:47.009
+<v Sollozzo><lang it>Capide?</lang>
+<i.translation>[Understand?]</i>
+
+01:21:18.600 --> 01:21:21.370
+<v Sollozzo>I'm gonna speak Italian to Mike.
+
+01:21:21.371 --> 01:21:22.210
+<v McCluskey>Go ahead.
+
+NOTE
+The following translations were posted by two Italian YouTubers correcting
+a botched translation attempt of this scene: https://youtu.be/AKBcRU5tPco
+
+01:21:28.000 --> 01:21:29.381
+<v Sollozzo><lang scn>Mi dispiace—</lang>
+<i.translation>[I'm sorry about—]</i>
+
+<v Michael><lang scn>U Sai.</lang>
+<i.translation>[Forget it.]</i>
+
+01:21:33.182 --> 01:21:39.571
+<v Sollozzo><lang scn>Tu ai sapiri ca chiddu che e' successo tra mi e tu' padri fu una cosa di "bizunis".</lang>
+<i.translation>[You know what happened between me and your father was just business?]</i>
+
+01:21:40.612 --> 01:21:43.593
+<v Sollozzo><lang scn>Eu aiu un grosso rispettu pi tu' padri</lang>
+<i.translation>[I have great respect for your father]</i>
+
+01:21:43.634 --> 01:21:47.033
+<v Sollozzo><lang scn>ma tu' padri pensa a l'antica e tu nun.</lang>
+<i.translation>but his way of thinking is old-fashioned.</i>
+
+01:21:48.013 --> 01:21:52.968
+<v Sollozzo><lang scn>Lo vo' capiri che eu sono un uomo di onore.</lang>
+<i.translation>[You have to understand that I am a man of honor.]</i>
+
+01:21:53.009 --> 01:21:57.969
+<v Michael><lang scn>Di sti' cosi, li sacciu.</lang>
+<i.translation>[Don't tell me these things. I know.]</i>
+
+01:21:58.010 --> 01:21:59.210
+<v Sollozzo><lang scn>Lo sai?</lang>
+<i.translation>[You know?]</i>
+
+01:22:10.782 --> 01:22:16.397
+<v Sollozzo><lang scn>E tu ai sapiri che eu ho auitato la famiglia Tataglia.</lang>
+<i.translation>[And you understand that I have helped the Tattaglia family.]</i>
+
+01:22:17.805 --> 01:22:21.807
+<v Sollozzo><lang scn>Io credu che ci potemu mettere in accordo.</lang>
+<i.translation>[I think we can come to an agreement.]</i>
+
+01:22:22.601 --> 01:22:24.393
+<v Sollozzo><lang scn>Io voglio pace</lang>
+<i.translation>[I want peace]</i>
+
+01:22:24.794 --> 01:22:27.747
+<v Sollozzo><lang scn>e lasciamo perdere cu tutti sti cazzati.</lang>
+<i.translation>[and we can drop all this crap.]</i>
+
+01:22:27.788 --> 01:22:29.588
+<v Michael><lang scn>Ma vogghiu ca...</lang>
+<i.translation>[But I want...]</i>
+
+01:22:31.401 --> 01:22:32.393
+<v Sollozzo><lang scn>Che?</lang>
+<i.translation>[What?]</i>
+
+01:22:34.007 --> 01:22:35.791
+<v Michael><lang scn>Come se dice...?</lang>
+<i.translation>[How do you say...?]</i>
+
+01:22:38.000 --> 01:22:39.809
+<v Michael>What I want...
+
+01:22:40.800 --> 01:22:42.994
+<v Michael>...what's most important to me...
+
+01:22:45.400 --> 01:22:49.392
+<v Michael>...is that I have a guarantee: no more attempts on my father's life.
+
+01:22:49.440 --> 01:22:53.799
+<v Sollozzo>What guarantees could I give you? I am the hunted one.
+
+01:22:54.000 --> 01:22:57.390
+<v Sollozzo>I missed my chance. You think too much of me, kid.
+
+01:22:57.440 --> 01:22:59.636
+<v Sollozzo>I'm not that clever.
+
+01:23:00.800 --> 01:23:03.216
+<v Sollozzo>All I want is a truce.
+
+01:23:09.400 --> 01:23:12.989
+<v Michael>I have to go to the bathroom. Is that all right?
+
+01:23:14.200 --> 01:23:17.392
+<v McCluskey>You gotta go, you gotta go.
+
+01:23:22.000 --> 01:23:23.759
+<v McCluskey>I frisked him. He's clean.
+
+01:23:23.800 --> 01:23:25.607
+<v Sollozzo>Don't take too long.
+
+01:23:28.800 --> 01:23:30.996
+<v McCluskey>I've frisked a thousand young punks.
+
+NOTE
+After Michael returns from the bathroom with a concealed firearm
+
+01:24:43.585 --> 01:24:45.391
+<v Sollozzo><lang scn>Ti senti megghiu?</lang>
+<i.translation>[You feel better?]</i>
+
+01:24:47.212 --> 01:24:49.145
+<v Sollozzo><lang scn>Micheluzzo, tu mi capisci, no?</lang>
+<i.translation>[Little Michael, you understand me, don't you?]</i>
+
+01:24:49.217 --> 01:24:51.818
+<v Sollozzo><lang scn>Si' Italiano come tu' padri.</lang>
+<i.translation>[You're Italian like your father.]</i>
+
+01:24:53.210 --> 01:24:55.588
+<v Sollozzo><lang scn>Tu' padri sta mali.</lang>
+<i.translation>[Your father is sick.]</i>
+
+01:24:57.188 --> 01:24:58.816
+<v Sollozzo><lang scn>Quando iddru sta megghiu</lang>
+<i.translation>[When he gets better]</i>
+
+NOTE (The word after "megghiu" was too unclear for the Sicilian translator to make out)
+
+01:24:58.840 --> 01:25:01.440
+<v Sollozzo><lang scn>di fari un riunioni</lang>
+<i.translation>[we arrange a meeting]</i>
+
+01:25:01.465 --> 01:25:03.303
+<v Sollozzo><lang scn>e mettiamo tutto apposto.</lang>
+<i.translation>[and put everything in place.]</i>
+
+NOTE (Again, a few Sicilian words here were unintelligible.)
+
+01:25:04.397 --> 01:25:07.596
+<v Sollozzo><lang scn>Si deve finiri.</lang>
+<i.translation>[This foolishness must end.]</i>

--- a/samples/WebVTT/example.vtt
+++ b/samples/WebVTT/example.vtt
@@ -1,0 +1,43 @@
+WEBVTT Kind: captions; Language: en
+
+00:09.000 --> 00:11.000
+<v Roger Bingham>We are in New York City
+
+00:11.000 --> 00:13.000
+<v Roger Bingham>We are in New York City
+
+00:13.000 --> 00:16.000
+<v Roger Bingham>We're actually at the Lucern Hotel, just down the street
+
+00:16.000 --> 00:18.000
+<v Roger Bingham>from the American Museum of Natural History
+
+00:18.000 --> 00:20.000
+<v Roger Bingham>And with me is Neil deGrasse Tyson
+
+00:20.000 --> 00:22.000
+<v Roger Bingham>Astrophysicist, Director of the Hayden Planetarium
+
+00:22.000 --> 00:24.000
+<v Roger Bingham>at the AMNH.
+
+00:24.000 --> 00:26.000
+<v Roger Bingham>Thank you for walking down here.
+
+00:27.000 --> 00:30.000
+<v Roger Bingham>And I want to do a follow-up on the last conversation we did.
+
+00:30.000 --> 00:31.500 align:end size:50%
+<v Roger Bingham>When we e-mailed—
+
+00:30.500 --> 00:32.500 align:start size:50%
+<v Neil deGrasse Tyson>Didn't we talk about enough in that conversation?
+
+00:32.000 --> 00:35.500 align:end size:50%
+<v Roger Bingham>No! No no no no; 'cos 'cos obviously 'cos
+
+00:32.500 --> 00:33.500 align:start size:50%
+<v Neil deGrasse Tyson><i>Laughs</i>
+
+00:35.500 --> 00:38.000
+<v Roger Bingham>You know I'm so excited my glasses are falling off here.

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -412,6 +412,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Web Ontology Language:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)
 - **WebAssembly:** [Alhadis/language-webassembly](https://github.com/Alhadis/language-webassembly)
 - **WebIDL:** [andik/IDL-Syntax](https://github.com/andik/IDL-Syntax)
+- **WebVTT:** [weizhenye/language-vtt](https://github.com/weizhenye/language-vtt)
 - **Windows Registry Entries:** [bsara/language-reg](https://github.com/bsara/language-reg)
 - **Wollok:** [uqbar-project/wollok-sublime](https://github.com/uqbar-project/wollok-sublime)
 - **World of Warcraft Addon Data:** [nebularg/language-toc-wow](https://github.com/nebularg/language-toc-wow)

--- a/vendor/licenses/grammar/language-vtt.txt
+++ b/vendor/licenses/grammar/language-vtt.txt
@@ -1,0 +1,27 @@
+---
+type: grammar
+name: language-vtt
+version: a3e29f2006218645169e799a0f6588a9e56ec878
+license: mit
+---
+The MIT License (MIT)
+
+Copyright (c) 2016 Zhenye Wei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/licenses/grammar/language-vtt.txt
+++ b/vendor/licenses/grammar/language-vtt.txt
@@ -1,7 +1,7 @@
 ---
 type: grammar
 name: language-vtt
-version: a3e29f2006218645169e799a0f6588a9e56ec878
+version: d09adc8c98f4304836b1ecb99a953eb16492ee46
 license: mit
 ---
 The MIT License (MIT)


### PR DESCRIPTION
This PR adds support for [WebVTT files](https://en.wikipedia.org/wiki/WebVTT), a standardised web format for video captions and subtitles.

## Description
This PR is pretty self-explanatory. W3C specification, unambiguous, and no conflicting file extensions. In-the-wild usage is healthy with around [~607,234 results](https://github.com/search?q=extension%3Avtt+NOT+nothack&type=Code). Out of the [2,939 `.vtt` files](https://github.com/Alhadis/Silos/blob/vtt/urls.txt) I captured with Harvester, [only 14](https://github.com/Alhadis/Silos/tree/vtt/files-without-vtt-header) lacked the characteristic `WEBVTT` header, and most of those appear to be fixtures for VTT regression tests.

## Checklist:
- [x] **I am adding a new language.**
	- [x] **The extension of the new language is used in hundreds of repositories on GitHub.com.**
		- [~607,234 in-the-wild `.vtt` files](https://github.com/search?q=extension%3Avtt+NOT+nothack&type=Code)
	- [x] **I have included a real-world usage sample for all extensions added in this PR:**
		- [`example.vtt`](https://github.com/github/linguist/blob/aafe1d7ad163f4619098d4116b1e55b8a4bd3564/samples/WebVTT/example.vtt): Taken from the more-or-less believable example on [Wikipedia](https://en.wikipedia.org/wiki/WebVTT#Example_of_WebVTT_format) and the [specification itself](https://w3c.github.io/webvtt/#introduction-caption).
		- [`Godfather-Restaurant-Scene.vtt`](https://github.com/github/linguist/blob/aafe1d7ad163f4619098d4116b1e55b8a4bd3564/samples/WebVTT/Godfather-Restaurant-Scene.vtt): Compiled by yours truly using actual dialogue from a [particularly memorable scene](https://www.youtube.com/watch?v=VBl_gvTBO9g) from *The Godfather*. I made sure to use as many language elements as possible, including Sicilian translations provided by [Italian](https://www.youtube.com/watch?v=AKBcRU5tPco&lc=Ugiq4ESv3PMHgHgCoAEC) [YouTubers](https://www.youtube.com/watch?v=AKBcRU5tPco&lc=UgzjUAkBnbt7YS-W80d4AaABAg).
	- [x] **I have included a syntax highlighting grammar:**
		- [`weizhenye/language-vtt`](https://github.com/weizhenye/language-vtt): [MIT-licensed](https://github.com/weizhenye/language-vtt/blob/f451af4316eeabcd6a78f60478ff2e1ff9907497/LICENSE) | [Highlighting preview](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=cson&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fweizhenye%2Flanguage-vtt%2Fmaster%2Fgrammars%2Fvtt.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fgithub%2Flinguist%2Fblob%2Faafe1d7ad163f4619098d4116b1e55b8a4bd3564%2Fsamples%2FWebVTT%2FGodfather-Restaurant-Scene.vtt&code=)

I also just noticed the highlighted preview looks like crap in Lightshow for some reason (it didn't in Atom). Will send the author a pull-request shortly.