### PR TITLE
Add `eqnrc` and `troffrc` to Roff filenames list

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4355,8 +4355,11 @@ Roff:
   - ".rno"
   - ".tmac"
   filenames:
+  - eqnrc
   - mmn
   - mmt
+  - troffrc
+  - troffrc-end
   tm_scope: text.roff
   aliases:
   - groff


### PR DESCRIPTION
This PR registers three more filenames as Roff source:

-	[[`eqnrc`](https://github.com/search?q=filename%3Aeqnrc+NOT+nothack&type=Code)]: [384 results](https://github.com/Alhadis/Silos/blob/eqnrc/urls.log) / [349 repos](https://github.com/Alhadis/Silos/blob/eqnrc/repos.log) / [173 users](https://github.com/Alhadis/Silos/blob/eqnrc/users.log)
-	[[`troffrc`](https://github.com/search?q=filename%3Atroffrc+NOT+nothack&type=Code)]: [386 results](https://github.com/Alhadis/Silos/blob/troffrc/urls.log) / [355 results](https://github.com/Alhadis/Silos/blob/troffrc/repos.log) / [320 users](https://github.com/Alhadis/Silos/blob/troffrc/users.log)
-	[[`troffrc-end`](https://github.com/search?q=filename%3Atroffrc-end+NOT+nothack&type=Code)]: [355 results](https://github.com/Alhadis/Silos/blob/troffrc-end/urls.log) / [325 repos](https://github.com/Alhadis/Silos/blob/troffrc-end/repos.log) / [293 users](https://github.com/Alhadis/Silos/blob/troffrc-end/users.log)

Not much else to say. Pretty straightforward pull-request.

## Checklist:
- [x] **I am associating a language with a new file extension.**
	-	[x] **The new extension is used in hundreds of repositories on GitHub.com**
	-	[ ] ~~**I have included a real-world usage sample for all extensions added in this PR:**~~  
		_Every result I found was GPL-licensed._

