### PR TITLE
Lazy load samples cache until Classifier is used

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -505,8 +505,9 @@ module Linguist
     end
   end
 
-  extensions   = Samples.cache['extnames']
-  interpreters = Samples.cache['interpreters']
+  samples      = Samples.load_samples
+  extensions   = samples['extnames']
+  interpreters = samples['interpreters']
   popular      = YAML.load_file(File.expand_path("../popular.yml", __FILE__))
 
   languages_yml  = File.expand_path("../languages.yml",  __FILE__)

--- a/lib/linguist/samples.rb
+++ b/lib/linguist/samples.rb
@@ -17,12 +17,15 @@ module Linguist
     # Path for serialized samples db
     PATH = File.expand_path('../samples.json', __FILE__)
 
-    # Hash of serialized samples object
+    # Hash of serialized samples object, cached in memory
     def self.cache
-      @cache ||= begin
-        serializer = defined?(Yajl) ? Yajl : YAML
-        serializer.load(File.read(PATH, encoding: 'utf-8'))
-      end
+      @cache ||= load_samples
+    end
+
+    # Hash of serialized samples object, uncached
+    def self.load_samples
+      serializer = defined?(Yajl) ? Yajl : YAML
+      serializer.load(File.read(PATH, encoding: 'utf-8'))
     end
 
     # Public: Iterate over each sample.


### PR DESCRIPTION
samples.json is a very large (3.7M) json file, which allocates 183209 ruby strings, which takes 8.2MB of memory according to memsize_of.

Instead of keeping the cache around when loading language.rb, we can instead just load the JSON and allow it to be GC'd after we use it. Cache will still be used if the Classifier is invoked.