### PR TITLE
Update vscode-scala-syntax

### DIFF
--- a/vendor/licenses/grammar/vscode-scala-syntax.txt
+++ b/vendor/licenses/grammar/vscode-scala-syntax.txt
@@ -1,7 +1,7 @@
 ---
 type: grammar
 name: vscode-scala-syntax
-version: 1ed018272080856f356afb4cff29b1236df7e041
+version: f544ee8d282b66142fbe6db06e65f0db339577b0
 license: mit
 ---
 MIT License


### PR DESCRIPTION
Use commit hash from vscode-scala-syntax 0.3.5
* https://github.com/scala/vscode-scala-syntax/releases/tag/0.3.5