### PR TITLE
Force name to be string when looking up mime type

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -26,7 +26,7 @@ module Linguist
       File.extname(name.to_s)
     end
 
-    # Internal: Lookup mime type for extension.
+    # Internal: Lookup mime type for filename.
     #
     # Returns a MIME::Type
     def _mime_type

--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -33,7 +33,7 @@ module Linguist
       if defined? @_mime_type
         @_mime_type
       else
-        @_mime_type = MiniMime.lookup_by_filename(name)
+        @_mime_type = MiniMime.lookup_by_filename(name.to_s)
       end
     end
 

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -49,6 +49,9 @@ class TestFileBlob < Minitest::Test
     assert_equal "application/xml", sample_blob("XML/bar.xml").mime_type
     assert_equal "audio/ogg", fixture_blob("Binary/foo.ogg").mime_type
     assert_equal "text/plain", fixture_blob("Data/README").mime_type
+    # GitHub doesn't use a filename when returning raw blobs
+    blob = Struct.new(:name) { include Linguist::BlobHelper }
+    assert_equal "text/plain", blob.new(nil).mime_type
   end
 
   def test_content_type


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
https://github.com/github/linguist/pull/4531 switched a dependency from using mime-types to mini_mime but missed a scenario that didn't come up until I started testing the forth-coming v.7.5.0 release: `_mime_type()` will fail if `nil` is passed as the filename, as is the case when GitHub serves raw data.

This results in `MiniMime.lookup_by_filename(name)` failing with:

```
TypeError: no implicit conversion of nil into String
    /var/lib/jenkins/workspace/github/vendor/gems/2.6.2/ruby/2.6.0/gems/mini_mime-1.0.1/lib/mini_mime.rb:45:in `extname'
    /var/lib/jenkins/workspace/github/vendor/gems/2.6.2/ruby/2.6.0/gems/mini_mime-1.0.1/lib/mini_mime.rb:45:in `lookup_by_filename'
    /var/lib/jenkins/workspace/github/vendor/gems/2.6.2/ruby/2.6.0/gems/mini_mime-1.0.1/lib/mini_mime.rb:6:in `lookup_by_filename'
    /var/lib/jenkins/workspace/github/vendor/gems/2.6.2/ruby/2.6.0/gems/github-linguist-7.4.0.32.g7f67bc95/lib/linguist/blob_helper.rb:36:in `_mime_type'
    /var/lib/jenkins/workspace/github/vendor/gems/2.6.2/ruby/2.6.0/gems/github-linguist-7.4.0.32.g7f67bc95/lib/linguist/blob_helper.rb:56:in `binary_mime_type?'
    /var/lib/jenkins/workspace/github/vendor/gems/2.6.2/ruby/2.6.0/gems/github-linguist-7.4.0.32.g7f67bc95/lib/linguist/blob_helper.rb:79:in `content_type'
[...]
```

This PR fixes issue by forcing the name to always be a string, even if `nil`.

[ _Checklist removed as it doesn't apply_ ]

/cc @ksolo 