### PR TITLE
Consider go.sum to be generated

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -62,6 +62,7 @@ module Linguist
       node_modules? ||
       go_vendor? ||
       go_lock? ||
+      go_sum? ||
       npm_shrinkwrap_or_package_lock? ||
       godeps? ||
       generated_by_zephir? ||
@@ -357,6 +358,13 @@ module Linguist
       !!name.match(/vendor\/((?!-)[-0-9A-Za-z]+(?<!-)\.)+(com|edu|gov|in|me|net|org|fm|io)/)
     end
 
+    # Internal: Is the blob a generated go.sum file?
+    #
+    # Returns true or false.
+    def go_sum?
+      !!name.match(/go\.sum/)
+    end
+
     # Internal: Is the blob a generated Go dep or glide lock file?
     #
     # Returns true or false.
@@ -591,7 +599,7 @@ module Linguist
       return lines[2].match(/\"modelName\"\:\s*\"GM/) ||
              lines[0] =~ /^\d\.\d\.\d.+\|\{/
     end
-        
+
     # Internal: Is this a generated GIMP C image file?
     #
     # GIMP saves C sources with one of two comment forms:

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -93,6 +93,8 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data("Dummy/npm-shrinkwrap.json")
     generated_sample_without_loading_data("Dummy/package-lock.json")
 
+    generated_sample_without_loading_data("Dummy/go.sum")
+
     # Godep saved dependencies
     generated_sample_without_loading_data("Godeps/Godeps.json")
     generated_sample_without_loading_data("Godeps/_workspace/src/github.com/kr/s3/sign.go")
@@ -161,7 +163,7 @@ class TestGenerated < Minitest::Test
     generated_fixture_loading_data("HTML/unknown.html", true)
     generated_fixture_loading_data("HTML/no-content.html", true)
     generated_sample_loading_data("HTML/pages.html")
-    
+
     # GIMP
     generated_fixture_loading_data("C/image.c")
     generated_fixture_loading_data("C/image.h")


### PR DESCRIPTION
Go 1.11 and newer include built in support for Go modules, with a user-editable go.mod file and a generated go.sum file.

This flags go.sum as a generated file so that it will be suppressed in diffs.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
