### PR TITLE
Add alias "m68k" to "Motorola 68K Assembly"

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3226,6 +3226,8 @@ MoonScript:
 Motorola 68K Assembly:
   type: programming
   group: Assembly
+  aliases:
+  - m68k
   extensions:
   - ".X68"
   tm_scope: source.m68k


### PR DESCRIPTION
This allows to use this linguist-language in .gitattributes
as the syntax of that file doesn't allow whitespaces.

See https://github.com/github/linguist/issues/4681