### PR TITLE
add .p extension to Gnuplot

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -289,6 +289,13 @@ disambiguations:
   - language: NL
     pattern: '^(b|g)[0-9]+ '
   - language: NewLisp
+- extensions: ['.p']
+  rules:
+  - language: Gnuplot
+    pattern:
+    - '^s?plot\b'
+    - '^set\s+(term|terminal|out|output|[xy]tics|[xy]label|[xy]range|style)\b'
+  - language: OpenEdge ABL
 - extensions: ['.php']
   rules:
   - language: Hack

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1777,6 +1777,7 @@ Gnuplot:
   - ".gp"
   - ".gnu"
   - ".gnuplot"
+  - ".p"
   - ".plot"
   - ".plt"
   interpreters:

--- a/samples/Gnuplot/defense_plotter.p
+++ b/samples/Gnuplot/defense_plotter.p
@@ -1,0 +1,40 @@
+#
+# defense_plotter.p
+#
+# This is a gnuplot script that creates the graphs for defense values.
+#
+# Defense values are from:
+#
+#   http://wiki.starsautohost.org/wiki/Guts_of_bombing
+#   Author:  Leonard Dickens
+#   Date:  1998/07/17
+#   Forums:  rec.games.computer.stars
+#
+# :author: Brandon Arrendondo
+# :license: MIT
+#
+set terminal pngcairo transparent truecolor font "Arial Bold,10" size 350, 250
+set output "out.png"
+
+set title "Shield Coverage vs. Defense Quantity"
+set grid
+set xrange [0:100]
+set xlabel "Number of Defenses"
+
+set format y '%2.0f%%'
+set yrange [0:100]
+
+set key right bottom
+
+sdi = 0.0099
+missile_battery = 0.0199
+laser_battery = 0.0239
+planetary_shield = 0.0299
+neutron_shield = 0.0379
+
+val = neutron_shield
+
+f(x) = (1.0 - ((1.0 - (val)) ** x)) * 100.0
+g(x) = (1.0 - ((1.0 - (val/2.0)) ** x)) * 100.0
+
+plot f(x) title "Standard" lt rgb "#000080", g(x) title "Smart" lt rgb "#000000"

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -334,6 +334,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_p_by_heuristics
+    assert_heuristics({
+      "Gnuplot" => all_fixtures("Gnuplot"),
+      "OpenEdge ABL" => all_fixtures("OpenEdge ABL")
+    }, alt_name="test.p")
+  end
+
   # Candidate languages = ["Hack", "PHP"]
   def test_php_by_heuristics
     assert_heuristics({


### PR DESCRIPTION
## Description
- add .p extension to Gnuplot (fixes #4388)
- add disambiguation rule for Gnuplot and OpenEdge ABL

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - https://github.com/search?p=90&q=extension%3Ap+plot+set+output&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR: https://github.com/szarta/stars-research/blob/master/defense_plotter.p (MIT license)
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

Continuation of https://github.com/github/linguist/pull/4403