### PR TITLE
Fix Incorrect Line Splitting

### DIFF
--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -270,8 +270,10 @@ module Linguist
           # also--importantly--without having to duplicate many (potentially
           # large) strings.
           begin
-
-            data.split(encoded_newlines_re, -1)
+            # `data` is split after having its last `\n` removed by
+            # chomp (if any). This prevents the creation of an empty
+            # element after the final `\n` character on POSIX files.
+            data.chomp.split(encoded_newlines_re, -1)
           rescue Encoding::ConverterNotFoundError
             # The data is not splittable in the detected encoding.  Assume it's
             # one big line.

--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -57,9 +57,9 @@ class TestBlob < Minitest::Test
   end
 
   def test_lines
-    assert_equal ["module Foo", "end", ""], sample_blob_memory("Ruby/foo.rb").lines
-    assert_equal ["line 1", "line 2", ""], sample_blob_memory("Text/mac.txt").lines
-    assert_equal 475, sample_blob_memory("Emacs Lisp/ess-julia.el").lines.length
+    assert_equal ["module Foo", "end"], sample_blob_memory("Ruby/foo.rb").lines
+    assert_equal ["line 1", "line 2"], sample_blob_memory("Text/mac.txt").lines
+    assert_equal 474, sample_blob_memory("Emacs Lisp/ess-julia.el").lines.length
   end
 
   def test_lines_maintains_original_encoding
@@ -75,7 +75,7 @@ class TestBlob < Minitest::Test
   end
 
   def test_loc
-    assert_equal 3, sample_blob_memory("Ruby/foo.rb").loc
+    assert_equal 2, sample_blob_memory("Ruby/foo.rb").loc
   end
 
   def test_sloc

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -77,9 +77,9 @@ class TestFileBlob < Minitest::Test
   end
 
   def test_lines
-    assert_equal ["module Foo", "end", ""], sample_blob("Ruby/foo.rb").lines
-    assert_equal ["line 1", "line 2", ""], sample_blob("Text/mac.txt").lines
-    assert_equal 475, sample_blob("Emacs Lisp/ess-julia.el").lines.length
+    assert_equal ["module Foo", "end"], sample_blob("Ruby/foo.rb").lines
+    assert_equal ["line 1", "line 2"], sample_blob("Text/mac.txt").lines
+    assert_equal 474, sample_blob("Emacs Lisp/ess-julia.el").lines.length
   end
 
   def test_lines_maintains_original_encoding
@@ -95,7 +95,7 @@ class TestFileBlob < Minitest::Test
   end
 
   def test_loc
-    assert_equal 3, sample_blob("Ruby/foo.rb").loc
+    assert_equal 2, sample_blob("Ruby/foo.rb").loc
   end
 
   def test_sloc


### PR DESCRIPTION
## Description

Files with complete lines (every line terminating in a _newline_ character) are always reported with an incorrect line count. Since this is not only common behavior to many text editors but also part of the POSIX standard, this problem affects a big quantity of files. It is visible through GitHub directly as well. As an example, any license file (such as Linguist's [license](https://github.com/github/linguist/blob/master/LICENSE) itself) is reported as having one line more than what it actually has.

The reported line count is merely the lines array size, which is generated by `BlobHelper`. Data is split at newlines with `split` having its second argument set to `-1`:

https://github.com/github/linguist/blob/001ca526694a32a5ac4c977a79032ced0b8c0aca/lib/linguist/blob_helper.rb#L274

I assume this happens to prevent trimming empty lines at the end of a file. However it has this side effect of creating an empty last element on files with complete lines. The final line count uses this empty line.

Since there is no straightforward way of distinguishing intentional empty lines from the generated empty line, the solution I propose here is rather simple: remove a final newline (if there is one) before splitting. This can be easily achieved with `chomp`.

The only remaining indistinguishable case I see would be a file ending with an empty line. For example:

    line content\n\n

Here it is not clear if the file is supposed to have 2 complete lines or 3 incomplete lines. The `chomp` solution would treat it as 2 complete lines.

I also updated the tests. Some of them checked files such as [samples/Ruby/foo.rb](https://github.com/github/linguist/blob/3b7d23c217b58266bc9e9ae819031f5c306879a4/samples/Ruby/foo.rb) and asserted that it had three lines of code, with one last empty line. Even though it clearly has 2:

https://github.com/github/linguist/blob/3b7d23c217b58266bc9e9ae819031f5c306879a4/samples/Ruby/foo.rb#L1-L2

https://github.com/github/linguist/blob/3b7d23c217b58266bc9e9ae819031f5c306879a4/test/test_file_blob.rb#L80

https://github.com/github/linguist/blob/3b7d23c217b58266bc9e9ae819031f5c306879a4/test/test_file_blob.rb#L98

I'm also assuming `chomp` will handle encoding correctly since we are dealing with POSIX files after all, however as described in the original issue text (#4563) this could be changed to something else.

## Checklist:

- [X] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [X] I have added or updated the tests for the new or changed functionality.
