### PR TITLE
Add .rbi for Sorbet files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4522,6 +4522,7 @@ Ruby:
   - ".podspec"
   - ".rabl"
   - ".rake"
+  - ".rbi"
   - ".rbuild"
   - ".rbw"
   - ".rbx"

--- a/samples/Ruby/gem_loader.rbi
+++ b/samples/Ruby/gem_loader.rbi
@@ -1,0 +1,15 @@
+# typed: true
+
+# Write this as an RBI because the gem_loader.rb file itself cannot be typed.
+# By nature, it references constants in other gems in an attempt to load them.
+# They will not load in this project. It's marked as `typed: ignore`, and this
+# file exists so that we can call into gem_loader from typed code.
+
+class Sorbet::Private::GemLoader
+  sig {params(gem: String).void}
+  def self.require_gem(gem)
+  end
+
+  sig {void}
+  def self.require_all_gems; end
+end


### PR DESCRIPTION
Adds https://sorbet.org/docs/rbi. They are valid Ruby files, with a `.rbi` extension.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Arbi+typed&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/sorbet/sorbet/blob/master/gems/sorbet/lib/gem_loader.rbi
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
    - No, as this extension isn't used elsewhere.