### PR TITLE
Register `DEPS` as a Python filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4001,6 +4001,7 @@ Python:
   - BUCK
   - BUILD
   - BUILD.bazel
+  - DEPS
   - SConscript
   - SConstruct
   - Snakefile

--- a/samples/Python/filenames/DEPS
+++ b/samples/Python/filenames/DEPS
@@ -1,0 +1,152 @@
+gclient_gn_args_file = 'src/build/config/gclient_args.gni'
+gclient_gn_args = [
+  'build_with_chromium',
+  'checkout_android',
+  'checkout_android_native_support',
+  'checkout_libaom',
+  'checkout_nacl',
+  'checkout_oculus_sdk'
+]
+
+vars = {
+  'chromium_version':
+    'f200986dfaabd6aad6a4b37dad7aae42fec349e9',
+  'node_version':
+    '229bd3245b2f54c12ea9ad0abcadbc209f8023dc',
+  'nan_version':
+    '960dd6c70fc9eb136efdf37b4bef18fadbc3436f',
+
+  'boto_version': 'f7574aa6cc2c819430c1f05e9a1a1a666ef8169b',
+  'pyyaml_version': '3.12',
+  'requests_version': 'e4d59bedfd3c7f4f254f4f5d036587bcd8152458',
+
+  'boto_git': 'https://github.com/boto',
+  'chromium_git': 'https://chromium.googlesource.com',
+  'electron_git': 'https://github.com/electron',
+  # FIXME: Once https://github.com/nodejs/nan/pull/857 lands this should point at nodejs/nan
+  'nodejs_git': 'https://github.com/marshallofsound',
+  'requests_git': 'https://github.com/kennethreitz',
+  'yaml_git': 'https://github.com/yaml',
+
+  # KEEP IN SYNC WITH utils.js FILE
+  'yarn_version': '1.15.2',
+
+  # To be able to build clean Chromium from sources.
+  'apply_patches': True,
+
+  # Python interface to Amazon Web Services. Is used for releases only.
+  'checkout_boto': False,
+
+  # To allow in-house builds to checkout those manually.
+  'checkout_chromium': True,
+  'checkout_node': True,
+  'checkout_nan': True,
+
+  # It's only needed to parse the native tests configurations.
+  'checkout_pyyaml': False,
+
+  # Python "requests" module is used for releases only.
+  'checkout_requests': False,
+
+  # To allow running hooks without parsing the DEPS tree
+  'process_deps': True,
+
+  # It is always needed for normal Electron builds,
+  # but might be impossible for custom in-house builds.
+  'download_external_binaries': True,
+
+  'checkout_nacl':
+    False,
+  'checkout_libaom':
+    True,
+  'checkout_oculus_sdk':
+    False,
+  'build_with_chromium':
+    True,
+  'checkout_android':
+    False,
+  'checkout_android_native_support':
+    False,
+}
+
+deps = {
+  'src': {
+    'url': (Var("chromium_git")) + '/chromium/src.git@' + (Var("chromium_version")),
+    'condition': 'checkout_chromium and process_deps',
+  },
+  'src/third_party/nan': {
+    'url': (Var("nodejs_git")) + '/nan.git@' + (Var("nan_version")),
+    'condition': 'checkout_nan and process_deps',
+  },
+  'src/third_party/electron_node': {
+    'url': (Var("electron_git")) + '/node.git@' + (Var("node_version")),
+    'condition': 'checkout_node and process_deps',
+  },
+  'src/electron/vendor/pyyaml': {
+    'url': (Var("yaml_git")) + '/pyyaml.git@' + (Var("pyyaml_version")),
+    'condition': 'checkout_pyyaml and process_deps',
+  },
+  'src/electron/vendor/boto': {
+    'url': Var('boto_git') + '/boto.git' + '@' +  Var('boto_version'),
+    'condition': 'checkout_boto and process_deps',
+  },
+  'src/electron/vendor/requests': {
+    'url': Var('requests_git') + '/requests.git' + '@' +  Var('requests_version'),
+    'condition': 'checkout_requests and process_deps',
+  },
+}
+
+hooks = [
+  {
+    'name': 'patch_chromium',
+    'condition': '(checkout_chromium and apply_patches) and process_deps',
+    'pattern': 'src/electron',
+    'action': [
+      'python',
+      'src/electron/script/apply_all_patches.py',
+      'src/electron/patches/config.json',
+    ],
+  },
+  {
+    'name': 'electron_external_binaries',
+    'pattern': 'src/electron/script/update-external-binaries.py',
+    'condition': 'download_external_binaries',
+    'action': [
+      'python',
+      'src/electron/script/update-external-binaries.py',
+    ],
+  },
+  {
+    'name': 'electron_npm_deps',
+    'pattern': 'src/electron/package.json',
+    'action': [
+      'python',
+      '-c',
+      'import os, subprocess; os.chdir(os.path.join("src", "electron")); subprocess.check_call(["python", "script/lib/npx.py", "yarn@' + (Var("yarn_version")) + '", "install", "--frozen-lockfile"]);',
+    ],
+  },
+  {
+    'name': 'setup_boto',
+    'pattern': 'src/electron',
+    'condition': 'checkout_boto and process_deps',
+    'action': [
+      'python',
+      '-c',
+      'import os, subprocess; os.chdir(os.path.join("src", "electron", "vendor", "boto")); subprocess.check_call(["python", "setup.py", "build"]);',
+    ],
+  },
+  {
+    'name': 'setup_requests',
+    'pattern': 'src/electron',
+    'condition': 'checkout_requests and process_deps',
+    'action': [
+      'python',
+      '-c',
+      'import os, subprocess; os.chdir(os.path.join("src", "electron", "vendor", "requests")); subprocess.check_call(["python", "setup.py", "build"]);',
+    ],
+  },
+]
+
+recursedeps = [
+  'src',
+]


### PR DESCRIPTION
This PR as support for [`DEPS` files](https://dev.chromium.org/developers/how-tos/depottools#TOC-DEPS-file), used by Google's build-chain for declaring dependencies. It's used by [Chromium](https://github.com/chromium/chromium/blob/7f31d076f0181e0b86912dab1d7f6440c9e168ef/DEPS) and related projects like [V8](https://github.com/v8/v8/blob/9764d98da6fe387b75503e16810901e8b9627d85/DEPS#L1), and in derived projects like [Electron](https://github.com/electron/electron/blob/370e9522b4641b973a082f15c4d866de6dbebf5f/DEPS).

## Description
A large handful of search-results were files whose names included `DEPS` or `deps` as a substring, so Harvester could only collect [1,000 "real" results](https://github.com/Alhadis/Silos/blob/134880a7bad68b8e9b45794fe0fe70c55f8de255/urls.log) (deduped to [222 unique files](https://github.com/Alhadis/Silos/tree/DEPS/files)). Even with that subsample, there were [677 unique repos](https://github.com/Alhadis/Silos/blob/134880a7bad68b8e9b45794fe0fe70c55f8de255/unique-repos.txt#L1) amongst [675 users](https://github.com/Alhadis/Silos/blob/134880a7bad68b8e9b45794fe0fe70c55f8de255/unique-users.txt#L1).

## Checklist:
- [x] **I am associating a language with a new file extension.**
	- [x] **The new extension is used in hundreds of repositories on GitHub.com**
		- Search results: [~2,034,099](https://github.com/search?q=filename%3ADEPS+NOT+nothack&type=Code) (but see above)
	- [x] **I have included a real-world usage sample for all extensions added in this PR:**
		- Source: [Electron](https://github.com/electron/electron/blob/370e9522b4641b973a082f15c4d866de6dbebf5f/DEPS)
		- License: [MIT](https://github.com/electron/electron/blob/master/LICENSE)
