### PR TITLE
Use GitHub actions-provided build status badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ Sometimes getting the tests running can be too much work, especially if you don'
 It's okay: be lazy and let [GitHub Actions](https://github.com/features/actions) run the tests for you.
 Just open a pull request and the bot will start cranking away.
 
-Here's our current build status: [![Actions Status](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/github/linguist)](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/results/github/linguist)
+Here's our current build status: [![Actions Status](https://github.com/github/linguist/workflows/Run%20Tests/badge.svg)](https://github.com/github/linguist/actions)
 
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Linguist
 
-[![Actions Status](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/github/linguist)](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/results/github/linguist)
+[![Actions Status](https://github.com/github/linguist/workflows/Run%20Tests/badge.svg)](https://github.com/github/linguist/actions)
 
 [issues]: https://github.com/github/linguist/issues
 [new-issue]: https://github.com/github/linguist/issues/new


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

The service we were using for the badge has now been deprecated in favour of the GitHub Actions provided status badge.  This PR updates our usage.

[![Actions Status](https://github.com/github/linguist/workflows/Run%20Tests/badge.svg)](https://github.com/github/linguist/actions)

_[Template removed as not relevant]_