### PR TITLE
Add .hql extension to HiveQL

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2107,6 +2107,7 @@ HiveQL:
   type: programming
   extensions:
   - ".q"
+  - ".hql"
   color: "#dce200"
   tm_scope: source.hql
   ace_mode: sql

--- a/samples/HiveQL/query.hql
+++ b/samples/HiveQL/query.hql
@@ -1,0 +1,35 @@
+SET hive.tez.container.size = 2048;
+set hive.optimize.sort.dynamic.partition=true;
+
+SET hivevar:DB=test;
+
+create database if not exists ${DB};
+
+-- External CSV table
+CREATE EXTERNAL TABLE ${DB}.users (
+  id STRING,
+  name STRING,
+  age INT
+)
+COMMENT 'External table mapping CSV files'
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY ','
+NULL DEFINED AS ''
+STORED AS TEXTFILE
+LOCATION 'hdfs:///some/hdfs/path'
+TBLPROPERTIES ('skip.header.line.count' = '1');
+MSCK REPAIR TABLE ${DB}.methodos_csv SYNC PARTITIONS;
+
+-- ORC table
+create table ${DB}.purchases
+as
+  select product, price, user_id
+from ${DB}.purchases_extended
+stored as orc
+tblproperties ('orc.compress'='ZLIB');
+
+-- Join query
+SELECT name, sum(price) as total_spent, count(product) as nb_products
+FROM ${DB}.users
+LEFT JOIN ${DB}.purchases
+GROUP BY name;


### PR DESCRIPTION
I added the `.hql` extension to the HiveQL language. This extension is pretty widely used on Github and in official documentations (e.g. [Azure HDInsight Documentation](https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-hadoop-use-hive-beeline#file)).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Ahql+external+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [query.hql](https://github.com/Nuttymoon/linguist/blob/master/samples/HiveQL/query.hql)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.