### PR TITLE
Recommend using set/unset gitattributes (vs. true/false strings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Use the `linguist-vendored` attribute to vendor or un-vendor paths:
 
 ```gitattributes
 special-vendored-path/* linguist-vendored
-jquery.js linguist-vendored=false
+jquery.js -linguist-vendored
 ```
 
 #### Documentation
@@ -202,7 +202,7 @@ Use the `linguist-documentation` attribute to mark or unmark paths as documentat
 
 ```gitattributes
 project-docs/* linguist-documentation
-docs/formatter.rb linguist-documentation=false
+docs/formatter.rb -linguist-documentation
 ```
 
 #### Generated code
@@ -215,7 +215,7 @@ As an added bonus, unlike vendored and documentation files, these files are supp
 Use the `linguist-generated` attribute to mark or unmark paths as generated.
 
 ```gitattributes
-Api.elm linguist-generated=true
+Api.elm linguist-generated
 ```
 
 #### Detectable
@@ -226,9 +226,9 @@ Languages of a different type (as defined in [`languages.yml`](/lib/linguist/lan
 Use the `linguist-detectable` attribute to mark or unmark paths as detectable:
 
 ```gitattributes
-*.kicad_pcb linguist-detectable=true
-*.sch linguist-detectable=true
-tools/export_bom.py linguist-detectable=false
+*.kicad_pcb linguist-detectable
+*.sch linguist-detectable
+tools/export_bom.py -linguist-detectable
 ```
 
 ### Using Emacs or Vim modelines


### PR DESCRIPTION
Hi! I was going to file an issue, but the change I want is small (doc changes in README.md) so I just sent a PR for discussion.

For context, see [the git documentation for gitattributes](https://git-scm.com/docs/gitattributes#_description). There are four states for an attribute; "set", "unset", "set to a value", and "unspecified". All of linguist's special attributes except for `linguist-language` are boolean attributes. For these, linguist considers the option to be "on" if the attribute is set *or* set to the string "true". It considers the option to be "off" if the attribute is unset *or* set to the string "false".

That is, these are equivalent to linguist:

```gitattributes
x.txt linguist-generated=true
x.txt linguist-generated
```

as are these:

```gitattributes
x.txt linguist-generated=false
x.txt -linguist-generated
```

I found this confusing: linguist planted the notion that the strings "true" and "false" are special, so when I read

> special value "true"

on the gitattributes man page I did not understand that those strings are *not* special to gitattributes, only linguist. (The gitattributes man page could probably be more clear too.)

It's obviously too late to change linguist's behavior, but I propose that we change the documentation to promote set/unset vs. "true"/"false". Set/unset is the functionality for boolean options built right into gitattributes; "true"/"false" is special to linguist. (I initially stumbled onto this wondering while looking at the gitattributes file at my company and wondering why `binary` is specified like that but `linguist-generated=true` uses "true".)

Furthermore, note that the examples for `linguist-vendored` and `linguist-documentation` in the README currently *mix* the set/unset and "true"/"false" styles:

```gitattributes
special-vendored-path/* linguist-vendored
jquery.js linguist-vendored=false
```

This seems extra confusing.

Finally, I think the example on the help page [Customizing how changed files appear on GitHub](https://help.github.com/en/articles/customizing-how-changed-files-appear-on-github) should be changed from

    search/index.json linguist-generated=true

to

    search/index.json linguist-generated

(This might not be the right place to request that change.)