### PR TITLE
Fix failing tests

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4909,7 +4909,7 @@ SmPL:
   type: programming
   extensions:
   - ".cocci"
-  alias:
+  aliases:
   - coccinelle
   ace_mode: text
   tm_scope: source.smpl


### PR DESCRIPTION
In #4575, the `aliases` field was erroneously entered as `alias`, a mistake which wasn't noticed until it was caught by a [test](https://github.com/github/linguist/pull/4585#issuecomment-513302506) I added in #4585 (for reasons exactly like this). Both PRs were merged earlier, revealing the error.

*Template removed as it doesn't apply.*