### PR TITLE
Recognize .hs-boot files as Haskell sources

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2084,8 +2084,8 @@ Haskell:
   color: "#5e5086"
   extensions:
   - ".hs"
-  - ".hsc"
   - ".hs-boot"
+  - ".hsc"
   interpreters:
   - runhaskell
   tm_scope: source.haskell

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2085,6 +2085,7 @@ Haskell:
   extensions:
   - ".hs"
   - ".hsc"
+  - ".hs-boot"
   interpreters:
   - runhaskell
   tm_scope: source.haskell


### PR DESCRIPTION
This PR adds `.hs-boot` files to the list for Haskell. These files are more or less ordinary Haskell sources, but are used to break cycles in module imports, [as documented in the `ghc` user’s guide](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/separate_compilation.html?highlight=circular#how-to-compile-mutually-recursive-modules). For the purposes of language statistics and syntax highlighting, they should absolutely be considered as Haskell.

## Checklist:

- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?utf8=✓&type=Code&ref=searchresults&q=extension%3Ahs-boot+haskell+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/typelead/eta/blob/08f98b47094f27237823832a3255b84476fa1c5b/compiler/Eta/HsSyn/HsPat.hs-boot
    - Sample license(s):
      - https://github.com/typelead/eta/blob/08f98b47094f27237823832a3255b84476fa1c5b/LICENSE
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

> I have included a real-world usage sample for all extensions added in this PR:

I’ve added links to one, above, but I’m not sure if that’s what this item meant by “included.”

> I have included a change to the heuristics to distinguish my language from others using the same extension.

I’m not aware of anyone doing so, so I’m not sure that this applies.