### PR TITLE
Modula 2 definition

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3173,6 +3173,7 @@ Modula-2:
   type: programming
   extensions:
   - ".mod"
+  - ".def"
   tm_scope: source.modula2
   ace_mode: text
   language_id: 234

--- a/samples/Modula-2/RESERROR.DEF
+++ b/samples/Modula-2/RESERROR.DEF
@@ -1,0 +1,17 @@
+DEFINITION MODULE RESerrors;
+
+TYPE
+        RESerrorcodes = (USERERROR, NOENVAR, NOMEMAVAIL,
+                         NOFILEFOUND, FILEEMPTY,
+                         PICKLIMITERROR
+                         );
+        RESerrorlevel = (WARNING,FATAL);
+
+PROCEDURE RESerror( err : RESerrorcodes;
+                    msg : ARRAY OF CHAR;
+                    lev : RESerrorlevel);
+END RESerrors.
+
+
+
+


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Add ".def" file suffix for Modula-2 definition files (similar to C header files).
## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
As with C, typical Modula-2 repositories contain almost as many DEF files as MOD files.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I am associating a language with a new file extension.**
  - [X] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=%22definition+module%22+NOT+nothack+extension%3Adef&type=Code
  - [X] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/axtens/res/blob/4e749b53aace81e5f08a9b7706b816e56857d90f/v2/RESERROR.DEF
    - Sample license(s): MIT
  - [-] I have included a change to the heuristics to distinguish my language from others using the same extension.