### PR TITLE
Allow $schema key to be present in grammars

### DIFF
--- a/tools/grammars/compiler/data.go
+++ b/tools/grammars/compiler/data.go
@@ -18,6 +18,7 @@ var GrammarAliases = map[string]string{
 }
 
 var KnownFields = map[string]bool{
+	"$schema":               true,
 	"comment":               true,
 	"uuid":                  true,
 	"author":                true,


### PR DESCRIPTION
This enables a json schema link to be present in grammars. 

Resolves #4594.