### PR TITLE
Support for Coccinelle's SmPL language

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -434,7 +434,9 @@ vendor/grammars/language-etc:
 - source.man-conf
 - source.nanorc
 - source.opts
+- source.smpl
 - source.ssh-config
+- text.xml.svg
 vendor/grammars/language-fontforge:
 - source.afm
 - source.bdf

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4819,6 +4819,16 @@ Slim:
   codemirror_mode: slim
   codemirror_mime_type: text/x-slim
   language_id: 350
+SmPL:
+  type: programming
+  extensions:
+  - ".cocci"
+  alias:
+  - coccinelle
+  ace_mode: text
+  tm_scope: source.smpl
+  color: "#c94949"
+  language_id: 164123055
 Smali:
   type: programming
   extensions:

--- a/samples/SmPL/atomic_as_refcounter.cocci
+++ b/samples/SmPL/atomic_as_refcounter.cocci
@@ -1,0 +1,129 @@
+// Check if refcount_t type and API should be used
+// instead of atomic_t type when dealing with refcounters
+//
+// Copyright (c) 2016-2017, Elena Reshetova, Intel Corporation
+//
+// Confidence: Moderate
+// URL: http://coccinelle.lip6.fr/
+// Options: --include-headers --very-quiet
+
+virtual report
+
+@r1 exists@
+identifier a, x;
+position p1, p2;
+identifier fname =~ ".*free.*";
+identifier fname2 =~ ".*destroy.*";
+identifier fname3 =~ ".*del.*";
+identifier fname4 =~ ".*queue_work.*";
+identifier fname5 =~ ".*schedule_work.*";
+identifier fname6 =~ ".*call_rcu.*";
+
+@@
+
+(
+ atomic_dec_and_test@p1(&(a)->x)
+|
+ atomic_dec_and_lock@p1(&(a)->x, ...)
+|
+ atomic_long_dec_and_lock@p1(&(a)->x, ...)
+|
+ atomic_long_dec_and_test@p1(&(a)->x)
+|
+ atomic64_dec_and_test@p1(&(a)->x)
+|
+ local_dec_and_test@p1(&(a)->x)
+)
+...
+(
+ fname@p2(a, ...);
+|
+ fname2@p2(...);
+|
+ fname3@p2(...);
+|
+ fname4@p2(...);
+|
+ fname5@p2(...);
+|
+ fname6@p2(...);
+)
+
+
+@script:python depends on report@
+p1 << r1.p1;
+p2 << r1.p2;
+@@
+msg = "atomic_dec_and_test variation before object free at line %s."
+coccilib.report.print_report(p1[0], msg % (p2[0].line))
+
+@r4 exists@
+identifier a, x, y;
+position p1, p2;
+identifier fname =~ ".*free.*";
+
+@@
+
+(
+ atomic_dec_and_test@p1(&(a)->x)
+|
+ atomic_dec_and_lock@p1(&(a)->x, ...)
+|
+ atomic_long_dec_and_lock@p1(&(a)->x, ...)
+|
+ atomic_long_dec_and_test@p1(&(a)->x)
+|
+ atomic64_dec_and_test@p1(&(a)->x)
+|
+ local_dec_and_test@p1(&(a)->x)
+)
+...
+y=a
+...
+fname@p2(y, ...);
+
+
+@script:python depends on report@
+p1 << r4.p1;
+p2 << r4.p2;
+@@
+msg = "atomic_dec_and_test variation before object free at line %s."
+coccilib.report.print_report(p1[0], msg % (p2[0].line))
+
+@r2 exists@
+identifier a, x;
+position p1;
+@@
+
+(
+atomic_add_unless(&(a)->x,-1,1)@p1
+|
+atomic_long_add_unless(&(a)->x,-1,1)@p1
+|
+atomic64_add_unless(&(a)->x,-1,1)@p1
+)
+
+@script:python depends on report@
+p1 << r2.p1;
+@@
+msg = "atomic_add_unless"
+coccilib.report.print_report(p1[0], msg)
+
+@r3 exists@
+identifier x;
+position p1;
+@@
+
+(
+x = atomic_add_return@p1(-1, ...);
+|
+x = atomic_long_add_return@p1(-1, ...);
+|
+x = atomic64_add_return@p1(-1, ...);
+)
+
+@script:python depends on report@
+p1 << r3.p1;
+@@
+msg = "x = atomic_add_return(-1, ...)"
+coccilib.report.print_report(p1[0], msg)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -367,6 +367,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Slash:** [slash-lang/Slash.tmbundle](https://github.com/slash-lang/Slash.tmbundle)
 - **Slice:** [zeroc-ice/vscode-slice](https://github.com/zeroc-ice/vscode-slice)
 - **Slim:** [slim-template/ruby-slim.tmbundle](https://github.com/slim-template/ruby-slim.tmbundle)
+- **SmPL:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Smali:** [ShaneWilton/sublime-smali](https://github.com/ShaneWilton/sublime-smali)
 - **Smalltalk:** [tomas-stefano/smalltalk-tmbundle](https://github.com/tomas-stefano/smalltalk-tmbundle)
 - **Smarty:** [textmate/php-smarty.tmbundle](https://github.com/textmate/php-smarty.tmbundle)

--- a/vendor/licenses/grammar/language-etc.txt
+++ b/vendor/licenses/grammar/language-etc.txt
@@ -1,7 +1,7 @@
 ---
 type: grammar
 name: language-etc
-version: d2eca5747be8a95667040d8782d869408b36289d
+version: 0ee6082ccd137a7c4713bcf5c380fe2b4cb13de6
 license: isc
 ---
 Copyright (c) 2018-2019, John Gardner


### PR DESCRIPTION
This pull request adds support for [the SmPL language](http://coccinelle.lip6.fr/docs/index.html) used by [the Coccinelle tool](http://coccinelle.lip6.fr) to write semantic patches.

## Description

I didn't find a grammar to highlight SmPL files.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - [`extension:cocci NOT fhdifhdfdggd`](https://github.com/search?q=extension%3Acocci+NOT+fhdifhdfdggd)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source: [torvalds/linux](https://github.com/torvalds/linux/blob/fa1b5d09d0771247d407df89228b3902de8e2ce6/scripts/coccinelle/api/atomic_as_refcounter.cocci)
    - Sample license: GPLv2
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
