### PR TITLE
Add JSON output for single file classification

### DIFF
--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -58,20 +58,20 @@ elsif File.file?(path)
     'Binary'
   end
 
-  if !json_breakdown
+  if json_breakdown
+    puts JSON.generate( { blob.name =>  {
+                                          :lines => blob.loc,
+                                          :sloc => blob.sloc,
+                                          :type => type,
+                                          :mime_type => blob.mime_type,
+                                          :language => blob.language
+                                        }
+                        } )
+  else
     puts "#{blob.name}: #{blob.loc} lines (#{blob.sloc} sloc)"
     puts "  type:      #{type}"
     puts "  mime type: #{blob.mime_type}"
     puts "  language:  #{blob.language}"
-  else
-    puts JSON.generate( { blob.name =>	{
-	    					:lines => blob.loc,
-						:sloc => blob.sloc,
-						:type => type,
-						:mime_type => blob.mime_type,
-						:language => blob.language
-    					}
-    			} )
   end
 
   if blob.large?

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -22,10 +22,10 @@ end
 ARGV.shift
 breakdown = true if ARGV[0] == "--breakdown"
 json_breakdown = true if ARGV[0] == "--json"
-
 if File.directory?(path)
   rugged = Rugged::Repository.new(path)
   repo = Linguist::Repository.new(rugged, rugged.head.target_id)
+
   if !json_breakdown
     repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
       percentage = ((size / repo.size.to_f) * 100)
@@ -48,6 +48,7 @@ if File.directory?(path)
   end
 elsif File.file?(path)
   blob = Linguist::FileBlob.new(path, Dir.pwd)
+
   type = if blob.text?
     'Text'
   elsif blob.image?
@@ -56,10 +57,21 @@ elsif File.file?(path)
     'Binary'
   end
 
-  puts "#{blob.name}: #{blob.loc} lines (#{blob.sloc} sloc)"
-  puts "  type:      #{type}"
-  puts "  mime type: #{blob.mime_type}"
-  puts "  language:  #{blob.language}"
+  if !json_breakdown
+    puts "#{blob.name}: #{blob.loc} lines (#{blob.sloc} sloc)"
+    puts "  type:      #{type}"
+    puts "  mime type: #{blob.mime_type}"
+    puts "  language:  #{blob.language}"
+  else
+    puts JSON.generate( { blob.name =>	{
+	    					:lines => blob.loc,
+						:sloc => blob.sloc,
+						:type => type,
+						:mime_type => blob.mime_type,
+						:language => blob.language
+    					}
+    			} )
+  end
 
   if blob.large?
     puts "  blob is too large to be shown"

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -22,6 +22,7 @@ end
 ARGV.shift
 breakdown = true if ARGV[0] == "--breakdown"
 json_breakdown = true if ARGV[0] == "--json"
+
 if File.directory?(path)
   rugged = Rugged::Repository.new(path)
   repo = Linguist::Repository.new(rugged, rugged.head.target_id)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

This PR attempts to resolve https://github.com/github/linguist/issues/3562 by outputting JSON-format results for a single file.

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Example based on issue:

```
$ ./bin/github-linguist grammars.yml --json
{"grammars.yml":{"lines":857,"sloc":856,"type":"Text","mime_type":"text/x-yaml","language":"YAML"}}
```

- [X] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
