### PR TITLE
Added Rōblox files to languages.yml

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4306,7 +4306,7 @@ Ring:
   ace_mode: text
   language_id: 431
 Roblox:
-  type: data
+  type: markup
   tm_scope: none
   ace_mode: text
   color: "#E2231A"
@@ -4315,8 +4315,10 @@ Roblox:
   - ".rbxm"
   language_id: 8292744 # In reference to the US patent number of the Roblox platform.
 Roblox XML:
-  type: data
-  tm_scope: none
+  type: markup
+  tm_scope: text.xml
+  codemirror_mode: xml
+  codemirror_mime_type: text/xml
   ace_mode: xml # New syntax highlighter should come later.
   color: "#E2231A"
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4313,18 +4313,6 @@ Roblox:
   extensions:
   - ".rbxl"
   - ".rbxm"
-  language_id: 8292744 # In reference to the US patent number of the Roblox platform.
-Roblox XML:
-  type: markup
-  tm_scope: text.xml
-  codemirror_mode: xml
-  codemirror_mime_type: text/xml
-  ace_mode: xml # New syntax highlighter should come later.
-  color: "#E2231A"
-  extensions:
-  - ".rbxlx"
-  - ".rbxmx"
-  language_id: 8292745 # In reference to the US patent number of the Roblox platform (+1).
 RobotFramework:
   type: programming
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4305,6 +4305,24 @@ Ring:
   tm_scope: source.ring
   ace_mode: text
   language_id: 431
+Roblox:
+  type: data
+  tm_scope: none
+  ace_mode: text
+  color: "#E2231A"
+  extensions:
+  - ".rbxl"
+  - ".rbxm"
+  language_id: 8292744 # In reference to the US patent number of the Roblox platform.
+Roblox XML:
+  type: data
+  tm_scope: none
+  ace_mode: xml # New syntax highlighter should come later.
+  color: "#E2231A"
+  extensions:
+  - ".rbxlx"
+  - ".rbxmx"
+  language_id: 8292745 # In reference to the US patent number of the Roblox platform (+1).
 RobotFramework:
   type: programming
   extensions:


### PR DESCRIPTION
I added support for the file formats used by [Rōblox Studio](https://www.roblox.com/create) (`.rbxl`, `.rbxlx`, `.rbxm`, `.rbxmx`).  The corresponding syntax highlighter on CodeMirror (for `.rbxlx` and `.rbxmx` files) is not yet completed, as these file formats should parse both XML and a modified form of Lua.

Although I made sure to follow the procedure to the best of my ability, this pull request may not fully be suitable without modifications on your end.  I intend to add these data types to allow people who visit my repositories to know that the code is designed on Rōblox the same way Linguist labels projects on Node with the appropriate language identifiers.

If you'd like to learn more about Rōblox Studio, visit [this page](https://developer.roblox.com).