### PR TITLE
Add ".cjs" as a JavaScript extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2470,6 +2470,7 @@ JavaScript:
   - ".js"
   - "._js"
   - ".bones"
+  - ".cjs"
   - ".es"
   - ".es6"
   - ".frag"


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Add ".cjs" as a valid JavaScript extension, as it's what Node, in `--experimental-modules` mode, currently recognizes as a commonjs file even in packages with `"type": "module"` in the closest `package.json`.

The extension is not (as of 2019-11) yet in widespread use, as `--experimental-modules` did not yet get its wide release, but it can be used on multi-format modules, or for modules that need access to some commonjs-only functionality to be ready for the release.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in ~~hundreds~~ a handful of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Acjs+require
