### PR TITLE
Add "bzl" and "build" (Starlark) as Python aliases

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4111,6 +4111,8 @@ Python:
   - python2
   - python3
   aliases:
+  - bzl
+  - build
   - rusthon
   - python3
   language_id: 303


### PR DESCRIPTION
Starlark files (*.bzl, BUILD, BUILD.bazel) have been included under Python for almost four years, since 864a6c0a2 (by @Dominator008). Would be good for "bzl" and "build" fenced code blocks to be able to get that highlighting, too.

## Checklist:
- [ ] **I am associating a language with a new file extension.**
- [ ] **I am adding a new language.**
- [ ] **I am fixing a misclassified language**
- [ ] **I am changing the source of a syntax highlighting grammar**
- [ ] **I am updating a grammar submodule**
- [x] **I am adding new or changing current functionality**
  - [ ] I have added or updated the tests for the new or changed functionality.
- [ ] **I am changing the color associated with a language**

Where are tests relevant to this change?

Would it be better to split this into its own language entry?