### PR TITLE
Recognize .hsig files as Haskell sources

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2086,6 +2086,7 @@ Haskell:
   - ".hs"
   - ".hs-boot"
   - ".hsc"
+  - ".hsig"
   interpreters:
   - runhaskell
   tm_scope: source.haskell


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
`.hsig` is introduced by Haskell de-facto Compiler - GHC's [Backpack](https://gitlab.haskell.org/ghc/ghc/wikis/backpack) feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Ahsig+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/andrewthad/indexed-unboxed-array/blob/master/src/Array.hsig
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.