### PR TITLE
Add Highlighting for Igor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -428,6 +428,9 @@
 [submodule "vendor/grammars/idris"]
 	path = vendor/grammars/idris
 	url = https://github.com/idris-hackers/idris-sublime.git
+[submodule "vendor/grammars/igor-linguist-syntax"]
+	path = vendor/grammars/igor-linguist-syntax
+	url = https://github.com/byte-physics/igor-linguist-syntax
 [submodule "vendor/grammars/ini.tmbundle"]
 	path = vendor/grammars/ini.tmbundle
 	url = https://github.com/textmate/ini.tmbundle

--- a/.gitmodules
+++ b/.gitmodules
@@ -428,9 +428,6 @@
 [submodule "vendor/grammars/idris"]
 	path = vendor/grammars/idris
 	url = https://github.com/idris-hackers/idris-sublime.git
-[submodule "vendor/grammars/igor-linguist-syntax"]
-	path = vendor/grammars/igor-linguist-syntax
-	url = https://github.com/byte-physics/igor-linguist-syntax
 [submodule "vendor/grammars/ini.tmbundle"]
 	path = vendor/grammars/ini.tmbundle
 	url = https://github.com/textmate/ini.tmbundle
@@ -539,6 +536,9 @@
 [submodule "vendor/grammars/language-html"]
 	path = vendor/grammars/language-html
 	url = https://github.com/atom/language-html
+[submodule "vendor/grammars/language-igor"]
+	path = vendor/grammars/language-igor
+	url = https://github.com/byte-physics/language-igor
 [submodule "vendor/grammars/language-inform7"]
 	path = vendor/grammars/language-inform7
 	url = https://github.com/erkyrath/language-inform7

--- a/grammars.yml
+++ b/grammars.yml
@@ -358,8 +358,6 @@ vendor/grammars/idl.tmbundle:
 - text.idl-idldoc
 vendor/grammars/idris:
 - source.idris
-vendor/grammars/igor-linguist-syntax:
-- source.igor
 vendor/grammars/ini.tmbundle:
 - source.ini
 vendor/grammars/io.tmbundle:
@@ -473,6 +471,8 @@ vendor/grammars/language-hql:
 - source.hql
 vendor/grammars/language-html:
 - text.html.basic
+vendor/grammars/language-igor:
+- source.igor
 vendor/grammars/language-inform7:
 - source.inform7
 vendor/grammars/language-javascript:

--- a/grammars.yml
+++ b/grammars.yml
@@ -358,6 +358,8 @@ vendor/grammars/idl.tmbundle:
 - text.idl-idldoc
 vendor/grammars/idris:
 - source.idris
+vendor/grammars/igor-linguist-syntax:
+- source.igor
 vendor/grammars/ini.tmbundle:
 - source.ini
 vendor/grammars/io.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2100,12 +2100,13 @@ IDL:
   language_id: 161
 IGOR Pro:
   type: programming
+  color: "#0000cc"
   extensions:
   - ".ipf"
   aliases:
   - igor
   - igorpro
-  tm_scope: none
+  tm_scope: source.igor
   ace_mode: text
   language_id: 162
 INI:

--- a/samples/IGOR Pro/CodeBrowser.ipf
+++ b/samples/IGOR Pro/CodeBrowser.ipf
@@ -1,0 +1,221 @@
+#pragma rtGlobals=3
+#pragma version=1.3
+#pragma IgorVersion = 6.3.0
+#pragma IndependentModule=CodeBrowserModule
+
+#include "CodeBrowser_gui"
+#include <Resize Controls>
+
+// Copyright (c) 2019, () byte physics support@byte-physics.de
+// All rights reserved.
+//
+// This source code is licensed under the BSD 3-Clause license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// source: https://github.com/byte-physics/igor-code-browser/blob/6a1497795f606d9d837d4012cbb4bbc481af3683/procedures/CodeBrowser.ipf
+
+Menu "CodeBrowser"
+	// CTRL+0 is the keyboard shortcut
+	"Open/0", /Q, CodeBrowserModule#CreatePanel()
+	"Reset", /Q, CodeBrowserModule#ResetPanel()
+End
+
+// Markers for the different listbox elements
+StrConstant strConstantMarker = "\\W539"
+StrConstant constantMarker    = "\\W534"
+
+Function addDecoratedStructure(text, declWave, lineWave, [parseVariables])
+	WAVE/T text
+	WAVE/T declWave
+	WAVE/D lineWave
+	Variable parseVariables
+	if(paramIsDefault(parseVariables) | parseVariables != 1)
+		parseVariables = 1 // added for debugging
+	endif
+
+	variable numLines, idx, numEntries, numMatches
+	string procText, reStart, name, StaticKeyword
+
+	Wave/T helpWave = getHelpWave()
+
+	// regexp: match case insensitive (?i) leading spaces don't matter. optional static statement. search for structure name which contains no spaces. followed by an optional space and nearly anything like inline comments
+	// help for regex on https://regex101.com/
+	reStart = "^(?i)[[:space:]]*((?:static[[:space:]])?)[[:space:]]*structure[[:space:]]+([^[:space:]\/]+)[[:space:]\/]?.*"
+	Grep/Q/INDX/E=reStart text
+	Wave W_Index
+	Duplicate/FREE W_Index wavStructureStart
+	KillWaves/Z W_Index
+	KillStrings/Z S_fileName
+	WaveClear W_Index
+	if(!V_Value) // no matches
+		return 0
+	endif
+	numMatches = DimSize(wavStructureStart, 0)
+
+	// optionally analyze structure elements
+	if(parseVariables)
+		// regexp: match case insensitive endstructure followed by (space or /) and anything else or just a lineend
+		// does not match endstructure23 but endstructure//
+		Grep/Q/INDX/E="^(?i)[[:space:]]*(?:endstructure(?:[[:space:]]|\/).*)|endstructure$" text
+		Wave W_Index
+		Duplicate/FREE W_Index wavStructureEnd
+		KillWaves/Z W_Index
+		KillStrings/Z S_fileName
+		WaveClear W_Index
+		if(numMatches != DimSize(wavStructureEnd, 0))
+			numMatches = 0
+			return 0
+		endif
+	endif
+
+	numEntries = DimSize(declWave, 0)
+	Redimension/N=(numEntries + numMatches, -1) declWave, lineWave, helpWave
+
+	for(idx = numEntries; idx < (numEntries + numMatches); idx +=1)
+		SplitString/E=reStart text[wavStructureStart[(idx - numEntries)]], StaticKeyword, name
+		declWave[idx][0] = createMarkerForType(LowerStr(StaticKeyword) + "structure") // no " " between static and structure needed
+		declWave[idx][1] = name
+
+		// optionally parse structure elements
+		if(parseVariables)
+			Duplicate/FREE/R=[(wavStructureStart[(idx - numEntries)]),(wavStructureEnd[(idx - numEntries)])] text, temp
+			declWave[idx][1] += getStructureElements(temp)
+			WaveClear temp
+		endif
+
+		lineWave[idx] = wavStructureStart[(idx - numEntries)]
+	endfor
+
+	WaveClear wavStructureStart, wavStructureEnd
+End
+
+/// @brief Return the text of the given procedure as free wave splitted at the EOL
+static Function/WAVE getProcedureTextAsWave(module, procedureWithoutModule)
+	string module, procedureWithoutModule
+
+	string procText
+	variable numLines
+
+	// get procedure code
+	procText = getProcedureText("", 0, module, procedureWithoutModule)
+
+#if (IgorVersion() >= 7.0)
+	return ListToTextWave(procText, "\r")
+#else
+	numLines = ItemsInList(procText, "\r")
+
+	if(numLines == 0)
+		Make/FREE/N=(numLines)/T wv
+		return wv
+	endif
+
+	Make/FREE/N=(numLines)/T wv = StringFromList(p, procText, "\r")
+	return wv
+#endif
+End
+
+// add basic html
+Function/S AddHTML(context)
+	string context
+
+	string line, html, re
+	string str0, str1, str2, str3, str4
+	variable n, lines
+
+	html = ""
+	lines = ItemsInList(context, "\r")
+	for(n = 0; n < lines; n += 1)
+		line = StringFromList(n, context, "\r")
+		re = "\s*([\/]{2,})\s?(.*)"
+		SplitString/E=(re) line, str0, str1
+		if(V_flag != 2)
+			break
+		endif
+		line = str1
+		if(strlen(str0) == 3) // Doxygen comments
+			re = "(?i)(.*@param(?:\[(?:in|out)\])?\s+)(\w+)(\s.*)"
+			SplitString/E=(re) line, str0, str1, str2
+			if(V_flag == 3)
+				line  = str0
+				line += "<b>" + str1 + "</b> "
+				line += str2
+			endif
+			re = "(?i)(.*)@(\w+)(\s.*)"
+			SplitString/E=(re) line, str0, str1, str2
+			if(V_flag == 3)
+				line  = str0
+				line += "<b>@</b><i>" + str1 + "</i>"
+				line += str2
+			endif
+		endif
+		html += line + "<br>"
+	endfor
+	html = RemoveEnding(html, "<br>")
+	html = "<code>" + html + "</code>"
+
+	return html
+End
+
+// get code of procedure in module
+//
+// see `DisplayHelpTopic("ProcedureText")`
+//
+// @param funcName       Name of Function. Leave blank to get full procedure text
+// @param linesOfContext line numbers in addition to the function definition. Set to @c 0 to return only the function.
+//                       set to @c -1 to return lines before the procedure that are not part of the preceding macro or function
+// @param module         independent module
+// @param procedure      procedure without module definition
+// @return multi-line string with function definition
+Function/S getProcedureText(funcName, linesOfContext, module, procedure)
+	string funcName, module, procedure
+	variable linesOfContext
+
+	if(!isProcGlobal(module))
+		debugPrint(procedure + " is not in ProcGlobal")
+		procedure = procedure + " [" + module + "]"
+	endif
+
+	return ProcedureText(funcName, linesOfContext, procedure)
+End
+
+// Returns a list of independent modules
+// Includes ProcGlobal but skips all WM modules and the current module in release mode
+Function/S getModuleList()
+	String moduleList
+
+	moduleList = IndependentModuleList(";")
+	moduleList = ListMatch(moduleList, "!WM*", ";") // skip WM modules
+	moduleList = ListMatch(moduleList, "!RCP*", ";") // skip WM's Resize Controls modul
+	String module = GetIndependentModuleName()
+
+	moduleList = "ProcGlobal;" + SortList(moduleList)
+
+	return moduleList
+End
+
+// get help wave: after parsing the function comment is stored here
+//
+// Return refrence to (text) Wave/T
+Function/Wave getHelpWave()
+	DFREF dfr = createDFWithAllParents(pkgFolder)
+	WAVE/Z/T/SDFR=dfr wv = $helpWave
+
+	if(!WaveExists(wv))
+		Make/T/N=(128, 2) dfr:$helpWave/Wave=wv
+	endif
+
+	return wv
+End
+
+static Structure procedure
+	String id
+	Variable row
+	String name
+	String module
+	String fullName
+Endstructure
+
+/// @brief compile all procedures
+Function compile()
+	Execute/P/Z/Q "COMPILEPROCEDURES "
+End

--- a/samples/IGOR Pro/functions.ipf
+++ b/samples/IGOR Pro/functions.ipf
@@ -28,7 +28,7 @@ Function CallOperationsAndBuiltInFuncs(string var)
 
 	string someDQString = "abcd"
 
-	Make/N=(1,2,3,4) myWave
+	Make/N=(1,2,3,4) root:myWave/WAVE=myWave
 	Redimension/N=(-1,-1,-1,5) myWave
 
 	print strlen(someDQString)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -175,7 +175,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **HolyC:** [codingdandy/holyc.tmbundle](https://github.com/codingdandy/holyc.tmbundle)
 - **Hy:** [Slowki/hy.tmLanguage](https://github.com/Slowki/hy.tmLanguage)
 - **IDL:** [mgalloy/idl.tmbundle](https://github.com/mgalloy/idl.tmbundle)
-- **IGOR Pro:** [byte-physics/igor-linguist-syntax](https://github.com/byte-physics/igor-linguist-syntax)
+- **IGOR Pro:** [byte-physics/language-igor](https://github.com/byte-physics/language-igor)
 - **INI:** [textmate/ini.tmbundle](https://github.com/textmate/ini.tmbundle)
 - **Idris:** [idris-hackers/idris-sublime](https://github.com/idris-hackers/idris-sublime)
 - **Ignore List:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -175,6 +175,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **HolyC:** [codingdandy/holyc.tmbundle](https://github.com/codingdandy/holyc.tmbundle)
 - **Hy:** [Slowki/hy.tmLanguage](https://github.com/Slowki/hy.tmLanguage)
 - **IDL:** [mgalloy/idl.tmbundle](https://github.com/mgalloy/idl.tmbundle)
+- **IGOR Pro:** [byte-physics/igor-linguist-syntax](https://github.com/byte-physics/igor-linguist-syntax)
 - **INI:** [textmate/ini.tmbundle](https://github.com/textmate/ini.tmbundle)
 - **Idris:** [idris-hackers/idris-sublime](https://github.com/idris-hackers/idris-sublime)
 - **Ignore List:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)

--- a/vendor/licenses/grammar/igor-linguist-syntax.txt
+++ b/vendor/licenses/grammar/igor-linguist-syntax.txt
@@ -1,0 +1,38 @@
+---
+type: grammar
+name: igor-linguist-syntax
+version: 9bf5cad5d604db6c52f12619f8bcdbc1bf9872c6
+license: bsd-3-clause
+---
+BSD 3-Clause License
+
+Copyright (c) 2012, User 741
+Copyright (c) 2017, Jeanine Adkisson, Matthias Kastner
+Copyright (c) 2017, Thomas Braun
+Copyright (c) 2019, () byte physics
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/licenses/grammar/language-igor.txt
+++ b/vendor/licenses/grammar/language-igor.txt
@@ -1,6 +1,6 @@
 ---
 type: grammar
-name: igor-linguist-syntax
+name: language-igor
 version: 9bf5cad5d604db6c52f12619f8bcdbc1bf9872c6
 license: bsd-3-clause
 ---


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
The [Igor Pro](https://www.wavemetrics.com/) Syntax Highlighting had been [added in 2013](https://github.com/github/linguist/pull/681) / [2014](https://github.com/github/linguist/pull/1376) and was removed when moving linguist to tm based highlighting due to missing `*.tmlanguage`
file.  The language recognition is still present but it currently does not highlight the code on github.

There was a [demand from the Igor programmers community](https://www.wavemetrics.com/forum/general/igor-procedure-syntax-highlighting-github#comment-form) pending since 2017 and also [stale issues here](https://github.com/github/linguist/issues/3713). 

There are [quite a few Projects on Github](https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Aipf+rtGlobals+NOT+nothack), although the language is very specific to the scientific community. As the program itself is not open source, there are also fewer spread Open Source projects. Nevertheless, it suffices the requirement for adding the language to linguist.

I have added a tm [syntax highlighting under BSD-3 on github](https://github.com/byte-physics/language-igor) so I think it is time to get the highlighting for Igor back to github.

<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: none
  - New: https://github.com/byte-physics/language-igor
- [ ] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Aipf+rtGlobals+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [example code](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fbyte-physics%2Flanguage-igor%2Fblob%2Fmaster%2Figorpro.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fbyte-physics%2Flinguist%2Fadd_igor%2Fsamples%2FIGOR%2520Pro%2FCodeBrowser.ipf&code=)
    - Sample license(s): BSD-3
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: 
    * [plotly](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fbyte-physics%2Flanguage-igor%2Fblob%2Fmaster%2Figorpro.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fplotly%2FIgor-Pro-Graph-Converter%2Fmaster%2Fsrc%2FPlotlyFunctions.ipf&code=)
    * [mies](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fbyte-physics%2Flanguage-igor%2Fblob%2Fmaster%2Figorpro.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2FAllenInstitute%2FMIES%2Fmaster%2FPackages%2FMIES%2FMIES_Utilities.ipf&code=)
    * [swnt](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fbyte-physics%2Flanguage-igor%2Fblob%2Fmaster%2Figorpro.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fukos-git%2Figor-swnt-plem%2Fmaster%2Fapp%2Fplem-main.ipf&code=)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.