### PR TITLE
Don't test against Ruby 2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.6.x', '2.5.x', '2.4.x', '2.3.x' ]
+        ruby: [ '2.6.x', '2.5.x', '2.4.x' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Ruby 2.3 has been EOL since March and support was removed from GitHub Actions this weekend. This removal was announced in https://github.blog/changelog/2019-10-17-github-actions-removing-python-3-4-and-ruby-2-3-from-the-virtual-environments/ but I missed it 😊.

This PR removes 2.3 from the list of Ruby versions to test against.

[_Template removed as it doesn't apply_]