### PR TITLE
Add grammar for Inno Setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -245,6 +245,9 @@
 [submodule "vendor/grammars/atom-language-haproxy"]
 	path = vendor/grammars/atom-language-haproxy
 	url = https://github.com/abulimov/atom-language-haproxy
+[submodule "vendor/grammars/atom-language-innosetup"]
+	path = vendor/grammars/atom-language-innosetup
+	url = https://github.com/idleberg/atom-language-innosetup
 [submodule "vendor/grammars/atom-language-julia"]
 	path = vendor/grammars/atom-language-julia
 	url = https://github.com/JuliaEditorSupport/atom-language-julia

--- a/grammars.yml
+++ b/grammars.yml
@@ -208,6 +208,8 @@ vendor/grammars/atom-language-clean:
 - text.restructuredtext.clean
 vendor/grammars/atom-language-haproxy:
 - source.haproxy-config
+vendor/grammars/atom-language-innosetup:
+- source.inno
 vendor/grammars/atom-language-julia:
 - source.julia
 - source.julia.console

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2248,7 +2248,7 @@ Inno Setup:
   type: programming
   extensions:
   - ".iss"
-  tm_scope: none
+  tm_scope: source.inno
   ace_mode: text
   language_id: 167
 Io:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -181,6 +181,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Idris:** [idris-hackers/idris-sublime](https://github.com/idris-hackers/idris-sublime)
 - **Ignore List:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **Inform 7:** [erkyrath/language-inform7](https://github.com/erkyrath/language-inform7)
+- **Inno Setup:** [idleberg/atom-language-innosetup](https://github.com/idleberg/atom-language-innosetup)
 - **Io:** [textmate/io.tmbundle](https://github.com/textmate/io.tmbundle)
 - **Ioke:** [vic/ioke-outdated](https://github.com/vic/ioke-outdated)
 - **Isabelle:** [lsf37/Isabelle.tmbundle](https://github.com/lsf37/Isabelle.tmbundle)

--- a/vendor/licenses/grammar/atom-language-innosetup.txt
+++ b/vendor/licenses/grammar/atom-language-innosetup.txt
@@ -1,0 +1,15 @@
+---
+type: grammar
+name: atom-language-innosetup
+version: 7e0d2b969b17111843bc97cb74a535f7f57768d0
+license: mit
+---
+The MIT License (MIT)
+
+Copyright (c) 2015-2017 Jan T. Sott
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Description
This pull request adds syntax highlighting for Inno Setup files using [atom-language-innosetup](https://github.com/idleberg/atom-language-innosetup).

## Checklist:
- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: none
  - New: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=cson&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fidleberg%2Fatom-language-innosetup%2Fmaster%2Fgrammars%2Finno-setup.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fjrsoftware%2Fissrc%2Fmaster%2Fsetup.iss