### PR TITLE
Add 4DForm as a JSON language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2338,6 +2338,7 @@ JSON:
   - ".tern-project"
   - ".watchmanconfig"
   - composer.lock
+  - form.4DForm
   - mcmod.info
   language_id: 174
 JSON with Comments:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2315,6 +2315,7 @@ JSON:
   searchable: false
   extensions:
   - ".json"
+  - ".4DForm"
   - ".avsc"
   - ".geojson"
   - ".gltf"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2338,7 +2338,6 @@ JSON:
   - ".tern-project"
   - ".watchmanconfig"
   - composer.lock
-  - form.4DForm
   - mcmod.info
   language_id: 174
 JSON with Comments:

--- a/samples/JSON/form.4DForm
+++ b/samples/JSON/form.4DForm
@@ -1,0 +1,374 @@
+{
+	"destination": "detailScreen",
+	"formSizeAnchor": "Variable2",
+	"rightMargin": 19,
+	"bottomMargin": 20,
+	"markerHeader": 15,
+	"markerBody": 200,
+	"markerBreak": 220,
+	"markerFooter": 240,
+	"events": [
+		"onLoad",
+		"onValidate",
+		"onClick",
+		"onOutsideCall",
+		"onDoubleClick",
+		"onDrop",
+		"onMenuSelect",
+		"onPluginArea",
+		"onDataChange",
+		"onDragOver",
+		"onTimer",
+		"onAfterKeystroke",
+		"onAfterEdit",
+		"onBeginDragOver",
+		"onBoundVariableChange",
+		"onPageChange"
+	],
+	"method": "method.4dm",
+	"pages": [
+		null,
+		{
+			"objects": {
+				"Variable": {
+					"type": "input",
+					"top": 26,
+					"left": 13,
+					"width": 180,
+					"height": 17,
+					"dataSource": "Form:C1466.employeeName",
+					"focusable": false,
+					"fill": "transparent",
+					"borderStyle": "none",
+					"enterable": false,
+					"contextMenu": "none",
+					"dragging": "none",
+					"dropping": "custom",
+					"events": [
+						"onLoad",
+						"onLosingFocus",
+						"onGettingFocus",
+						"onDataChange",
+						"onAfterEdit"
+					]
+				},
+				"Text": {
+					"type": "text",
+					"top": 7,
+					"left": 13,
+					"width": 102,
+					"height": 17,
+					"stroke": "#696969",
+					"text": "Employee"
+				},
+				"Variable1": {
+					"type": "input",
+					"top": 26,
+					"left": 280,
+					"width": 260,
+					"height": 17,
+					"dataSource": "Form:C1466.creation",
+					"focusable": false,
+					"fill": "transparent",
+					"borderStyle": "none",
+					"enterable": false,
+					"contextMenu": "none",
+					"dragging": "none",
+					"dropping": "custom",
+					"events": [
+						"onLoad",
+						"onLosingFocus",
+						"onGettingFocus",
+						"onDataChange",
+						"onAfterEdit"
+					]
+				},
+				"Text1": {
+					"type": "text",
+					"top": 7,
+					"left": 280,
+					"width": 102,
+					"height": 17,
+					"stroke": "#696969",
+					"text": "Creation"
+				},
+				"Variable2": {
+					"type": "input",
+					"top": 418,
+					"left": 476,
+					"width": 220,
+					"height": 17,
+					"sizingX": "move",
+					"sizingY": "move",
+					"dataSource": "Form:C1466.priceTotal",
+					"dataSourceTypeHint": "number",
+					"textAlign": "right",
+					"fontWeight": "bold",
+					"focusable": false,
+					"fill": "transparent",
+					"borderStyle": "none",
+					"enterable": false,
+					"contextMenu": "none",
+					"numberFormat": {
+						"$ref": "/SOURCES/filters.json#/amount_CHF"
+					},
+					"dragging": "none",
+					"dropping": "custom",
+					"events": [
+						"onLoad",
+						"onLosingFocus",
+						"onGettingFocus",
+						"onDataChange",
+						"onAfterEdit"
+					]
+				},
+				"Text2": {
+					"type": "text",
+					"top": 399,
+					"left": 594,
+					"width": 102,
+					"height": 17,
+					"sizingX": "move",
+					"sizingY": "move",
+					"stroke": "#696969",
+					"textAlign": "right",
+					"fontWeight": "bold",
+					"text": "Total"
+				},
+				"List Box": {
+					"type": "listbox",
+					"top": 144,
+					"left": 13,
+					"width": 683,
+					"height": 245,
+					"sizingX": "grow",
+					"sizingY": "grow",
+					"listboxType": "currentSelection",
+					"movableRows": false,
+					"highlightSet": "$ListboxSet",
+					"table": 5,
+					"scrollbarHorizontal": "automatic",
+					"horizontalLineStroke": "transparent",
+					"verticalLineStroke": "transparent",
+					"alternateFill": "#F2F3F8",
+					"borderStyle": "none",
+					"events": [
+						"onClick",
+						"onDataChange",
+						"onSelectionChange",
+						"onHeaderClick"
+					],
+					"columns": [
+						{
+							"name": "Column1",
+							"dataSource": "[Product:3]name:2",
+							"width": 195,
+							"minWidth": 75,
+							"maxWidth": 300,
+							"alternateFill": "#F2F3F8",
+							"events": [
+								"onClick",
+								"onDataChange"
+							],
+							"header": {
+								"name": "Header1",
+								"text": "Product",
+								"textAlign": "left"
+							},
+							"footer": {
+								"name": "Footer1",
+								"timeFormat": "hh_mm_ss",
+								"fontWeight": "bold"
+							}
+						},
+						{
+							"name": "Column2",
+							"dataSource": "[Invoice_Line:5]quantity:4",
+							"width": 78,
+							"minWidth": 75,
+							"maxWidth": 100,
+							"alternateFill": "#F2F3F8",
+							"events": [
+								"onClick",
+								"onDataChange"
+							],
+							"header": {
+								"name": "Header2",
+								"text": "Qty",
+								"textAlign": "right"
+							},
+							"footer": {
+								"name": "Footer2",
+								"timeFormat": "hh_mm_ss"
+							}
+						},
+						{
+							"name": "Column3",
+							"dataSource": "[Invoice_Line:5]price:5",
+							"dataSourceTypeHint": "number",
+							"width": 150,
+							"minWidth": 30,
+							"maxWidth": 250,
+							"numberFormat": "|amount_CHF",
+							"alternateFill": "#F2F3F8",
+							"events": [
+								"onClick",
+								"onDataChange"
+							],
+							"header": {
+								"name": "Header3",
+								"text": "Price",
+								"textAlign": "right"
+							},
+							"footer": {
+								"name": "Footer3",
+								"variableCalculation": "sum",
+								"timeFormat": "hh_mm_ss",
+								"fontWeight": "bold"
+							}
+						}
+					]
+				},
+				"Text3": {
+					"type": "text",
+					"top": 122,
+					"left": 13,
+					"width": 102,
+					"height": 17,
+					"text": "Lines"
+				},
+				"product_list": {
+					"type": "dropdown",
+					"top": 94,
+					"left": 13,
+					"width": 207,
+					"height": 17,
+					"focusable": false,
+					"method": "ObjectMethods/product_list.4dm",
+					"events": [
+						"onDataChange"
+					]
+				},
+				"Text4": {
+					"type": "text",
+					"top": 75,
+					"left": 13,
+					"width": 102,
+					"height": 17,
+					"text": "Product"
+				},
+				"quantity": {
+					"type": "input",
+					"top": 95,
+					"left": 243,
+					"width": 152,
+					"height": 17,
+					"dataSource": "Form:C1466.quantity",
+					"dataSourceTypeHint": "number",
+					"borderStyle": "solid",
+					"contextMenu": "none",
+					"dragging": "none",
+					"dropping": "custom",
+					"method": "ObjectMethods/quantity.4dm",
+					"events": [
+						"onLoad",
+						"onLosingFocus",
+						"onGettingFocus",
+						"onDataChange",
+						"onAfterEdit"
+					]
+				},
+				"Text5": {
+					"type": "text",
+					"top": 75,
+					"left": 240,
+					"width": 102,
+					"height": 17,
+					"text": "Quatity"
+				},
+				"Variable4": {
+					"type": "input",
+					"top": 95,
+					"left": 408,
+					"width": 152,
+					"height": 17,
+					"dataSource": "Form:C1466.linePrice",
+					"dataSourceTypeHint": "number",
+					"focusable": false,
+					"borderStyle": "solid",
+					"enterable": false,
+					"contextMenu": "none",
+					"dragging": "none",
+					"dropping": "custom",
+					"events": [
+						"onLoad",
+						"onLosingFocus",
+						"onGettingFocus",
+						"onDataChange",
+						"onAfterEdit"
+					]
+				},
+				"Text6": {
+					"type": "text",
+					"top": 75,
+					"left": 405,
+					"width": 102,
+					"height": 17,
+					"text": "Price"
+				},
+				"Button": {
+					"type": "button",
+					"top": 91,
+					"left": 580,
+					"width": 87,
+					"height": 25,
+					"text": "Add Line",
+					"focusable": false,
+					"method": "ObjectMethods/Button.4dm",
+					"events": [
+						"onClick"
+					]
+				},
+				"product_id": {
+					"type": "dropdown",
+					"top": 494,
+					"left": 13,
+					"width": 207,
+					"height": 17,
+					"visibility": "hidden",
+					"dataSourceTypeHint": "arrayNumber",
+					"focusable": false,
+					"events": [
+						"onDataChange"
+					]
+				},
+				"product_price": {
+					"type": "dropdown",
+					"top": 514,
+					"left": 13,
+					"width": 207,
+					"height": 17,
+					"visibility": "hidden",
+					"dataSourceTypeHint": "arrayNumber",
+					"focusable": false,
+					"events": [
+						"onDataChange"
+					]
+				},
+				"Button1": {
+					"type": "button",
+					"top": 27,
+					"left": 197,
+					"width": 63,
+					"height": 18,
+					"text": "Select",
+					"focusable": false,
+					"method": "ObjectMethods/Button1.4dm",
+					"events": [
+						"onClick"
+					]
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
## Description
4DForm extension contains JSON data representing 4D Form description. It is used in the context of 4D software application which start to provide source control compatibility in beta within the new v17 R6 version and will be released officially in v18 (between end 19 - begin 20). More and more repositories contains that kind of files.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3A4DForm+pages+rightMargin+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - Example not on GitHub. It is a sample form that I have used during a training of 4D software development platform.
    - Sample license(s):
      - MIT
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.