### PR TITLE
Update CI GitHub Action to use new `ruby-version` key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
       run: script/ci/install_deps
     - name: Run tests


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
I noticed we're starting to get annotations like this added to our PRs from GitHub Actions:

![Screenshot 2019-10-11 at 16 13 41](https://user-images.githubusercontent.com/627280/66663295-5932aa00-ec42-11e9-81d5-bafa60044a5b.png)

This PR addresses that by changing `version` to `ruby-version` as suggested.

_Template removed as it doesn't apply_