### PR TITLE
Add MLIR grammar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -725,6 +725,9 @@
 [submodule "vendor/grammars/mercury-tmlanguage"]
 	path = vendor/grammars/mercury-tmlanguage
 	url = https://github.com/sebgod/mercury-tmlanguage
+[submodule "vendor/grammars/mlir-grammar"]
+	path = vendor/grammars/mlir-grammar
+	url = https://github.com/jpienaar/mlir-grammar
 [submodule "vendor/grammars/monkey"]
 	path = vendor/grammars/monkey
 	url = https://github.com/gingerbeardman/monkey.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -632,6 +632,8 @@ vendor/grammars/mediawiki.tmbundle:
 - text.html.mediawiki
 vendor/grammars/mercury-tmlanguage:
 - source.mercury
+vendor/grammars/mlir-grammar:
+- source.mlir
 vendor/grammars/monkey:
 - source.monkey
 vendor/grammars/moonscript-tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2926,6 +2926,13 @@ MAXScript:
   tm_scope: source.maxscript
   ace_mode: text
   language_id: 217
+MLIR:
+  type: programming
+  extensions:
+  - ".mlir"
+  tm_scope: source.mlir
+  ace_mode: text
+  language_id: 448253929
 MQL4:
   type: programming
   color: "#62A8D6"

--- a/samples/MLIR/const-fold.mlir
+++ b/samples/MLIR/const-fold.mlir
@@ -1,0 +1,457 @@
+// RUN: tf-opt %s -test-constant-fold | FileCheck %s --dump-input-on-failure
+
+// CHECK-LABEL: @add_float
+func @add_float() -> (tensor<f32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) {
+  %0 = constant dense<4.5> : tensor<f32>
+  %1 = constant dense<1.5> : tensor<f32>
+
+  %2 = constant dense< 3.5> : tensor<4xf32>
+  %3 = constant dense<-0.5> : tensor<4xf32>
+
+  // CHECK: %cst = constant dense<3.500000e+00> : tensor<4xf32>
+  // CHECK: %cst_0 = constant dense<-5.000000e-01> : tensor<4xf32>
+  // CHECK: %cst_1 = constant dense<6.000000e+00> : tensor<f32>
+  // CHECK: %cst_2 = constant dense<4.000000e+00> : tensor<4xf32>
+  // CHECK: %cst_3 = constant dense<5.000000e+00> : tensor<4xf32>
+  // CHECK: %cst_4 = constant dense<3.000000e+00> : tensor<4xf32>
+  // CHECK: %0 = tfl.add %cst, %cst_0 {fused_activation_function = "SIGN_BIT"} : tensor<4xf32>
+
+  %5 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<  f32>, tensor<  f32>) -> tensor<  f32>
+  %6 = "tfl.add"(%0, %3) {fused_activation_function = "NONE"} : (tensor<  f32>, tensor<4xf32>) -> tensor<4xf32>
+  %7 = "tfl.add"(%2, %1) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<  f32>) -> tensor<4xf32>
+  %8 = "tfl.add"(%2, %3) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  %9 = "tfl.add"(%2, %3) {fused_activation_function = "SIGN_BIT"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+
+  return %5, %6, %7, %8, %9 : tensor<f32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>
+}
+
+// CHECK-LABEL: @add_int
+func @add_int() -> (tensor<i32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) {
+  %0 = constant dense<8> : tensor<i32>
+  %1 = constant dense<1> : tensor<i32>
+
+  %2 = constant dense< 4> : tensor<4xi32>
+  %3 = constant dense<-2> : tensor<4xi32>
+
+  // CHECK: %cst = constant dense<9> : tensor<i32>
+  // CHECK: %cst_0 = constant dense<6> : tensor<4xi32>
+  // CHECK: %cst_1 = constant dense<5> : tensor<4xi32>
+  // CHECK: %cst_2 = constant dense<2> : tensor<4xi32>
+
+  %5 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<  i32>, tensor<  i32>) -> tensor<  i32>
+  %6 = "tfl.add"(%0, %3) {fused_activation_function = "NONE"} : (tensor<  i32>, tensor<4xi32>) -> tensor<4xi32>
+  %7 = "tfl.add"(%2, %1) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<  i32>) -> tensor<4xi32>
+  %8 = "tfl.add"(%2, %3) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+
+  return %5, %6, %7, %8 : tensor<i32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>
+}
+
+// CHECK-LABEL: @sub_float
+func @sub_float() -> (tensor<f32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) {
+  %0 = constant dense<4.5> : tensor<f32>
+  %1 = constant dense<1.5> : tensor<f32>
+
+  %2 = constant dense< 3.5> : tensor<4xf32>
+  %3 = constant dense<-0.5> : tensor<4xf32>
+
+  // CHECK: %cst = constant dense<3.000000e+00> : tensor<f32>
+  // CHECK: %cst_0 = constant dense<5.000000e+00> : tensor<4xf32>
+  // CHECK: %cst_1 = constant dense<2.000000e+00> : tensor<4xf32>
+  // CHECK: %cst_2 = constant dense<4.000000e+00> : tensor<4xf32>
+
+  %5 = "tfl.sub"(%0, %1) {fused_activation_function = "NONE"} : (tensor<  f32>, tensor<  f32>) -> tensor<  f32>
+  %6 = "tfl.sub"(%0, %3) {fused_activation_function = "NONE"} : (tensor<  f32>, tensor<4xf32>) -> tensor<4xf32>
+  %7 = "tfl.sub"(%2, %1) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<  f32>) -> tensor<4xf32>
+  %8 = "tfl.sub"(%2, %3) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+
+  return %5, %6, %7, %8 : tensor<f32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>
+}
+
+// CHECK-LABEL: @sub_int
+func @sub_int() -> (tensor<i32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) {
+  %0 = constant dense<8> : tensor<i32>
+  %1 = constant dense<1> : tensor<i32>
+
+  %2 = constant dense< 4> : tensor<4xi32>
+  %3 = constant dense<-2> : tensor<4xi32>
+
+  // CHECK: %cst = constant dense<7> : tensor<i32>
+  // CHECK: %cst_0 = constant dense<10> : tensor<4xi32>
+  // CHECK: %cst_1 = constant dense<3> : tensor<4xi32>
+  // CHECK: %cst_2 = constant dense<6> : tensor<4xi32>
+
+  %5 = "tfl.sub"(%0, %1) {fused_activation_function = "NONE"} : (tensor<  i32>, tensor<  i32>) -> tensor<  i32>
+  %6 = "tfl.sub"(%0, %3) {fused_activation_function = "NONE"} : (tensor<  i32>, tensor<4xi32>) -> tensor<4xi32>
+  %7 = "tfl.sub"(%2, %1) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<  i32>) -> tensor<4xi32>
+  %8 = "tfl.sub"(%2, %3) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+
+  return %5, %6, %7, %8 : tensor<i32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>
+}
+
+// CHECK-LABEL: @mul_float
+func @mul_float() -> (tensor<f32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>) {
+  %0 = constant dense<4.5> : tensor<f32>
+  %1 = constant dense<1.5> : tensor<f32>
+
+  %2 = constant dense< 3.5> : tensor<4xf32>
+  %3 = constant dense<-0.5> : tensor<4xf32>
+
+  // CHECK: %cst = constant dense<6.750000e+00> : tensor<f32>
+  // CHECK: %cst_0 = constant dense<-2.250000e+00> : tensor<4xf32>
+  // CHECK: %cst_1 = constant dense<5.250000e+00> : tensor<4xf32>
+  // CHECK: %cst_2 = constant dense<-1.750000e+00> : tensor<4xf32>
+
+  %5 = "tfl.mul"(%0, %1) {fused_activation_function = "NONE"} : (tensor<  f32>, tensor<  f32>) -> tensor<  f32>
+  %6 = "tfl.mul"(%0, %3) {fused_activation_function = "NONE"} : (tensor<  f32>, tensor<4xf32>) -> tensor<4xf32>
+  %7 = "tfl.mul"(%2, %1) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<  f32>) -> tensor<4xf32>
+  %8 = "tfl.mul"(%2, %3) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+
+  return %5, %6, %7, %8 : tensor<f32>, tensor<4xf32>, tensor<4xf32>, tensor<4xf32>
+}
+
+// CHECK-LABEL: @elementwise_unary_ops
+func @elementwise_unary_ops() -> (tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>) {
+  %0 = constant dense<-1.0> : tensor<f32>
+  %1 = constant dense<1.0> : tensor<f32>
+  %2 = constant dense<1.0> : tensor<f32>
+  %3 = constant dense<1.0> : tensor<f32>
+  %4 = constant dense<4.0> : tensor<f32>
+  %5 = constant dense<4.0> : tensor<f32>
+  %6 = constant dense<2.0> : tensor<f32>
+
+  // CHECK-DAG: [[cst0:%.*]] = constant dense<1.000000e+00> : tensor<f32>
+  // CHECK-DAG: [[cst1:%.*]] = constant dense<0.841470957> : tensor<f32>
+  // CHECK-DAG: [[cst2:%.*]] = constant dense<0.540302277> : tensor<f32>
+  // CHECK-DAG: [[cst3:%.*]] = constant dense<0.000000e+00> : tensor<f32>
+  // CHECK-DAG: [[cst4:%.*]] = constant dense<2.000000e+00> : tensor<f32>
+  // CHECK-DAG: [[cst5:%.*]] = constant dense<5.000000e-01> : tensor<f32>
+  // CHECK-DAG: [[cst6:%.*]] = constant dense<4.000000e+00> : tensor<f32>
+  // CHECK: return [[cst0]], [[cst1]], [[cst2]], [[cst3]], [[cst4]], [[cst5]], [[cst6]]
+
+  %7 = "tfl.abs"(%0) : (tensor<f32>) -> tensor<f32>
+  %8 = "tfl.sin"(%1) : (tensor<f32>) -> tensor<f32>
+  %9 = "tfl.cos"(%2) : (tensor<f32>) -> tensor<f32>
+  %10 = "tfl.log"(%3) : (tensor<f32>) -> tensor<f32>
+  %11 = "tfl.sqrt"(%4) : (tensor<f32>) -> tensor<f32>
+  %12 = "tfl.rsqrt"(%5) : (tensor<f32>) -> tensor<f32>
+  %13 = "tfl.square"(%6) : (tensor<f32>) -> tensor<f32>
+
+  return %7, %8, %9, %10, %11, %12, %13 : tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>, tensor<f32>
+}
+
+// CHECK-LABEL: @mul_int
+func @mul_int() -> (tensor<i32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) {
+  %0 = constant dense<8> : tensor<i32>
+  %1 = constant dense<1> : tensor<i32>
+
+  %2 = constant dense< 4> : tensor<4xi32>
+  %3 = constant dense<-2> : tensor<4xi32>
+
+  // CHECK-DAG: [[cst0:%.*]] = constant dense<8> : tensor<i32>
+  // CHECK-DAG: [[cst1:%.*]] = constant dense<-16> : tensor<4xi32>
+  // CHECK-DAG: [[cst2:%.*]] = constant dense<4> : tensor<4xi32>
+  // CHECK-DAG: [[cst3:%.*]] = constant dense<-8> : tensor<4xi32>
+  // CHECK: return [[cst0]], [[cst1]], [[cst2]], [[cst3]]
+
+  %5 = "tfl.mul"(%0, %1) {fused_activation_function = "NONE"} : (tensor<  i32>, tensor<  i32>) -> tensor<  i32>
+  %6 = "tfl.mul"(%0, %3) {fused_activation_function = "NONE"} : (tensor<  i32>, tensor<4xi32>) -> tensor<4xi32>
+  %7 = "tfl.mul"(%2, %1) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<  i32>) -> tensor<4xi32>
+  %8 = "tfl.mul"(%2, %3) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+
+  return %5, %6, %7, %8 : tensor<i32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>
+}
+
+// CHECK-LABEL: @add_dense_splat_int
+func @add_dense_splat_int() -> tensor<4xi32> {
+  %0 = constant dense<[-10, -1, 42, 100]> : tensor<4xi32>
+  %1 = constant dense< 5> : tensor<4xi32>
+
+  %2 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+
+  return %2 : tensor<4xi32>
+
+// CHECK:  %cst = constant dense<[-5, 4, 47, 105]> : tensor<4xi32>
+// CHECK:  return %cst
+}
+
+// CHECK-LABEL: @add_splat_dense_int
+func @add_splat_dense_int() -> tensor<4xi32> {
+  %0 = constant dense< 5> : tensor<4xi32>
+  %1 = constant dense<[-10, -1, 42, 100]> : tensor<4xi32>
+
+  %2 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+
+  return %2 : tensor<4xi32>
+
+// CHECK:  %cst = constant dense<[-5, 4, 47, 105]> : tensor<4xi32>
+// CHECK:  return %cst
+}
+
+// CHECK-LABEL: @add_dense_dense_int_same_shape
+func @add_dense_dense_int_same_shape() -> tensor<4xi32> {
+  %0 = constant dense<[15, 23, -44, -2]> : tensor<4xi32>
+  %1 = constant dense<[-10, -1, 42, 100]> : tensor<4xi32>
+
+  %2 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+
+  return %2 : tensor<4xi32>
+
+// CHECK:  %cst = constant dense<[5, 22, -2, 98]> : tensor<4xi32>
+// CHECK:  return %cst
+}
+
+// CHECK-LABEL: @add_dense_dense_int_trailing_dim
+func @add_dense_dense_int_trailing_dim() -> (tensor<2x2xi32>, tensor<2x2x2xi32>, tensor<2x2x2xi32>) {
+  %cst_0 = constant dense<[10, 20]> : tensor<2xi32>
+  %cst_1 = constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>
+  %cst_2 = constant dense<[[[1, 1], [2, 2]], [[3, 3], [4, 4]]]> : tensor<2x2x2xi32>
+
+  %0 = "tfl.add"(%cst_0, %cst_1) {fused_activation_function = "NONE"} : (tensor<    2xi32>, tensor<  2x2xi32>) -> tensor<  2x2xi32>
+  %1 = "tfl.add"(%cst_2, %cst_1) {fused_activation_function = "NONE"} : (tensor<2x2x2xi32>, tensor<  2x2xi32>) -> tensor<2x2x2xi32>
+  %2 = "tfl.add"(%cst_0, %cst_2) {fused_activation_function = "NONE"} : (tensor<    2xi32>, tensor<2x2x2xi32>) -> tensor<2x2x2xi32>
+
+  return %0, %1, %2 : tensor<2x2xi32>, tensor<2x2x2xi32>, tensor<2x2x2xi32>
+
+// CHECK:  %cst = constant dense<{{\[\[}}11, 22], [13, 24]]> : tensor<2x2xi32>
+// CHECK:  %cst_0 = constant dense<{{\[\[\[}}2, 3], [5, 6]], {{\[\[}}4, 5], [7, 8]]]> : tensor<2x2x2xi32>
+// CHECK:  %cst_1 = constant dense<{{\[\[\[}}11, 21], [12, 22]], {{\[\[}}13, 23], [14, 24]]]> : tensor<2x2x2xi32>
+// CHECK:  return %cst, %cst_0, %cst_1
+}
+
+// CHECK-LABEL: @add_dense_dense_int_mixing_1_n
+func @add_dense_dense_int_mixing_1_n() -> tensor<2x2xi32> {
+  %cst_0 = constant dense<[[1, 2]]> : tensor<1x2xi32>
+  %cst_1 = constant dense<[[3], [4]]> : tensor<2x1xi32>
+
+  %0 = "tfl.add"(%cst_0, %cst_1) {fused_activation_function = "NONE"} : (tensor<1x2xi32>, tensor<2x1xi32>) -> tensor<2x2xi32>
+
+  return %0 : tensor<2x2xi32>
+
+// We don't support this case yet.
+// %cst = constant dense<{{\[\[}}4, 5], [5, 6]]> : tensor<2x2xi32>
+// CHECK:  %0 = "tfl.add"
+// CHECK:  return %0
+}
+
+// CHECK-LABEL: @add_dense_splat_float
+func @add_dense_splat_float() -> tensor<4xf32> {
+  %0 = constant dense<[-10.0, -1.5, 42.0, 7.25]> : tensor<4xf32>
+  %1 = constant dense< 3.5> : tensor<4xf32>
+
+  %2 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+
+  return %2 : tensor<4xf32>
+
+// CHECK:  %cst = constant dense<[-6.500000e+00, 2.000000e+00, 4.550000e+01, 1.075000e+01]> : tensor<4xf32>
+// CHECK:  return %cst
+}
+
+// CHECK-LABEL: @add_splat_dense_float
+func @add_splat_dense_float() -> tensor<4xf32> {
+  %0 = constant dense< 3.5> : tensor<4xf32>
+  %1 = constant dense<[-10.0, -1.5, 42.0, 7.25]> : tensor<4xf32>
+
+  %2 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+
+  return %2 : tensor<4xf32>
+
+// CHECK:  %cst = constant dense<[-6.500000e+00, 2.000000e+00, 4.550000e+01, 1.075000e+01]> : tensor<4xf32>
+// CHECK:  return %cst
+}
+
+// CHECK-LABEL: @add_dense_dense_float_same_shape
+func @add_dense_dense_float_same_shape() -> (tensor<4xf32>) {
+  %0 = constant dense<[1.5, 2.3, -4.4, -2.0]> : tensor<4xf32>
+  %1 = constant dense<[-10.4, -1.3, 42.4, 100.0]> : tensor<4xf32>
+
+  %2 = "tfl.add"(%0, %1) {fused_activation_function = "NONE"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+
+  return %2 : tensor<4xf32>
+
+// CHECK:  %cst = constant dense<[-8.89999961, 1.000000e+00, 3.800000e+01, 9.800000e+01]> : tensor<4xf32>
+// CHECK:  return %cst
+}
+
+// CHECK-LABEL: @add_dense_dense_float_trailing_dim
+func @add_dense_dense_float_trailing_dim() -> (tensor<2x2xf32>, tensor<2x2x2xf32>, tensor<2x2x2xf32>) {
+  %cst_0 = constant dense<[1., -4.]> : tensor<2xf32>
+  %cst_1 = constant dense<[[-5.5, 1.5], [7.5, -4.5]]> : tensor<2x2xf32>
+  %cst_2 = constant dense<[[[1., 1.], [2., 2.]], [[3., 3.], [4., 4.]]]> : tensor<2x2x2xf32>
+
+  %0 = "tfl.add"(%cst_0, %cst_1) {fused_activation_function = "NONE"} : (tensor<    2xf32>, tensor<  2x2xf32>) -> tensor<  2x2xf32>
+  %1 = "tfl.add"(%cst_2, %cst_1) {fused_activation_function = "NONE"} : (tensor<2x2x2xf32>, tensor<  2x2xf32>) -> tensor<2x2x2xf32>
+  %2 = "tfl.add"(%cst_0, %cst_2) {fused_activation_function = "NONE"} : (tensor<    2xf32>, tensor<2x2x2xf32>) -> tensor<2x2x2xf32>
+
+  return %0, %1, %2 : tensor<2x2xf32>, tensor<2x2x2xf32>, tensor<2x2x2xf32>
+
+// CHECK:  %cst = constant dense<{{\[\[}}-4.500000e+00, -2.500000e+00], [8.500000e+00, -8.500000e+00]]> : tensor<2x2xf32>
+// CHECK:  %cst_0 = constant dense<{{\[\[\[}}-4.500000e+00, 2.500000e+00], [9.500000e+00, -2.500000e+00]], {{\[\[}}-2.500000e+00, 4.500000e+00], [1.150000e+01, -5.000000e-01]]]> : tensor<2x2x2xf32>
+// CHECK:  %cst_1 = constant dense<{{\[\[\[}}2.000000e+00, -3.000000e+00], [3.000000e+00, -2.000000e+00]], {{\[\[}}4.000000e+00, -1.000000e+00], [5.000000e+00, 0.000000e+00]]]> : tensor<2x2x2xf32>
+// CHECK:  return %cst, %cst_0, %cst_1
+}
+
+// CHECK-LABEL: @add_dense_dense_float_mixfng_1_n
+func @add_dense_dense_float_mixfng_1_n() -> tensor<2x2xf32> {
+  %cst_0 = constant dense<[[1.5, -2.5]]> : tensor<1x2xf32>
+  %cst_1 = constant dense<[[-3.], [4.]]> : tensor<2x1xf32>
+
+  %0 = "tfl.add"(%cst_0, %cst_1) {fused_activation_function = "NONE"} : (tensor<1x2xf32>, tensor<2x1xf32>) -> tensor<2x2xf32>
+
+  return %0 : tensor<2x2xf32>
+
+// We don't support this case yet.
+// CHECK:  %0 = "tfl.add"
+// CHECK:  return %0
+}
+
+// CHECK-LABEL: @rank
+func @rank() -> tensor<1xi32> {
+  %cst = constant dense<[[1], [2]]> : tensor<2x1xi32>
+
+  // CHECK: [[cst:%.*]] = constant dense<2> : tensor<1xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.rank"(%cst) : (tensor<2x1xi32>) -> tensor<1xi32>
+  return %0 : tensor<1xi32>
+}
+
+// CHECK-LABEL: @rank_input_known_rank
+func @rank_input_known_rank(%arg0 : tensor<2x1xi32>) -> tensor<1xi32> {
+  // CHECK: [[cst:%.*]] = constant dense<2> : tensor<1xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.rank"(%arg0) : (tensor<2x1xi32>) -> tensor<1xi32>
+  return %0 : tensor<1xi32>
+}
+
+// CHECK-LABEL: @reshape
+func @reshape() -> tensor<1x2xi32> {
+  %cst = constant dense<[1, 2]> : tensor<2xi32>
+
+  // CHECK: [[cst:%.*]] = constant dense<{{\[\[}}1, 2]]> : tensor<1x2xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.reshape"(%cst) : (tensor<2xi32>) -> tensor<1x2xi32>
+  return %0 : tensor<1x2xi32>
+}
+// CHECK-LABEL: @pseudo_const
+func @pseudo_const() -> tensor<i32> {
+  // CHECK: [[cst:%.*]] = constant dense<1> : tensor<i32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.pseudo_const"() {value = dense<1> : tensor<i32>} : () -> tensor<i32>
+  return %0 : tensor<i32>
+}
+
+
+// CHECK-LABEL: @range_int
+func @range_int() -> tensor<?xi32> {
+  %cst = constant dense<0> : tensor<i32>
+  %cst_1 = constant dense<4> : tensor<i32>
+  %cst_2 = constant dense<1> : tensor<i32>
+
+  // CHECK: [[cst:%.*]] = "tfl.pseudo_const"() {value = dense<[0, 1, 2, 3]> : tensor<4xi32>} : () -> tensor<?xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.range"(%cst, %cst_1, %cst_2) : (tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<?xi32>
+  return %0 : tensor<?xi32>
+}
+
+// CHECK-LABEL: @range_float
+func @range_float() -> tensor<?xf32> {
+  %cst = constant dense<0.0> : tensor<f32>
+  %cst_1 = constant dense<4.0> : tensor<f32>
+  %cst_2 = constant dense<1.0> : tensor<f32>
+
+  // CHECK: [[cst:%.*]] = "tfl.pseudo_const"() {value = dense<[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<4xf32>} : () -> tensor<?xf32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.range"(%cst, %cst_1, %cst_2) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+
+// CHECK-LABEL: @range_float_neg_delta
+func @range_float_neg_delta() -> tensor<?xf32> {
+  %cst = constant dense<0.0> : tensor<f32>
+  %cst_1 = constant dense<-4.0> : tensor<f32>
+  %cst_2 = constant dense<-1.0> : tensor<f32>
+
+  // CHECK: [[cst:%.*]] = "tfl.pseudo_const"() {value = dense<[0.000000e+00, -1.000000e+00, -2.000000e+00, -3.000000e+00]> : tensor<4xf32>} : () -> tensor<?xf32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.range"(%cst, %cst_1, %cst_2) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// CHECK-LABEL: @range_float_nonzero_base
+func @range_float_nonzero_base() -> tensor<?xf32> {
+  %cst = constant dense<2.0> : tensor<f32>
+  %cst_1 = constant dense<7.0> : tensor<f32>
+  %cst_2 = constant dense<1.5> : tensor<f32>
+
+  // CHECK: [[cst:%.*]] = "tfl.pseudo_const"() {value = dense<[2.000000e+00, 3.500000e+00, 5.000000e+00, 6.500000e+00]> : tensor<4xf32>} : () -> tensor<?xf32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.range"(%cst, %cst_1, %cst_2) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// CHECK-LABEL: @transpose_no_fold
+func @transpose_no_fold(%arg0 : tensor<2xi32>) -> tensor<2x2xi32> {
+  %cst = constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+
+  // CHECK: tfl.transpose
+  %0 = "tfl.transpose"(%cst, %arg0) : (tensor<2x2xi32>, tensor<2xi32>) -> tensor<2x2xi32>
+  return %0 : tensor<2x2xi32>
+}
+
+// CHECK-LABEL: @transpose_1d
+// Basic 1D identity
+func @transpose_1d() -> tensor<3xi32> {
+  %cst = constant dense<[1, 2, 3]> : tensor<3xi32>
+  %cst_perm = constant dense<0> : tensor<1xi32>
+
+  // CHECK: [[cst:%.*]] = constant dense<{{\[}}1, 2, 3]> : tensor<3xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.transpose"(%cst, %cst_perm) : (tensor<3xi32>, tensor<1xi32>) -> tensor<3xi32>
+  return %0 : tensor<3xi32>
+}
+
+// CHECK-LABEL: @transpose_dynamic
+func @transpose_dynamic() -> tensor<?xi32> {
+  %cst = constant dense<[1, 2, 3]> : tensor<3xi32>
+  %cst_perm = constant dense<0> : tensor<1xi32>
+
+  // CHECK: [[cst:%.*]] = "tfl.pseudo_const"() {value = dense<{{\[}}1, 2, 3]> : tensor<3xi32>} : () -> tensor<?xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.transpose"(%cst, %cst_perm) : (tensor<3xi32>, tensor<1xi32>) -> tensor<?xi32>
+  return %0 : tensor<?xi32>
+}
+
+// CHECK-LABEL: @transpose_2d
+func @transpose_2d() -> tensor<2x2xi32> {
+  %cst = constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %cst_perm = constant dense<[1, 0]> : tensor<2xi32>
+
+  // CHECK: [[cst:%.*]] = constant dense<{{\[\[}}0, 2], {{\[}}1, 3]]> : tensor<2x2xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.transpose"(%cst, %cst_perm) : (tensor<2x2xi32>, tensor<2xi32>) -> tensor<2x2xi32>
+  return %0 : tensor<2x2xi32>
+}
+
+// CHECK-LABEL: @transpose_2d_identity
+func @transpose_2d_identity() -> tensor<2x2xi32> {
+  %cst = constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %cst_perm = constant dense<[0, 1]> : tensor<2xi32>
+
+  // CHECK: [[cst:%.*]] = constant dense<{{\[\[}}0, 1], {{\[}}2, 3]]> : tensor<2x2xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.transpose"(%cst, %cst_perm) : (tensor<2x2xi32>, tensor<2xi32>) -> tensor<2x2xi32>
+  return %0 : tensor<2x2xi32>
+}
+
+// CHECK-LABEL: @transpose_3d
+// A test case adopted from TransposeTest.Test3DInputConstTensor in
+// tensorflow/lite/kernels/transpose_test.cc
+func @transpose_3d() -> tensor<4x2x3xi32> {
+  %cst = constant dense<[[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]]]> : tensor<2x3x4xi32>
+  %cst_perm = constant dense<[2, 0, 1]> : tensor<3xi32>
+
+  // CHECK: [[cst:%.*]] = constant dense<{{\[\[\[}}0, 4, 8], {{\[}}12, 16, 20]], {{\[\[}}1, 5, 9], {{\[}}13, 17, 21]], {{\[\[}}2, 6, 10], {{\[}}14, 18, 22]], {{\[\[}}3, 7, 11], {{\[}}15, 19, 23]]]> : tensor<4x2x3xi32>
+  // CHECK: return [[cst]]
+  %0 = "tfl.transpose"(%cst, %cst_perm) : (tensor<2x3x4xi32>, tensor<3xi32>) -> tensor<4x2x3xi32>
+  return %0 : tensor<4x2x3xi32>
+}

--- a/samples/MLIR/core-ops.mlir
+++ b/samples/MLIR/core-ops.mlir
@@ -1,0 +1,454 @@
+// RUN: mlir-opt %s | FileCheck %s
+// Verify the printed output can be parsed.
+// RUN: mlir-opt %s | mlir-opt | FileCheck %s
+// Verify the generic form can be parsed.
+// RUN: mlir-opt -mlir-print-op-generic %s | mlir-opt | FileCheck %s
+
+// CHECK: #map0 = (d0) -> (d0 + 1)
+
+// CHECK: #map1 = ()[s0] -> (s0 + 1)
+// CHECK-DAG: #[[map_proj_d0d1_d0:map[0-9]+]] = (d0, d1) -> (d0)
+// CHECK-DAG: #[[map_proj_d0d1_d1:map[0-9]+]] = (d0, d1) -> (d1)
+// CHECK-DAG: #[[map_proj_d0d1_d1d0:map[0-9]+]] = (d0, d1) -> (d1, d0)
+
+// CHECK-LABEL: func @func_with_ops(%arg0: f32) {
+func @func_with_ops(f32) {
+^bb0(%a : f32):
+  // CHECK: %0 = "getTensor"() : () -> tensor<4x4x?xf32>
+  %t = "getTensor"() : () -> tensor<4x4x?xf32>
+
+  // CHECK: %1 = dim %0, 2 : tensor<4x4x?xf32>
+  %t2 = "std.dim"(%t){index = 2} : (tensor<4x4x?xf32>) -> index
+
+  // CHECK: %2 = addf %arg0, %arg0 : f32
+  %x = "std.addf"(%a, %a) : (f32,f32) -> (f32)
+
+  // CHECK:   return
+  return
+}
+
+// CHECK-LABEL: func @standard_instrs(%arg0: tensor<4x4x?xf32>, %arg1: f32, %arg2: i32, %arg3: index, %arg4: i64) {
+func @standard_instrs(tensor<4x4x?xf32>, f32, i32, index, i64) {
+^bb42(%t: tensor<4x4x?xf32>, %f: f32, %i: i32, %idx : index, %j: i64):
+  // CHECK: %0 = dim %arg0, 2 : tensor<4x4x?xf32>
+  %a = "std.dim"(%t){index = 2} : (tensor<4x4x?xf32>) -> index
+
+  // CHECK: %1 = dim %arg0, 2 : tensor<4x4x?xf32>
+  %a2 = dim %t, 2 : tensor<4x4x?xf32>
+
+  // CHECK: %2 = addf %arg1, %arg1 : f32
+  %f2 = "std.addf"(%f, %f) : (f32,f32) -> f32
+
+  // CHECK: %3 = addf %2, %2 : f32
+  %f3 = addf %f2, %f2 : f32
+
+  // CHECK: %4 = addi %arg2, %arg2 : i32
+  %i2 = "std.addi"(%i, %i) : (i32,i32) -> i32
+
+  // CHECK: %5 = addi %4, %4 : i32
+  %i3 = addi %i2, %i2 : i32
+
+  // CHECK: %{{[0-9]+}} = addi %arg3, %arg3 : index
+  %idx1 = addi %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = addi %arg3, %{{[0-9]+}} : index
+  %idx2 = "std.addi"(%idx, %idx1) : (index, index) -> index
+
+  // CHECK: %8 = subf %arg1, %arg1 : f32
+  %f4 = "std.subf"(%f, %f) : (f32,f32) -> f32
+
+  // CHECK: %9 = subf %8, %8 : f32
+  %f5 = subf %f4, %f4 : f32
+
+  // CHECK: %10 = subi %arg2, %arg2 : i32
+  %i4 = "std.subi"(%i, %i) : (i32,i32) -> i32
+
+  // CHECK: %11 = subi %10, %10 : i32
+  %i5 = subi %i4, %i4 : i32
+
+  // CHECK: %12 = mulf %2, %2 : f32
+  %f6 = mulf %f2, %f2 : f32
+
+  // CHECK: %13 = muli %4, %4 : i32
+  %i6 = muli %i2, %i2 : i32
+
+  // CHECK: %c42_i32 = constant 42 : i32
+  %x = "std.constant"(){value = 42 : i32} : () -> i32
+
+  // CHECK: %c42_i32_0 = constant 42 : i32
+  %7 = constant 42 : i32
+
+  // CHECK: %c43 = constant {crazy = "std.foo"} 43 : index
+  %8 = constant {crazy = "std.foo"} 43: index
+
+  // CHECK: %cst = constant 4.300000e+01 : bf16
+  %9 = constant 43.0 : bf16
+
+  // CHECK: %f = constant @func_with_ops : (f32) -> ()
+  %10 = constant @func_with_ops : (f32) -> ()
+
+  // CHECK: %f_1 = constant @affine_apply : () -> ()
+  %11 = constant @affine_apply : () -> ()
+
+  // CHECK: %f_2 = constant @affine_apply : () -> ()
+  %12 = constant @affine_apply : () -> ()
+
+  // CHECK: %cst_3 = constant dense<0> : vector<4xi32>
+  %13 = constant dense<0> : vector<4 x i32>
+
+  // CHECK: %cst_4 = constant dense<0> : tensor<42xi32>
+  %tci32 = constant dense<0> : tensor<42 x i32>
+
+  // CHECK: %cst_5 = constant dense<0> : vector<42xi32>
+  %vci32 = constant dense<0> : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = cmpi "eq", %{{[0-9]+}}, %{{[0-9]+}} : i32
+  %14 = cmpi "eq", %i3, %i4 : i32
+
+  // Predicate 1 means inequality comparison.
+  // CHECK: %{{[0-9]+}} = cmpi "ne", %{{[0-9]+}}, %{{[0-9]+}} : i32
+  %15 = "std.cmpi"(%i3, %i4) {predicate = 1} : (i32, i32) -> i1
+
+  // CHECK: %{{[0-9]+}} = cmpi "slt", %cst_3, %cst_3 : vector<4xi32>
+  %16 = cmpi "slt", %13, %13 : vector<4 x i32>
+
+  // CHECK: %{{[0-9]+}} = cmpi "ne", %cst_3, %cst_3 : vector<4xi32>
+  %17 = "std.cmpi"(%13, %13) {predicate = 1} : (vector<4 x i32>, vector<4 x i32>) -> vector<4 x i1>
+
+  // CHECK: %{{[0-9]+}} = cmpi "slt", %arg3, %arg3 : index
+  %18 = cmpi "slt", %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = cmpi "eq", %cst_4, %cst_4 : tensor<42xi32>
+  %19 = cmpi "eq", %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = cmpi "eq", %cst_5, %cst_5 : vector<42xi32>
+  %20 = cmpi "eq", %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = select %{{[0-9]+}}, %arg3, %arg3 : index
+  %21 = select %18, %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = select %{{[0-9]+}}, %cst_4, %cst_4 : tensor<42xi32>
+  %22 = select %19, %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = select %{{[0-9]+}}, %cst_5, %cst_5 : vector<42xi32>
+  %23 = select %20, %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = select %{{[0-9]+}}, %arg3, %arg3 : index
+  %24 = "std.select"(%18, %idx, %idx) : (i1, index, index) -> index
+
+  // CHECK: %{{[0-9]+}} = select %{{[0-9]+}}, %cst_4, %cst_4 : tensor<42xi32>
+  %25 = "std.select"(%19, %tci32, %tci32) : (tensor<42 x i1>, tensor<42 x i32>, tensor<42 x i32>) -> tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = divis %arg2, %arg2 : i32
+  %26 = divis %i, %i : i32
+
+  // CHECK: %{{[0-9]+}} = divis %arg3, %arg3 : index
+  %27 = divis %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = divis %cst_5, %cst_5 : vector<42xi32>
+  %28 = divis %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = divis %cst_4, %cst_4 : tensor<42xi32>
+  %29 = divis %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = divis %arg2, %arg2 : i32
+  %30 = "std.divis"(%i, %i) : (i32, i32) -> i32
+
+  // CHECK: %{{[0-9]+}} = diviu %arg2, %arg2 : i32
+  %31 = diviu %i, %i : i32
+
+  // CHECK: %{{[0-9]+}} = diviu %arg3, %arg3 : index
+  %32 = diviu %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = diviu %cst_5, %cst_5 : vector<42xi32>
+  %33 = diviu %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = diviu %cst_4, %cst_4 : tensor<42xi32>
+  %34 = diviu %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = diviu %arg2, %arg2 : i32
+  %35 = "std.diviu"(%i, %i) : (i32, i32) -> i32
+
+  // CHECK: %{{[0-9]+}} = remis %arg2, %arg2 : i32
+  %36 = remis %i, %i : i32
+
+  // CHECK: %{{[0-9]+}} = remis %arg3, %arg3 : index
+  %37 = remis %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = remis %cst_5, %cst_5 : vector<42xi32>
+  %38 = remis %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = remis %cst_4, %cst_4 : tensor<42xi32>
+  %39 = remis %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = remis %arg2, %arg2 : i32
+  %40 = "std.remis"(%i, %i) : (i32, i32) -> i32
+
+  // CHECK: %{{[0-9]+}} = remiu %arg2, %arg2 : i32
+  %41 = remiu %i, %i : i32
+
+  // CHECK: %{{[0-9]+}} = remiu %arg3, %arg3 : index
+  %42 = remiu %idx, %idx : index
+
+  // CHECK: %{{[0-9]+}} = remiu %cst_5, %cst_5 : vector<42xi32>
+  %43 = remiu %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = remiu %cst_4, %cst_4 : tensor<42xi32>
+  %44 = remiu %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = remiu %arg2, %arg2 : i32
+  %45 = "std.remiu"(%i, %i) : (i32, i32) -> i32
+
+  // CHECK: %{{[0-9]+}} = divf %arg1, %arg1 : f32
+  %46 = "std.divf"(%f, %f) : (f32,f32) -> f32
+
+  // CHECK: %{{[0-9]+}} = divf %arg1, %arg1 : f32
+  %47 = divf %f, %f : f32
+
+  // CHECK: %{{[0-9]+}} = divf %arg0, %arg0 : tensor<4x4x?xf32>
+  %48 = divf %t, %t : tensor<4x4x?xf32>
+
+  // CHECK: %{{[0-9]+}} = remf %arg1, %arg1 : f32
+  %49 = "std.remf"(%f, %f) : (f32,f32) -> f32
+
+  // CHECK: %{{[0-9]+}} = remf %arg1, %arg1 : f32
+  %50 = remf %f, %f : f32
+
+  // CHECK: %{{[0-9]+}} = remf %arg0, %arg0 : tensor<4x4x?xf32>
+  %51 = remf %t, %t : tensor<4x4x?xf32>
+
+  // CHECK: %{{[0-9]+}} = and %arg2, %arg2 : i32
+  %52 = "std.and"(%i, %i) : (i32,i32) -> i32
+
+  // CHECK: %{{[0-9]+}} = and %arg2, %arg2 : i32
+  %53 = and %i, %i : i32
+
+  // CHECK: %{{[0-9]+}} = and %cst_5, %cst_5 : vector<42xi32>
+  %54 = std.and %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = and %cst_4, %cst_4 : tensor<42xi32>
+  %55 = and %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = or %arg2, %arg2 : i32
+  %56 = "std.or"(%i, %i) : (i32,i32) -> i32
+
+  // CHECK: %{{[0-9]+}} = or %arg2, %arg2 : i32
+  %57 = or %i, %i : i32
+
+  // CHECK: %{{[0-9]+}} = or %cst_5, %cst_5 : vector<42xi32>
+  %58 = std.or %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = or %cst_4, %cst_4 : tensor<42xi32>
+  %59 = or %tci32, %tci32 : tensor<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = xor %arg2, %arg2 : i32
+  %60 = "std.xor"(%i, %i) : (i32,i32) -> i32
+
+  // CHECK: %{{[0-9]+}} = xor %arg2, %arg2 : i32
+  %61 = xor %i, %i : i32
+
+  // CHECK: %{{[0-9]+}} = xor %cst_5, %cst_5 : vector<42xi32>
+  %62 = std.xor %vci32, %vci32 : vector<42 x i32>
+
+  // CHECK: %{{[0-9]+}} = xor %cst_4, %cst_4 : tensor<42xi32>
+  %63 = xor %tci32, %tci32 : tensor<42 x i32>
+
+  %64 = constant dense<0.> : vector<4 x f32>
+  %tcf32 = constant dense<0.> : tensor<42 x f32>
+  %vcf32 = constant dense<0.> : vector<4 x f32>
+
+  // CHECK: %{{[0-9]+}} = cmpf "ogt", %{{[0-9]+}}, %{{[0-9]+}} : f32
+  %65 = cmpf "ogt", %f3, %f4 : f32
+
+  // Predicate 0 means ordered equality comparison.
+  // CHECK: %{{[0-9]+}} = cmpf "oeq", %{{[0-9]+}}, %{{[0-9]+}} : f32
+  %66 = "std.cmpf"(%f3, %f4) {predicate = 1} : (f32, f32) -> i1
+
+  // CHECK: %{{[0-9]+}} = cmpf "olt", %cst_8, %cst_8 : vector<4xf32>
+  %67 = cmpf "olt", %vcf32, %vcf32 : vector<4 x f32>
+
+  // CHECK: %{{[0-9]+}} = cmpf "oeq", %cst_8, %cst_8 : vector<4xf32>
+  %68 = "std.cmpf"(%vcf32, %vcf32) {predicate = 1} : (vector<4 x f32>, vector<4 x f32>) -> vector<4 x i1>
+
+  // CHECK: %{{[0-9]+}} = cmpf "oeq", %cst_7, %cst_7 : tensor<42xf32>
+  %69 = cmpf "oeq", %tcf32, %tcf32 : tensor<42 x f32>
+
+  // CHECK: %{{[0-9]+}} = cmpf "oeq", %cst_8, %cst_8 : vector<4xf32>
+  %70 = cmpf "oeq", %vcf32, %vcf32 : vector<4 x f32>
+
+  // CHECK: %{{[0-9]+}} = rank %arg0 : tensor<4x4x?xf32>
+  %71 = "std.rank"(%t) : (tensor<4x4x?xf32>) -> index
+
+  // CHECK: %{{[0-9]+}} = rank %arg0 : tensor<4x4x?xf32>
+  %72 = rank %t : tensor<4x4x?xf32>
+
+  // CHECK: = constant unit
+  %73 = constant unit
+
+  // CHECK: constant true
+  %74 = constant true
+
+  // CHECK: constant false
+  %75 = constant false
+
+  // CHECK: = index_cast {{.*}} : index to i64
+  %76 = index_cast %idx : index to i64
+
+  // CHECK: = index_cast {{.*}} : i32 to index
+  %77 = index_cast %i : i32 to index
+
+  // CHECK: = sitofp {{.*}} : i32 to f32
+  %78 = sitofp %i : i32 to f32
+
+  // CHECK: = sitofp {{.*}} : i32 to f64
+  %79 = sitofp %i : i32 to f64
+
+  // CHECK: = sitofp {{.*}} : i64 to f32
+  %80 = sitofp %j : i64 to f32
+
+  // CHECK: = sitofp {{.*}} : i64 to f64
+  %81 = sitofp %j : i64 to f64
+
+  return
+}
+
+// CHECK-LABEL: func @affine_apply() {
+func @affine_apply() {
+  %i = "std.constant"() {value = 0: index} : () -> index
+  %j = "std.constant"() {value = 1: index} : () -> index
+
+  // CHECK: affine.apply #map0(%c0)
+  %a = "affine.apply" (%i) { map = (d0) -> (d0 + 1) } :
+    (index) -> (index)
+
+  // CHECK: affine.apply #map1()[%c0]
+  %b = affine.apply ()[x] -> (x+1)()[%i]
+
+  return
+}
+
+// CHECK-LABEL: func @load_store
+func @load_store(memref<4x4xi32>, index) {
+^bb0(%0: memref<4x4xi32>, %1: index):
+  // CHECK: %0 = load %arg0[%arg1, %arg1] : memref<4x4xi32>
+  %2 = "std.load"(%0, %1, %1) : (memref<4x4xi32>, index, index)->i32
+
+  // CHECK: %1 = load %arg0[%arg1, %arg1] : memref<4x4xi32>
+  %3 = load %0[%1, %1] : memref<4x4xi32>
+
+  return
+}
+
+// Test with zero-dimensional operands using no index in load/store.
+// CHECK-LABEL: func @zero_dim_no_idx
+func @zero_dim_no_idx(%arg0 : memref<i32>, %arg1 : memref<i32>, %arg2 : memref<i32>) {
+  %0 = std.load %arg0[] : memref<i32>
+  std.store %0, %arg1[] : memref<i32>
+  return
+  // CHECK: %0 = load %{{.*}}[] : memref<i32>
+  // CHECK: store %{{.*}}, %{{.*}}[] : memref<i32>
+}
+
+// CHECK-LABEL: func @return_op(%arg0: i32) -> i32 {
+func @return_op(%a : i32) -> i32 {
+  // CHECK: return %arg0 : i32
+  "std.return" (%a) : (i32)->()
+}
+
+// CHECK-LABEL: func @calls(%arg0: i32) {
+func @calls(%arg0: i32) {
+  // CHECK: %0 = call @return_op(%arg0) : (i32) -> i32
+  %x = call @return_op(%arg0) : (i32) -> i32
+  // CHECK: %1 = call @return_op(%0) : (i32) -> i32
+  %y = call @return_op(%x) : (i32) -> i32
+  // CHECK: %2 = call @return_op(%0) : (i32) -> i32
+  %z = "std.call"(%x) {callee = @return_op} : (i32) -> i32
+
+  // CHECK: %f = constant @affine_apply : () -> ()
+  %f = constant @affine_apply : () -> ()
+
+  // CHECK: call_indirect %f() : () -> ()
+  call_indirect %f() : () -> ()
+
+  // CHECK: %f_0 = constant @return_op : (i32) -> i32
+  %f_0 = constant @return_op : (i32) -> i32
+
+  // CHECK: %3 = call_indirect %f_0(%arg0) : (i32) -> i32
+  %2 = call_indirect %f_0(%arg0) : (i32) -> i32
+
+  // CHECK: %4 = call_indirect %f_0(%arg0) : (i32) -> i32
+  %3 = "std.call_indirect"(%f_0, %arg0) : ((i32) -> i32, i32) -> i32
+
+  return
+}
+
+// CHECK-LABEL: func @extract_element(%arg0: tensor<*xi32>, %arg1: tensor<4x4xf32>) -> i32 {
+func @extract_element(%arg0: tensor<*xi32>, %arg1 : tensor<4x4xf32>) -> i32 {
+  %c0 = "std.constant"() {value = 0: index} : () -> index
+
+  // CHECK: %0 = extract_element %arg0[%c0, %c0, %c0, %c0] : tensor<*xi32>
+  %0 = extract_element %arg0[%c0, %c0, %c0, %c0] : tensor<*xi32>
+
+  // CHECK: %1 = extract_element %arg1[%c0, %c0] : tensor<4x4xf32>
+  %1 = extract_element %arg1[%c0, %c0] : tensor<4x4xf32>
+
+  return %0 : i32
+}
+
+// CHECK-LABEL: func @tensor_cast(%arg0
+func @tensor_cast(%arg0: tensor<*xf32>, %arg1 : tensor<4x4xf32>, %arg2: tensor<?x?xf32>) {
+  // CHECK: %0 = tensor_cast %arg0 : tensor<*xf32> to tensor<?x?xf32>
+  %0 = tensor_cast %arg0 : tensor<*xf32> to tensor<?x?xf32>
+
+  // CHECK: %1 = tensor_cast %arg1 : tensor<4x4xf32> to tensor<*xf32>
+  %1 = tensor_cast %arg1 : tensor<4x4xf32> to tensor<*xf32>
+
+  // CHECK: %2 = tensor_cast %arg2 : tensor<?x?xf32> to tensor<4x?xf32>
+  %2 = tensor_cast %arg2 : tensor<?x?xf32> to tensor<4x?xf32>
+
+  // CHECK: %3 = tensor_cast %2 : tensor<4x?xf32> to tensor<?x?xf32>
+  %3 = tensor_cast %2 : tensor<4x?xf32> to tensor<?x?xf32>
+
+  return
+}
+
+// CHECK-LABEL: func @memref_cast(%arg0
+func @memref_cast(%arg0: memref<4xf32>, %arg1 : memref<?xf32>) {
+  // CHECK: %0 = memref_cast %arg0 : memref<4xf32> to memref<?xf32>
+  %0 = memref_cast %arg0 : memref<4xf32> to memref<?xf32>
+
+  // CHECK: %1 = memref_cast %arg1 : memref<?xf32> to memref<4xf32>
+  %1 = memref_cast %arg1 : memref<?xf32> to memref<4xf32>
+  return
+}
+
+// CHECK-LABEL: func @test_dimop(%arg0
+func @test_dimop(%arg0: tensor<4x4x?xf32>) {
+  // CHECK: %0 = dim %arg0, 2 : tensor<4x4x?xf32>
+  %0 = dim %arg0, 2 : tensor<4x4x?xf32>
+  // use dim as an affine_int to ensure type correctness
+  %1 = affine.apply (d0) -> (d0)(%0)
+  return
+}
+
+
+// CHECK-LABEL: func @test_vector.transfer_ops(%arg0
+func @test_vector.transfer_ops(%arg0: memref<?x?xf32>) {
+  %c3 = constant 3 : index
+  %cst = constant 3.0 : f32
+  // CHECK: %0 = vector.transfer_read %arg0[%c3, %c3] {permutation_map = #[[map_proj_d0d1_d0]]} : memref<?x?xf32>, vector<128xf32>
+  %0 = vector.transfer_read %arg0[%c3, %c3] {permutation_map = (d0, d1)->(d0)} : memref<?x?xf32>, vector<128xf32>
+  // CHECK: %1 = vector.transfer_read %arg0[%c3, %c3] {permutation_map = #[[map_proj_d0d1_d1d0]]} : memref<?x?xf32>, vector<3x7xf32>
+  %1 = vector.transfer_read %arg0[%c3, %c3] {permutation_map = (d0, d1)->(d1, d0)} : memref<?x?xf32>, vector<3x7xf32>
+  // CHECK: %2 = vector.transfer_read %arg0[%c3, %c3], (%cst) {permutation_map = #[[map_proj_d0d1_d0]]} : memref<?x?xf32>,  vector<128xf32>
+  %2 = vector.transfer_read %arg0[%c3, %c3], (%cst) {permutation_map = (d0, d1)->(d0)} : memref<?x?xf32>,  vector<128xf32>
+  // CHECK: %3 = vector.transfer_read %arg0[%c3, %c3], (%cst) {permutation_map = #[[map_proj_d0d1_d1]]} : memref<?x?xf32>,  vector<128xf32>
+  %3 = vector.transfer_read %arg0[%c3, %c3], (%cst) {permutation_map = (d0, d1)->(d1)} : memref<?x?xf32>,  vector<128xf32>
+  //
+  // CHECK: vector.transfer_write %0, %arg0[%c3, %c3] {permutation_map = #[[map_proj_d0d1_d0]]} : vector<128xf32>, memref<?x?xf32>
+  vector.transfer_write %0, %arg0[%c3, %c3] {permutation_map = (d0, d1)->(d0)} : vector<128xf32>, memref<?x?xf32>
+  // CHECK: vector.transfer_write %1, %arg0[%c3, %c3] {permutation_map = #[[map_proj_d0d1_d1d0]]} : vector<3x7xf32>, memref<?x?xf32>
+  vector.transfer_write %1, %arg0[%c3, %c3] {permutation_map = (d0, d1)->(d1, d0)} : vector<3x7xf32>, memref<?x?xf32>
+  return
+}
+

--- a/samples/MLIR/executor_to_control_dialect.mlir
+++ b/samples/MLIR/executor_to_control_dialect.mlir
@@ -1,0 +1,87 @@
+// RUN: tf-opt -tf-executor-to-control-conversion %s  | FileCheck %s --dump-input=fail
+
+// CHECK-LABEL: func @LoopTest() {
+func @LoopTest() {
+  tf_executor.graph {
+    %0:2 = tf_executor.island {
+      %cst = "tf.Const"() {device = "", dtype = "tfdtype$DT_INT32", name = "Const", value = dense<1> : tensor<i32>} : () -> tensor<i32>
+      tf_executor.yield %cst : tensor<i32>
+    }
+    %1:2 = tf_executor.Enter %0#0 frame "while/while_context" : (tensor<i32>) -> (tensor<*xi32>, !tf_executor.control) {T = "tfdtype$DT_INT32", device = "", name = "while/Enter"}
+    %2 = tf_executor.island {
+      "tf.NoOp"() {device = "", name = "cluster/pivot"} : () -> ()
+      tf_executor.yield
+    }
+    %3:3 = tf_executor.NextIteration.Source : tensor<*xi32> {T = "tfdtype$DT_INT32", device = "", id = 0 : i64, name = "while/NextIteration"}
+    %4:3 = tf_executor.Merge %3#0, %1#0 : tensor<*xi32> {N = 2 : i64, T = "tfdtype$DT_INT32", device = "", name = "while/Merge"}
+    %5:2 = tf_executor.island(%4#2) {
+      %cst = "tf.Const"() {device = "", dtype = "tfdtype$DT_INT32", name = "while/Less/y", value = dense<2> : tensor<i32>} : () -> tensor<i32>
+      tf_executor.yield %cst : tensor<i32>
+    }
+    %6:2 = tf_executor.island {
+      %14 = "tf.Less"(%4#0, %5#0) {T = "tfdtype$DT_INT32", device = "", name = "while/Less"} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi1>
+      tf_executor.yield %14 : tensor<*xi1>
+    }
+    %7:2 = tf_executor.LoopCond %6#0 : (tensor<*xi1>) -> (tensor<i1>, !tf_executor.control) {device = "", name = "while/LoopCond"}
+    %8:3 = tf_executor.Switch %4#0, %7#0 : tensor<*xi32> {T = "tfdtype$DT_INT32", _class = ["loc = @while/Merge"], device = "", name = "while/Switch"}
+    %9:2 = tf_executor.Exit %8#0 : tensor<*xi32> {T = "tfdtype$DT_INT32", device = "", name = "while/Exit"}
+    %10:2 = tf_executor.island {
+      %14 = "tf.Identity"(%8#1) {T = "tfdtype$DT_INT32", device = "", name = "while/Identity"} : (tensor<*xi32>) -> tensor<*xi32>
+      tf_executor.yield %14 : tensor<*xi32>
+    }
+    %11:2 = tf_executor.island(%10#1) {
+      %cst = "tf.Const"() {device = "", dtype = "tfdtype$DT_INT32", name = "while/Add/y", value = dense<3> : tensor<i32>} : () -> tensor<i32>
+      tf_executor.yield %cst : tensor<i32>
+    }
+    %12:2 = tf_executor.island {
+      %14 = "tf.Add"(%10#0, %11#0) {T = "tfdtype$DT_INT32", device = "", name = "while/Add"} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi32>
+      tf_executor.yield %14 : tensor<*xi32>
+    }
+    %13 = tf_executor.ControlTrigger %2, %12#1, %9#1 {_tpu_replicate = "cluster", device = "", name = "gradients/while/mul_2_Da30D05wlPU_grad/SymbolicGradient/b_sync"}
+    tf_executor.NextIteration.Sink [%3#1] %12#0, %13 : tensor<*xi32> {T = "tfdtype$DT_INT32", device = "", id = 0 : i64, name = "while/NextIteration"}
+    tf_executor.fetch
+  }
+  return
+}
+
+// CHECK-NEXT:   %[[CONST:[0-9]*]]:2 = "_tf.Const"() {device = "", dtype = "tfdtype$DT_INT32", name = "Const", value = dense<1> : tensor<i32>} : () -> (tensor<i32>, !_tf.control)
+// CHECK-NEXT:   %[[ENTER:[0-9]*]]:2 = "_tf.Enter"(%[[CONST]]#0) {T = "tfdtype$DT_INT32", device = "", frame_name = "while/while_context", is_constant = false, name = "while/Enter", parallel_iterations = 10 : i64} : (tensor<i32>) -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT:   %[[NOOP:[0-9]*]] = "_tf.NoOp"() {device = "", name = "cluster/pivot"} : () -> !_tf.control
+// CHECK-NEXT:   %[[SOURCE:[0-9]*]]:2 = "_tf.NextIteration.source"() {T = "tfdtype$DT_INT32", device = "", id = 0 : i64, name = "while/NextIteration"} : () -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT:   %[[MERGE:[0-9]*]]:3 = "_tf.Merge"(%[[SOURCE]]#0, %[[ENTER]]#0) {N = 2 : i64, T = "tfdtype$DT_INT32", device = "", name = "while/Merge"} : (tensor<*xi32>, tensor<*xi32>) -> (tensor<*xi32>, tensor<i32>, !_tf.control)
+// CHECK-NEXT:   %[[CONST_LESS:[0-9]*]]:2 = "_tf.Const"(%[[MERGE]]#2) {device = "", dtype = "tfdtype$DT_INT32", name = "while/Less/y", value = dense<2> : tensor<i32>} : (!_tf.control) -> (tensor<i32>, !_tf.control)
+// CHECK-NEXT:   %[[LESS:[0-9]*]]:2 = "_tf.Less"(%[[MERGE]]#0, %[[CONST_LESS]]#0) {T = "tfdtype$DT_INT32", device = "", name = "while/Less"} : (tensor<*xi32>, tensor<i32>) -> (tensor<*xi1>, !_tf.control)
+// CHECK-NEXT:   %[[COND:[0-9]*]]:2 = "_tf.LoopCond"(%[[LESS]]#0) {device = "", name = "while/LoopCond"} : (tensor<*xi1>) -> (tensor<i1>, !_tf.control)
+// CHECK-NEXT:   %[[SWITCH:[0-9]*]]:3 = "_tf.Switch"(%[[MERGE]]#0, %[[COND]]#0) {T = "tfdtype$DT_INT32", _class = ["loc = @while/Merge"], device = "", name = "while/Switch"} : (tensor<*xi32>, tensor<i1>) -> (tensor<*xi32>, tensor<*xi32>, !_tf.control)
+// CHECK-NEXT:   %[[EXIT:[0-9]*]]:2 = "_tf.Exit"(%[[SWITCH]]#0) {T = "tfdtype$DT_INT32", device = "", name = "while/Exit"} : (tensor<*xi32>) -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT:   %[[IDENTITY:[0-9]*]]:2 = "_tf.Identity"(%[[SWITCH]]#1) {T = "tfdtype$DT_INT32", device = "", name = "while/Identity"} : (tensor<*xi32>) -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT:   %[[CONST_ADD:[0-9]*]]:2 = "_tf.Const"(%[[IDENTITY]]#1) {device = "", dtype = "tfdtype$DT_INT32", name = "while/Add/y", value = dense<3> : tensor<i32>} : (!_tf.control) -> (tensor<i32>, !_tf.control)
+// CHECK-NEXT:   %[[ADD:[0-9]*]]:2 = "_tf.Add"(%[[IDENTITY]]#0, %[[CONST_ADD]]#0) {T = "tfdtype$DT_INT32", device = "", name = "while/Add"} : (tensor<*xi32>, tensor<i32>) -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT:   %[[CT:[0-9]*]] = "_tf.ControlTrigger"(%[[NOOP]], %[[ADD]]#1, %[[EXIT]]#1) {_tpu_replicate = "cluster", device = "", name = "gradients/while/mul_2_Da30D05wlPU_grad/SymbolicGradient/b_sync"} : (!_tf.control, !_tf.control, !_tf.control) -> !_tf.control
+// CHECK-NEXT:   %[[SINK:[0-9]*]] = "_tf.NextIteration.sink"(%[[ADD]]#0, %[[CT]]) {T = "tfdtype$DT_INT32", device = "", id = 0 : i64, name = "while/NextIteration"} : (tensor<*xi32>, !_tf.control) -> !_tf.control
+// CHECK-NEXT:   return
+
+
+
+
+// CHECK-LABEL: func @multiple_ops_region
+func @multiple_ops_region(%arg0 : tensor<*xi32>, %arg1 : tensor<i32>) {
+  tf_executor.graph {
+    %0:2 = tf_executor.island {
+      // The 4 operations are independent, but the current conversion will add
+      // control dependencies conservatively.
+      %1 = "tf.Add"(%arg0, %arg1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add1"} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi32>
+      %2 = "tf.Add"(%arg0, %arg1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add2"} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi32>
+      %3 = "tf.Add"(%arg0, %arg1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add3"} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi32>
+      %4 = "tf.Add"(%arg0, %arg1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add4"} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi32>
+      tf_executor.yield %4 : tensor<*xi32>
+    }
+    tf_executor.fetch
+  }
+  return
+}
+
+// CHECK-NEXT: %[[ADD1:[0-9]*]]:2 = "_tf.Add"(%arg0, %arg1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add1"} : (tensor<*xi32>, tensor<i32>) -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT: %[[ADD2:[0-9]*]]:2 = "_tf.Add"(%arg0, %arg1, %[[ADD1]]#1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add2"} : (tensor<*xi32>, tensor<i32>, !_tf.control) -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT: %[[ADD3:[0-9]*]]:2 = "_tf.Add"(%arg0, %arg1, %[[ADD2]]#1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add3"} : (tensor<*xi32>, tensor<i32>, !_tf.control) -> (tensor<*xi32>, !_tf.control)
+// CHECK-NEXT: %[[ADD4:[0-9]*]]:2 = "_tf.Add"(%arg0, %arg1, %[[ADD3]]#1) {T = "tfdtype$DT_INT32", device = "", name = "while/Add4"} : (tensor<*xi32>, tensor<i32>, !_tf.control) -> (tensor<*xi32>, !_tf.control)

--- a/samples/MLIR/sample.mlir
+++ b/samples/MLIR/sample.mlir
@@ -1,0 +1,102 @@
+// CHECK-LABEL: func @func_with_ops(%arg0: f32) {
+func @func_with_ops(%a : f32) {
+  // CHECK: %0 = "getTensor"() : () -> tensor<4x4x?xf32>
+  %t = "getTensor"() : () -> tensor<4x4x?xvector<10xf32>>>
+
+  %i6 = muli %i2, %i2 : i32
+  %t2 = "std.dim"(%t){index = 2} : (tensor<4x4x?xvector<10xf32>>) -> index
+  %x = "foo"(%a, %a) : (f32,f32) -> (memref<1 x i32, (d0) -> (d0), 4>)
+
+  return
+}
+
+func @count(%x: tensor<i64) -> (i64, i64)
+  attributes {fruit = "banana"} {
+  return %x, %x: i64, i64
+}
+
+func @correct_number_of_regions() {
+    // CHECK: test.two_region_op
+    "test.two_region_op"()(
+      {"work"() : () -> ()},
+      {"work"() : () -> ()}
+    ) : () -> ()
+    return
+}
+
+func @inline_notation() -> i32 {
+  %1 = "foo"() : () -> i32 loc("foo")
+  %1p = "foo"() : () -> i32 loc(fused<"myPass">["abc", "de"])
+
+  // CHECK: constant 4 : index loc(callsite("foo" at "mysource.cc":10:8))
+  %2 = constant 4 : index loc(callsite("foo" at "mysource.cc":10:8))
+
+  affine.for %i0 = 0 to 8 {
+  } loc(fused["foo", "mysource.cc":10:8])
+
+  affine.if #set0(%2) {
+  } loc(fused<"myPass">["foo", "foo2"])
+
+  return %1 : i32 loc(unknown)
+}
+
+func @simple(i64, i1) -> i64 {
+^bb0(%a: i64, %cond: i1): // Code dominated by ^bb0 may refer to %a
+  cond_br %cond, ^bb1, ^bb2
+
+^bb1:
+  br ^bb3(%a: i64)    // Branch passes %a as the argument
+
+^bb2:
+  %b = addi %a, %a : i64
+  br ^bb3(%b: i64)    // Branch passes %b as the argument
+
+// ^bb3 receives an argument, named %c, from predecessors
+// and passes it on to bb4 twice.
+^bb3(%c: i64):
+  br ^bb4(%c, %c : i64, i64)
+
+^bb4(%d : i64, %e : i64):
+  %0 = addi %d, %e : i64
+  return %0 : i64
+}
+
+// CHECK-LABEL: func @func_with_ops(%arg0: f32) {
+func @func_with_ops(f32) {
+^bb0(%a : f32):
+  %t = "getTensor"() : () -> tensor<4x4x?xf32>
+  %t2 = "std.dim"(%t){index = 2} : (tensor<4x4x?xf32>) -> index
+
+  %x = "std.addf"(%a, %a) : (f32,f32) -> (f32) // help
+
+  return
+}
+
+func @multiblock() {
+  return     // CHECK:   return
+^bb1:         // CHECK: ^bb1:   // no predecessors
+  br ^bb4     // CHECK:   br ^bb3
+^bb2:         // CHECK: ^bb2:   // pred: ^bb2
+  br ^bb2     // CHECK:   br ^bb2
+^bb4:         // CHECK: ^bb3:   // pred: ^bb1
+  return     // CHECK:   return
+}
+
+func @dialect_attribute_with_type() {
+  "foo.unknown_op"() {foo = #foo.attr : i32} : () -> ()
+}
+
+func @inline_notation() -> i32 {
+  %1 = "foo"() : () -> i32 loc("foo")
+
+  %2 = constant 4 : index loc(callsite("foo" at "mysource.cc":10:8))
+
+  affine.for %i0 = 0 to 8 {
+  } loc(fused["foo", "mysource.cc":10:8])
+
+  affine.if #set0(%2) {
+  } loc(fused<"myPass">["foo", "foo2"])
+
+  return %1 : i32 loc(unknown)
+}
+

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -232,6 +232,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Lua:** [textmate/lua.tmbundle](https://github.com/textmate/lua.tmbundle)
 - **MATLAB:** [mathworks/MATLAB-Language-grammar](https://github.com/mathworks/MATLAB-Language-grammar)
 - **MAXScript:** [Alhadis/language-maxscript](https://github.com/Alhadis/language-maxscript)
+- **MLIR:** [jpienaar/mlir-grammar](https://github.com/jpienaar/mlir-grammar)
 - **MQL4:** [mqsoft/MQL5-sublime](https://github.com/mqsoft/MQL5-sublime)
 - **MQL5:** [mqsoft/MQL5-sublime](https://github.com/mqsoft/MQL5-sublime)
 - **MTML:** [atom/language-html](https://github.com/atom/language-html)

--- a/vendor/licenses/grammar/mlir-grammar.txt
+++ b/vendor/licenses/grammar/mlir-grammar.txt
@@ -1,0 +1,207 @@
+---
+type: grammar
+name: mlir-grammar
+version: ed9128820888a496605d1bd801ac62c6f335dc16
+license: apache-2.0
+---
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/licenses/grammar/mlir-grammar.txt
+++ b/vendor/licenses/grammar/mlir-grammar.txt
@@ -1,7 +1,7 @@
 ---
 type: grammar
 name: mlir-grammar
-version: ed9128820888a496605d1bd801ac62c6f335dc16
+version: 91c8a962cfcf207d1d094f8137669ddef90ca7ad
 license: apache-2.0
 ---
                                  Apache License


### PR DESCRIPTION
Add support for MLIR

## Description
Add support for [MLIR](https://github.com/tensorflow/mlir).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?q=extension%3Amlir+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [const-fold.mlir](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/mlir/lite/tests/const-fold.mlir)
      - [core-ops.mlir](https://github.com/tensorflow/mlir/blob/master/test/IR/core-ops.mlir)
      - [executor_to_control_dialect.mlir](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/mlir/tensorflow/tests/executor_to_control_dialect.mlir)
      - [sample.mlir](https://github.com/jpienaar/mlir-grammar/blob/master/sample.mlir)
    - Sample license(s): Apache-2.0
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: 
    [core-ops](https://github-lightshow.herokuapp.com/?utf8=✓&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fjpienaar%2Fmlir-grammar%2Fmaster%2Fgrammars%2Fmlir.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftensorflow%2Fmlir%2Fmaster%2Ftest%2FIR%2Fcore-ops.mlir&code=)
