### PR TITLE
Add Prisma language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -977,6 +977,9 @@
 [submodule "vendor/grammars/vscode-opa"]
 	path = vendor/grammars/vscode-opa
 	url = https://github.com/tsandall/vscode-opa
+[submodule "vendor/grammars/vscode-prisma"]
+	path = vendor/grammars/vscode-prisma
+	url = https://github.com/prisma/vscode-prisma
 [submodule "vendor/grammars/vscode-scala-syntax"]
 	path = vendor/grammars/vscode-scala-syntax
 	url = https://github.com/scala/vscode-scala-syntax

--- a/grammars.yml
+++ b/grammars.yml
@@ -830,6 +830,8 @@ vendor/grammars/vscode-lean:
 - source.lean
 vendor/grammars/vscode-opa:
 - source.rego
+vendor/grammars/vscode-prisma:
+- source.prisma
 vendor/grammars/vscode-scala-syntax:
 - source.scala
 vendor/grammars/vscode-slice:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3970,7 +3970,7 @@ PowerShell:
   language_id: 293
 Prisma:
   type: data
-  color: "#0C344B"
+  color: "#162d3b"
   extensions:
   - ".prisma"
   tm_scope: source.prisma

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3968,6 +3968,13 @@ PowerShell:
   interpreters:
   - pwsh
   language_id: 293
+Prisma:
+  type: data
+  extensions:
+  - ".prisma"
+  tm_scope: source.prisma
+  ace_mode: text
+  language_id: 499933428
 Processing:
   type: programming
   color: "#0096D8"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3970,7 +3970,6 @@ PowerShell:
   language_id: 293
 Prisma:
   type: data
-  color: "#162d3b"
   extensions:
   - ".prisma"
   tm_scope: source.prisma

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3970,6 +3970,7 @@ PowerShell:
   language_id: 293
 Prisma:
   type: data
+  color: "#0C344B"
   extensions:
   - ".prisma"
   tm_scope: source.prisma

--- a/samples/Prisma/blog-minimal-schema.prisma
+++ b/samples/Prisma/blog-minimal-schema.prisma
@@ -1,0 +1,25 @@
+datasource mysql {
+  provider = "mysql"
+  url      = env("MYSQL_URL")
+}
+
+generator photon {
+  provider = "photonjs"
+}
+
+model Author {
+  id    String  @default(cuid()) @id @unique
+  email String  @unique
+  name  String?
+  posts Post[]
+}
+
+model Post {
+  id        String   @default(cuid()) @id @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  published Boolean
+  title     String
+  content   String?
+  author    Author?
+}

--- a/samples/Prisma/blog-schema-advanced.prisma
+++ b/samples/Prisma/blog-schema-advanced.prisma
@@ -1,0 +1,41 @@
+datasource sqlite {
+  url      = "file:data.db"
+  provider = "sqlite"
+}
+
+model User {
+  id        Int      @id
+  createdAt DateTime @default(now())
+  email     String   @unique
+  name      String?
+  role      Role     @default(USER)
+  posts     Post[]
+  profile   Profile?
+}
+
+model Profile {
+  id   Int    @id
+  user User
+  bio  String
+}
+
+model Post {
+  id         Int        @id
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  author     User
+  title      String
+  published  Boolean    @default(false)
+  categories Category[]
+}
+
+model Category {
+  id    Int    @id
+  name  String
+  posts Post[]
+}
+
+enum Role {
+  USER
+  ADMIN
+}

--- a/samples/Prisma/mcu-schema.prisma
+++ b/samples/Prisma/mcu-schema.prisma
@@ -1,0 +1,32 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+  default  = true
+}
+
+generator photon {
+  provider = "photonjs"
+  output   = "node_modules/@generated/photon"
+}
+
+generator nexus_prisma {
+  provider = "nexus-prisma"
+  output   = "node_modules/@generated/nexus-prisma"
+}
+
+model Hero {
+  id     String  @default(cuid()) @id @unique
+  email  String  @unique
+  name   String?
+  movies Movie[]
+}
+
+model Movie {
+  id            String   @default(cuid()) @id @unique
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  released      Boolean
+  title         String
+  description   String?
+  mainCharacter Hero?
+}

--- a/samples/Prisma/now-example-schema.prisma
+++ b/samples/Prisma/now-example-schema.prisma
@@ -1,0 +1,121 @@
+datasource db {
+  provider = "mysql"
+  url      = "mysql://prisma:localhost:3306/strapi"
+}
+
+generator photon {
+  provider = "photonjs"
+}
+
+model CoreStore {
+  id          Int     @id
+  environment String?
+  key         String?
+  tag         String?
+  type        String?
+  value       String?
+
+  @@map("core_store")
+}
+
+model Migration {
+  revision          Int       @id
+  applied           Int
+  databaseMigration String    @map("database_migration")
+  datamodel         String
+  datamodelSteps    String    @map("datamodel_steps")
+  errors            String
+  finishedAt        DateTime? @map("finished_at")
+  name              String
+  rolledBack        Int       @map("rolled_back")
+  startedAt         DateTime  @map("started_at")
+  status            String
+
+  @@map("_Migration")
+}
+
+model Post {
+  id        Int       @id
+  content   String?
+  createdAt DateTime? @map("created_at")
+  reads     Int
+  title     String
+  updatedAt DateTime? @map("updated_at")
+
+  @@map("posts")
+}
+
+model StrapiAdministrator {
+  id                 Int      @id
+  blocked            Boolean?
+  email              String
+  password           String
+  resetPasswordToken String?
+  username           String
+
+  @@map("strapi_administrator")
+}
+
+model UploadFile {
+  id        Int       @id
+  createdAt DateTime? @map("created_at")
+  ext       String?
+  hash      String
+  mime      String
+  name      String
+  provider  String
+  publicId  String?   @map("public_id")
+  sha256    String?
+  size      String
+  updatedAt DateTime? @map("updated_at")
+  url       String
+
+  @@map("upload_file")
+}
+
+model UploadFileMorph {
+  id           Int     @id
+  field        String?
+  relatedId    Int?    @map("related_id")
+  relatedType  String? @map("related_type")
+  uploadFileId Int?    @map("upload_file_id")
+
+  @@map("upload_file_morph")
+}
+
+model UsersPermissionsPermission {
+  id         Int     @id
+  action     String
+  controller String
+  enabled    Boolean
+  policy     String?
+  role       Int?
+  type       String
+
+  @@map("users-permissions_permission")
+}
+
+model UsersPermissionsRole {
+  id          Int     @id
+  description String?
+  name        String
+  type        String?
+
+  @@map("users-permissions_role")
+}
+
+model UsersPermissionsUser {
+  id                 Int       @id
+  blocked            Boolean?
+  confirmed          Boolean?
+  createdAt          DateTime? @map("created_at")
+  email              String
+  password           String?
+  provider           String?
+  resetPasswordToken String?
+  role               Int?
+  updatedAt          DateTime? @map("updated_at")
+  username           String
+
+  @@map("users-permissions_user")
+}

--- a/samples/Prisma/schema.prisma
+++ b/samples/Prisma/schema.prisma
@@ -1,0 +1,33 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+  default  = true
+}
+
+generator photon {
+  provider = "photonjs"
+}
+
+generator nexus_prisma {
+  provider = "nexus-prisma"
+  output   = "node_modules/@generated/nexus-prisma"
+}
+
+model Post {
+  id        String   @default(cuid()) @id @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  published Boolean
+  title     String
+  content   String?
+  author    User?
+}
+
+
+model User {
+  id       String  @default(cuid()) @id @unique
+  email    String  @unique
+  password String
+  name     String?
+  posts    Post[]
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -310,6 +310,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **PostCSS:** [hudochenkov/Syntax-highlighting-for-PostCSS](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS)
 - **PostScript:** [textmate/postscript.tmbundle](https://github.com/textmate/postscript.tmbundle)
 - **PowerShell:** [PowerShell/EditorSyntax](https://github.com/PowerShell/EditorSyntax)
+- **Prisma:** [prisma/vscode-prisma](https://github.com/prisma/vscode-prisma)
 - **Processing:** [textmate/processing.tmbundle](https://github.com/textmate/processing.tmbundle)
 - **Prolog:** [alnkpa/sublimeprolog](https://github.com/alnkpa/sublimeprolog)
 - **Propeller Spin:** [bitbased/sublime-spintools](https://github.com/bitbased/sublime-spintools)

--- a/vendor/licenses/grammar/vscode-prisma.txt
+++ b/vendor/licenses/grammar/vscode-prisma.txt
@@ -1,0 +1,207 @@
+---
+type: grammar
+name: vscode-prisma
+version: 3b602d3f1ba3d50b90d89b5ebba59c19f7b69a4e
+license: apache-2.0
+---
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Adding support for [Prisma 2's](https://www.prisma.io/blog/announcing-prisma-2-zq1s745db8i5) new datamodel syntax for `.prisma` extensions.

This PR is based on #4579, and fixes the issue in regards to the license.

## Description
Adds support and grammar for [Prisma 2's](https://www.prisma.io/blog/announcing-prisma-2-zq1s745db8i5) new datamodel syntax language for `.prisma` files.

> Information about the new datamodel syntax can be found [on Prisma 2's docs](https://github.com/prisma/prisma2/blob/master/docs/data-modeling.md#example). 

**Documentation References**
- [Prisma 2's Data Modeling docs](https://github.com/prisma/prisma2/blob/master/docs/data-modeling.md#example)
- [Prisma schema file usage docs](https://github.com/prisma/prisma2/blob/master/docs/prisma-schema-file.md)

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?q=extension%3Aprisma+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
       - [schema.prisma](https://github.com/prisma/prisma2/blob/master/docs/data-modeling.md#example)
       - [blog-minimal-schema.prisma](https://github.com/prisma-labs/linguist/blob/feature/prisma-language/samples/Prisma/blog-minimal-schema.prisma)
       - [blog-schema-advanced.prisma](https://github.com/prisma-labs/linguist/blob/feature/prisma-language/samples/Prisma/blog-schema-advanced.prisma)
       - [mcu-schema.prisma](https://github.com/prisma-labs/linguist/blob/feature/prisma-language/samples/Prisma/mcu-schema.prisma)
       - [now-example-schema.prisma](https://github.com/prisma-labs/linguist/blob/feature/prisma-language/samples/Prisma/now-example-schema.prisma)
    - Sample license(s):
       - All are under `apache-2.0`
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: [github-lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fprisma%2Fvscode-prisma%2Fblob%2Fmaster%2Fsyntaxes%2Fprisma.tmLanguage.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fprisma-labs%2Flinguist%2Fblob%2Ffeature%2Fprisma-language%2Fsamples%2FPrisma%2Fblog-schema-advanced.prisma&code=)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
 

> Not sure if the section below is applicable?
- [x] **I am changing the color associated with a language**
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [Optional: URL to official branding guidelines for the language]: https://www.prisma.io/ - We could not use our official brand color, so we used one that was a close to possible without conflicting with other existing colors