### PR TITLE
Fix BibTeX highlighting and use LaTeX grammar for TeX files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -418,6 +418,16 @@ Befunge:
   - ".befunge"
   ace_mode: text
   language_id: 30
+BibTeX:
+  type: markup
+  group: TeX
+  extensions:
+  - ".bib"
+  tm_scope: text.bibtex
+  ace_mode: tex
+  codemirror_mode: stex
+  codemirror_mime_type: text/x-stex
+  language_id: 982188347
 Bison:
   type: programming
   group: Yacc
@@ -5066,7 +5076,6 @@ TeX:
   - ".tex"
   - ".aux"
   - ".bbx"
-  - ".bib"
   - ".cbx"
   - ".cls"
   - ".dtx"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5069,6 +5069,7 @@ TeX:
   ace_mode: tex
   codemirror_mode: stex
   codemirror_mime_type: text/x-stex
+  tm_scope: text.tex.latex
   wrap: true
   aliases:
   - latex

--- a/samples/BibTeX/citations.bib
+++ b/samples/BibTeX/citations.bib
@@ -1,0 +1,29 @@
+%% Following example taken from BibTeX's Wikipedia article
+
+@Book{abramowitz+stegun,
+ author    = "Milton {Abramowitz} and Irene A. {Stegun}",
+ title     = "Handbook of Mathematical Functions with
+              Formulas, Graphs, and Mathematical Tables",
+ publisher = "Dover",
+ year      =  1964,
+ address   = "New York City",
+ edition   = "ninth Dover printing, tenth GPO printing"
+}
+
+%% Next two examples were taken from github/linguist#3679
+
+@incollection{dijkstra1982role,
+  title={On the role of scientific thought},
+  author={Dijkstra, Edsger W},
+  booktitle={Selected writings on computing: a personal perspective},
+  pages={60--66},
+  year={1982},
+  publisher={Springer}}
+
+@book{knuth1998art,
+  title={The art of computer programming: sorting and searching $math$},
+  author={Knuth, Donald Ervin},
+  volume={3},
+  year={1998},
+  publisher={Pearson Education}
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -38,6 +38,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Ballerina:** [ballerina-platform/ballerina-grammar](https://github.com/ballerina-platform/ballerina-grammar)
 - **Batchfile:** [mmims/language-batchfile](https://github.com/mmims/language-batchfile)
 - **Befunge:** [johanasplund/sublime-befunge](https://github.com/johanasplund/sublime-befunge)
+- **BibTeX:** [textmate/latex.tmbundle](https://github.com/textmate/latex.tmbundle)
 - **Bison:** [textmate/bison.tmbundle](https://github.com/textmate/bison.tmbundle)
 - **Blade:** [jawee/language-blade](https://github.com/jawee/language-blade)
 - **BlitzBasic:** [textmate/blitzmax.tmbundle](https://github.com/textmate/blitzmax.tmbundle)


### PR DESCRIPTION
## Description
This PR adds a separate language entry for BibTeX to fix the syntax highlighting of `.bib` files. In addition, it enhances the highlighting of TeX files by switching to the [LaTeX grammar](https://github.com/textmate/latex.tmbundle/blob/master/Syntaxes/LaTeX.plist) instead of the [plain TeX one](https://github.com/textmate/latex.tmbundle/blob/master/Syntaxes/TeX.plist).

References: #3679
/cc @ruffsl, @blegat

## Checklist:
- [x] **I am adding a new language.**
	- [x] **The extension of the new language is used in hundreds of repositories.**
	- [x] **I have included a real-world usage sample.**  
	Assembled from BibTeX samples posted by @blegat in #3679, as well from [Wikipedia's BibTeX page](https://en.wikipedia.org/wiki/BibTeX#Bibliographic_information_file). Given that BibTeX files are just citations, I'd say this qualifies as "real-world" usage.

- [x] **I am changing the source of a syntax highlighting grammar**
	- **BibTeX:** [Before](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=text.tex&grammar_format=auto&grammar_url=&grammar_text=&code_source=from-text&code_url=&code=%40incollection%7Bdijkstra1982role%2C%0D%0A++title%3D%7BOn+the+role+of+scientific+thought%7D%2C%0D%0A++author%3D%7BDijkstra%2C+Edsger+W%7D%2C%0D%0A++booktitle%3D%7BSelected+writings+on+computing%3A+a+personal+perspective%7D%2C%0D%0A++pages%3D%7B60--66%7D%2C%0D%0A++year%3D%7B1982%7D%2C%0D%0A++publisher%3D%7BSpringer%7D%7D) | [After](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=xml&grammar_url=https%3A%2F%2Fgithub.com%2Ftextmate%2Flatex.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FBibtex.plist&grammar_text=&code_source=from-text&code_url=&code=%40incollection%7Bdijkstra1982role%2C%0D%0A++title%3D%7BOn+the+role+of+scientific+thought%7D%2C%0D%0A++author%3D%7BDijkstra%2C+Edsger+W%7D%2C%0D%0A++booktitle%3D%7BSelected+writings+on+computing%3A+a+personal+perspective%7D%2C%0D%0A++pages%3D%7B60--66%7D%2C%0D%0A++year%3D%7B1982%7D%2C%0D%0A++publisher%3D%7BSpringer%7D%7D)
	- **(La)TeX:** [Before](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=xml&grammar_url=https%3A%2F%2Fgithub.com%2Ftextmate%2Flatex.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FTeX.plist&grammar_text=&code_source=from-text&code_url=&code=%0D%0A%5Cdefinecolor%7Bopticlimb%7D%7Brgb%7D%7B0%2C0.65%2C0.65%7D%0D%0A%0D%0A%25%5Cusepackage%7Btimes%7D+%25+Use+the+times+font%0D%0A%25%5Cusepackage%7Bpalatino%7D+%25+Uncomment+to+use+the+Palatino+font%0D%0A%25%5Cusepackage%7Bhelvet%7D%0D%0A%5Cusepackage%7Bavant%7D%0D%0A%0D%0A%5Cusepackage%7Bgraphicx%7D+%25+Required+for+including+images%0D%0A%5Cgraphicspath%7B%7Bfigures%2F%7D%7D+%25+Location+of+the+graphics+files%0D%0A%5Cusepackage%7Bbooktabs%7D+%25+Top+and+bottom+rules+for+table%0D%0A%5Cusepackage%5Bfont%3Dsmall%2Clabelfont%3Dbf%5D%7Bcaption%7D+%25+Required+for+specifying+captions+to+tables+and+figures%0D%0A%5Cusepackage%7Bamsfonts%2C+amsmath%2C+amsthm%2C+amssymb%2Cbm%7D+%25+For+math+fonts%2C+symbols+and+environments%0D%0A%5Cusepackage%7Bwrapfig%7D+%25+Allows+wrapping+text+around+tables+and+figures%0D%0A) | [After](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=xml&grammar_url=https%3A%2F%2Fgithub.com%2Ftextmate%2Flatex.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FLaTeX.plist&grammar_text=&code_source=from-text&code_url=&code=%5Cdefinecolor%7Bopticlimb%7D%7Brgb%7D%7B0%2C0.65%2C0.65%7D%0D%0A%0D%0A%25%5Cusepackage%7Btimes%7D+%25+Use+the+times+font%0D%0A%25%5Cusepackage%7Bpalatino%7D+%25+Uncomment+to+use+the+Palatino+font%0D%0A%25%5Cusepackage%7Bhelvet%7D%0D%0A%5Cusepackage%7Bavant%7D%0D%0A%0D%0A%5Cusepackage%7Bgraphicx%7D+%25+Required+for+including+images%0D%0A%5Cgraphicspath%7B%7Bfigures%2F%7D%7D+%25+Location+of+the+graphics+files%0D%0A%5Cusepackage%7Bbooktabs%7D+%25+Top+and+bottom+rules+for+table%0D%0A%5Cusepackage%5Bfont%3Dsmall%2Clabelfont%3Dbf%5D%7Bcaption%7D+%25+Required+for+specifying+captions+to+tables+and+figures%0D%0A%5Cusepackage%7Bamsfonts%2C+amsmath%2C+amsthm%2C+amssymb%2Cbm%7D+%25+For+math+fonts%2C+symbols+and+environments%0D%0A%5Cusepackage%7Bwrapfig%7D+%25+Allows+wrapping+text+around+tables+and+figures%0D%0A)

## Sidenote
I had to dig around to figure out which of [`textmate/latex.tmbundle`](https://github.com/textmate/latex.tmbundle/tree/f22af139cacaa41a5138ca4caa4b59c409bb18b1/Syntaxes)'s six grammars are being used for TeX highlighting. The `tm_scope` entry was missing, and I discovered Linguist is guessing the scope of languages that don't declare one:

https://github.com/github/linguist/blob/001ca526694a32a5ac4c977a79032ced0b8c0aca/lib/linguist/language.rb#L276-L285

I really don't think we should be doing this. We should declare a `tm_scope` for *every* entry, even if it's `none`. Tests can easily be added which check for missing or invalid scope fields. @lildude, if you agree, I'm happy to submit a PR to address this.