### PR TITLE
Add pull_request to on events list for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
-name: CI
+name: Run Tests
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  run:
+    name: Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Description

When switching from Travis to GitHub Actions, I missed out that we need to trigger builds for the `pull_request` event else CI won't run for PRs submitted from forks.

This isn't very clear from the docs or the available examples.

I'm also taking this opportunity to use more descriptive names so the checks look better.

Before:

![Screenshot 2019-08-13 at 10 57 13](https://user-images.githubusercontent.com/627280/62932999-2a6e9380-bdb9-11e9-95ce-5ab6a417fdb1.png)

After:

![Screenshot 2019-08-13 at 10 59 35](https://user-images.githubusercontent.com/627280/62933158-7f120e80-bdb9-11e9-95f4-1062f31a7080.png)

I'll update the list of required status checks once this PR has been merged.

_[Template removed as it is not relevant]_