### PR TITLE
Add dotnet-install scripts to vendor list

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -32,6 +32,9 @@
 - (^|/)ltversion.m4
 - (^|/)lt~obsolete.m4
 
+# .NET Core Install Scripts
+- dotnet-install\.(ps1|sh)$
+
 # Linters
 - cpplint.py
 


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
For .NET Core, there are two install scripts that Microsoft has made named `dotnet-install.ps1` and `dotnet-install.sh`. These files help builds have the correct version of .NET Core installed but otherwise sit unaltered in the repository.

See Microsoft's documentation on the scripts: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
