### PR TITLE
trivial: add .hack extension for Hack language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2003,6 +2003,7 @@ Hack:
   codemirror_mode: php
   codemirror_mime_type: application/x-httpd-php
   extensions:
+  - ".hack"
   - ".hh"
   - ".php"
   tm_scope: source.hack

--- a/samples/Hack/first.hack
+++ b/samples/Hack/first.hack
@@ -1,0 +1,17 @@
+// from https://docs.hhvm.com/hack/getting-started/getting-started
+// note: no <?hh header needed for .hack files
+
+namespace Hack\GettingStarted\MyFirstProgram;
+
+<<__EntryPoint>>
+function main(): noreturn{
+  echo "Welcome to Hack!\n\n";
+
+  \printf("Table of Squares\n" .
+          "----------------\n");
+  for ($i = -5; $i <= 5; ++$i) {
+    \printf("  %2d        %2d  \n", $i, $i * $i);
+  }
+  \printf("----------------\n");
+  exit(0);
+}


### PR DESCRIPTION
`.hack` was agreed on as the main extension for Hack files in the future, and is already used by standard Hack libraries ([example](https://github.com/hhvm/hacktest/tree/master/src)) and official documentation ([example](https://docs.hhvm.com/hack/getting-started/getting-started#your-first-hack-program__3.-write-your-first-hack-program)).

This should fix syntax highlighting for pull requests such as https://github.com/hhvm/hacktest/pull/84/files

For context, `.php` is deprecated for Hack files since the languages are no longer compatible, and `.hh` is discouraged because it can cause confusion with C++ header files.

- [x] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Ahack+function+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/hhvm/hacktest/tree/master/src
      - https://docs.hhvm.com/hack/getting-started/getting-started#your-first-hack-program__3.-write-your-first-hack-program
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.