### PR TITLE
Add Dhall language support.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1074,6 +1074,16 @@ DataWeave:
   ace_mode: text
   tm_scope: source.data-weave
   language_id: 974514097
+Dhall:
+  type: programming
+  color: "#dfafff"
+  extensions:
+  - ".dhall"
+  tm_scope: source.haskell
+  ace_mode: haskell
+  codemirror_mode: haskell
+  codemirror_mime_type: text/x-haskell
+  language_id: 793969321
 Diff:
   type: data
   extensions:

--- a/samples/Dhall/largeExpressionA.dhall
+++ b/samples/Dhall/largeExpressionA.dhall
@@ -1,0 +1,254 @@
+  λ ( xs
+    : List
+      { cores             : Natural
+      , host              : Text
+      , key               : Text
+      , mandatoryFeatures : List Text
+      , platforms         :
+          List
+          < AArch64_Linux  : {}
+          | ARMv5tel_Linux : {}
+          | ARMv7l_Linux   : {}
+          | I686_Cygwin    : {}
+          | I686_Linux     : {}
+          | MIPS64el_Linux : {}
+          | PowerPC_Linux  : {}
+          | X86_64_Cygwin  : {}
+          | X86_64_Darwin  : {}
+          | X86_64_FreeBSD : {}
+          | X86_64_Linux   : {}
+          | X86_64_Solaris : {}
+          >
+      , speedFactor       : Natural
+      , supportedFeatures : List Text
+      , user              : Optional Text
+      }
+    )
+→ List/fold
+  { cores             : Natural
+  , host              : Text
+  , key               : Text
+  , mandatoryFeatures : List Text
+  , platforms         :
+      List
+      < AArch64_Linux  : {}
+      | ARMv5tel_Linux : {}
+      | ARMv7l_Linux   : {}
+      | I686_Cygwin    : {}
+      | I686_Linux     : {}
+      | MIPS64el_Linux : {}
+      | PowerPC_Linux  : {}
+      | X86_64_Cygwin  : {}
+      | X86_64_Darwin  : {}
+      | X86_64_FreeBSD : {}
+      | X86_64_Linux   : {}
+      | X86_64_Solaris : {}
+      >
+  , speedFactor       : Natural
+  , supportedFeatures : List Text
+  , user              : Optional Text
+  }
+  xs
+  Text
+  (   λ ( x
+        : { cores             : Natural
+          , host              : Text
+          , key               : Text
+          , mandatoryFeatures : List Text
+          , platforms         :
+              List
+              < AArch64_Linux  : {}
+              | ARMv5tel_Linux : {}
+              | ARMv7l_Linux   : {}
+              | I686_Cygwin    : {}
+              | I686_Linux     : {}
+              | MIPS64el_Linux : {}
+              | PowerPC_Linux  : {}
+              | X86_64_Cygwin  : {}
+              | X86_64_Darwin  : {}
+              | X86_64_FreeBSD : {}
+              | X86_64_Linux   : {}
+              | X86_64_Solaris : {}
+              >
+          , speedFactor       : Natural
+          , supportedFeatures : List Text
+          , user              : Optional Text
+          }
+        )
+    → λ(y : Text)
+    →     (     Optional/fold
+                Text
+                x.user
+                Text
+                (λ(user : Text) → user ++ "@" ++ x.host ++ "")
+                x.host
+            ++  " "
+            ++  ( merge
+                  { Empty    = λ(_ : {}) → ""
+                  , NonEmpty = λ(result : Text) → result
+                  }
+                  ( List/fold
+                    < AArch64_Linux  : {}
+                    | ARMv5tel_Linux : {}
+                    | ARMv7l_Linux   : {}
+                    | I686_Cygwin    : {}
+                    | I686_Linux     : {}
+                    | MIPS64el_Linux : {}
+                    | PowerPC_Linux  : {}
+                    | X86_64_Cygwin  : {}
+                    | X86_64_Darwin  : {}
+                    | X86_64_FreeBSD : {}
+                    | X86_64_Linux   : {}
+                    | X86_64_Solaris : {}
+                    >
+                    x.platforms
+                    < Empty : {} | NonEmpty : Text >
+                    (   λ ( element
+                          : < AArch64_Linux  : {}
+                            | ARMv5tel_Linux : {}
+                            | ARMv7l_Linux   : {}
+                            | I686_Cygwin    : {}
+                            | I686_Linux     : {}
+                            | MIPS64el_Linux : {}
+                            | PowerPC_Linux  : {}
+                            | X86_64_Cygwin  : {}
+                            | X86_64_Darwin  : {}
+                            | X86_64_FreeBSD : {}
+                            | X86_64_Linux   : {}
+                            | X86_64_Solaris : {}
+                            >
+                          )
+                      → λ(status : < Empty : {} | NonEmpty : Text >)
+                      → merge
+                        { Empty    =
+                              λ(_ : {})
+                            → < Empty : {} | NonEmpty : Text >.NonEmpty (
+                                  merge
+                                  { AArch64_Linux  = λ(_ : {}) → "aarch64-linux"
+                                  , ARMv5tel_Linux =
+                                      λ(_ : {}) → "armv5tel-linux"
+                                  , ARMv7l_Linux   = λ(_ : {}) → "armv7l-linux"
+                                  , I686_Cygwin    = λ(_ : {}) → "i686-cygwin"
+                                  , I686_Linux     = λ(_ : {}) → "i686-linux"
+                                  , MIPS64el_Linux =
+                                      λ(_ : {}) → "mips64el-linux"
+                                  , PowerPC_Linux  = λ(_ : {}) → "powerpc-linux"
+                                  , X86_64_Cygwin  = λ(_ : {}) → "x86_64-cygwin"
+                                  , X86_64_Darwin  = λ(_ : {}) → "x86_64-darwin"
+                                  , X86_64_FreeBSD =
+                                      λ(_ : {}) → "x86_64-freebsd"
+                                  , X86_64_Linux   = λ(_ : {}) → "x86_64-linux"
+                                  , X86_64_Solaris =
+                                      λ(_ : {}) → "x86_64-solaris"
+                                  }
+                                  element
+                              )
+                        , NonEmpty =
+                              λ(result : Text)
+                            → < Empty : {} | NonEmpty : Text >.NonEmpty (
+                                      ( merge
+                                        { AArch64_Linux  =
+                                            λ(_ : {}) → "aarch64-linux"
+                                        , ARMv5tel_Linux =
+                                            λ(_ : {}) → "armv5tel-linux"
+                                        , ARMv7l_Linux   =
+                                            λ(_ : {}) → "armv7l-linux"
+                                        , I686_Cygwin    =
+                                            λ(_ : {}) → "i686-cygwin"
+                                        , I686_Linux     =
+                                            λ(_ : {}) → "i686-linux"
+                                        , MIPS64el_Linux =
+                                            λ(_ : {}) → "mips64el-linux"
+                                        , PowerPC_Linux  =
+                                            λ(_ : {}) → "powerpc-linux"
+                                        , X86_64_Cygwin  =
+                                            λ(_ : {}) → "x86_64-cygwin"
+                                        , X86_64_Darwin  =
+                                            λ(_ : {}) → "x86_64-darwin"
+                                        , X86_64_FreeBSD =
+                                            λ(_ : {}) → "x86_64-freebsd"
+                                        , X86_64_Linux   =
+                                            λ(_ : {}) → "x86_64-linux"
+                                        , X86_64_Solaris =
+                                            λ(_ : {}) → "x86_64-solaris"
+                                        }
+                                        element
+                                      )
+                                  ++  ","
+                                  ++  result
+                              )
+                        }
+                        status
+                        : < Empty : {} | NonEmpty : Text >
+                    )
+                   (< Empty : {} | NonEmpty : Text >.Empty {=})
+                  )
+                  : Text
+                )
+            ++  " "
+            ++  x.key
+            ++  " "
+            ++  Integer/show (Natural/toInteger x.cores)
+            ++  " "
+            ++  Integer/show (Natural/toInteger x.speedFactor)
+            ++  " "
+            ++  ( merge
+                  { Empty    = λ(_ : {}) → ""
+                  , NonEmpty = λ(result : Text) → result
+                  }
+                  ( List/fold
+                    Text
+                    x.supportedFeatures
+                    < Empty : {} | NonEmpty : Text >
+                    (   λ(element : Text)
+                      → λ(status : < Empty : {} | NonEmpty : Text >)
+                      → merge
+                        { Empty    =
+                            λ(_ : {}) →
+                            (< Empty : {} | NonEmpty : Text >.NonEmpty element)
+                        , NonEmpty =
+                              λ(result : Text)
+                            → < Empty : {} | NonEmpty : Text >.NonEmpty (
+                                  element ++ "," ++ result
+                              )
+                        }
+                        status
+                        : < Empty : {} | NonEmpty : Text >
+                    )
+                   (< Empty : {} | NonEmpty : Text >.Empty {=})
+                  )
+                  : Text
+                )
+            ++  " "
+            ++  ( merge
+                  { Empty    = λ(_ : {}) → ""
+                  , NonEmpty = λ(result : Text) → result
+                  }
+                  ( List/fold
+                    Text
+                    x.mandatoryFeatures
+                    < Empty : {} | NonEmpty : Text >
+                    (   λ(element : Text)
+                      → λ(status : < Empty : {} | NonEmpty : Text >)
+                      → merge
+                        { Empty    =
+                            λ(_ : {}) →
+                            < Empty : {} | NonEmpty : Text >.NonEmpty element
+                        , NonEmpty =
+                              λ(result : Text)
+                            → < Empty : {} | NonEmpty : Text >.NonEmpty (
+                                  element ++ "," ++ result
+                              )
+                        }
+                        status
+                        : < Empty : {} | NonEmpty : Text >
+                    )
+                   (< Empty : {} | NonEmpty : Text >.Empty {=})
+                  )
+                  : Text
+                )
+            ++  "\n"
+          )
+      ++  y
+  )
+  ""

--- a/samples/Dhall/remoteSystemsA.dhall
+++ b/samples/Dhall/remoteSystemsA.dhall
@@ -1,0 +1,52 @@
+let Text/concatMap = ../../../Prelude/Text/concatMap
+
+let Text/concatSep = ../../../Prelude/Text/concatSep
+
+let Row =
+      { cores :
+          Natural
+      , host :
+          Text
+      , key :
+          Text
+      , mandatoryFeatures :
+          List Text
+      , platforms :
+          List Text
+      , speedFactor :
+          Natural
+      , supportedFeatures :
+          List Text
+      , user :
+          Optional Text
+      }
+
+let renderRow =
+        λ ( row
+          : Row
+          )
+      → let host =
+              Optional/fold
+              Text
+              row.user
+              Text
+              (λ(user : Text) → "${user}@${row.host}")
+              row.host
+        
+        let platforms = Text/concatSep "," row.platforms
+        
+        let key = row.key
+        
+        let cores = Integer/show (Natural/toInteger row.cores)
+        
+        let speedFactor = Integer/show (Natural/toInteger row.speedFactor)
+        
+        let supportedFeatures = Text/concatSep "," row.supportedFeatures
+        
+        let mandatoryFeatures = Text/concatSep "," row.mandatoryFeatures
+        
+        in  ''
+            ${host} ${platforms} ${key} ${cores} ${speedFactor} ${supportedFeatures} ${mandatoryFeatures}
+            ''
+
+in  Text/concatMap Row renderRow

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -95,6 +95,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **DTrace:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **Dart:** [dart-atom/dartlang](https://github.com/dart-atom/dartlang)
 - **DataWeave:** [mulesoft-labs/data-weave-tmLanguage](https://github.com/mulesoft-labs/data-weave-tmLanguage)
+- **Dhall:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
 - **Diff:** [textmate/diff.tmbundle](https://github.com/textmate/diff.tmbundle)
 - **Dockerfile:** [asbjornenge/Docker.tmbundle](https://github.com/asbjornenge/Docker.tmbundle)
 - **Dylan:** [textmate/dylan.tmbundle](https://github.com/textmate/dylan.tmbundle)


### PR DESCRIPTION
Fixes dhall-lang/dhall-lang#198.

There’s not yet a Dhall grammar in a supported format, so it uses Haskell for now.

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Adhall+NOT+nothack
      - here are Harvester results:
        - Unique repos: 489
        - Unique users: 314
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/dhall-lang/dhall-lang/blob/master/tests/parser/success/largeExpressionA.dhall
      - https://github.com/dhall-lang/dhall-lang/blob/master/tests/normalization/success/remoteSystemsA.dhall
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.