### PR TITLE
add Proguard support

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -329,6 +329,8 @@ disambiguations:
     pattern: '^\s+\w+\s+=>\s'
 - extensions: ['.pro']
   rules:
+  - language: Proguard
+    pattern: '^-(include\b.*\.pro$|keep\b|keepclassmembers\b|keepattributes\b)'
   - language: Prolog
     pattern: '^[^\[#]+:-'
   - language: INI

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4013,6 +4013,13 @@ Processing:
   tm_scope: source.processing
   ace_mode: text
   language_id: 294
+Proguard:
+  type: data
+  extensions:
+  - ".pro"
+  tm_scope: none
+  ace_mode: text
+  language_id: 716513858
 Prolog:
   type: programming
   color: "#74283c"

--- a/samples/Proguard/proguard-rules.pro
+++ b/samples/Proguard/proguard-rules.pro
@@ -1,0 +1,42 @@
+# Proguard 2018-4-18 16:28:00
+
+-basedirectory proguard-pro
+
+-include proguard-normal.pro
+-include proguard-support-design.pro
+-include proguard-support-v7-appcompat.pro
+-include proguard-support-v7-cardview.pro
+
+-include proguard-google.pro
+-include proguard-google-gson2.pro
+-include proguard-google-protobuf.pro
+
+-include proguard-butterknife-7.pro
+-include proguard-eventbus-3.pro
+-include proguard-gson.pro
+
+-include proguard-alipay.pro
+-include proguard-baidu-map.pro
+-include proguard-bugtags.pro
+-include proguard-jpush.pro
+-include proguard-mob.pro
+-include proguard-pingplus.pro
+-include proguard-umeng.pro
+-include proguard-wechat.pro
+
+-include proguard-android-gif-drawable.pro
+-include proguard-androidannotations.pro
+-include proguard-glide.pro
+-include proguard-greendao.pro
+-include proguard-jsoup.pro
+-include proguard-matisse.pro
+-include proguard-tencent-webview.pro
+
+-include proguard-rx-java.pro
+-include proguard-square-okhttp.pro
+-include proguard-square-okhttp3.pro
+-include proguard-square-okio.pro
+-include proguard-square-picasso.pro
+
+-include proguard-facebook-stetho.pro
+-include proguard-leakcanary.pro

--- a/samples/Proguard/proguard-rules2.pro
+++ b/samples/Proguard/proguard-rules2.pro
@@ -1,0 +1,105 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /usr/local/android/android-sdk-linux/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+
+##---------------Begin: ProGuard configuration for Android Architecture Components ----------
+
+# IMPORTANT: There are no proper ProGuard rules for Android Architecture Components yet.
+# We are just keeping everything for now but this needs to be revised.
+
+-keep class android.arch.** { *; }
+
+##---------------End: ProGuard configuration for Android Architecture Components ------------
+
+
+##---------------Begin: ProGuard configuration for Dagger ----------
+
+# Based on https://github.com/google/dagger/issues/645
+
+-dontwarn com.google.errorprone.annotations.**
+
+##---------------End: ProGuard configuration for Dagger ------------
+
+
+##---------------Begin: ProGuard configuration for Glide ----------
+
+# Based on https://github.com/bumptech/glide#proguard
+
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$** {
+  **[] $VALUES;
+  public *;
+}
+
+##---------------End: ProGuard configuration for Glide ------------
+
+
+##---------------Begin: ProGuard configuration for Moshi ----------
+
+# Based on https://github.com/square/moshi#proguard
+
+-dontwarn okio.**
+-dontwarn javax.annotation.Nullable
+-dontwarn javax.annotation.ParametersAreNonnullByDefault
+
+##---------------End: ProGuard configuration for Moshi ------------
+
+
+##---------------Begin: ProGuard configuration for OkHttp ----------
+
+# Based on https://github.com/square/okhttp#proguard
+
+-dontwarn okio.**
+-dontwarn javax.annotation.Nullable
+-dontwarn javax.annotation.ParametersAreNonnullByDefault
+
+##---------------End: ProGuard configuration for OkHttp ------------
+
+
+##---------------Begin: ProGuard configuration for Okio ----------
+
+# Based on https://github.com/square/okio#proguard
+
+-dontwarn okio.**
+
+##---------------End: ProGuard configuration for Okio ------------
+
+
+##---------------Begin: ProGuard configuration for Retrofit ----------
+
+# Based on http://square.github.io/retrofit/
+
+# Platform calls Class.forName on types which do not exist on Android to determine platform.
+-dontnote retrofit2.Platform
+# Platform used when running on Java 8 VMs. Will not be used at runtime.
+-dontwarn retrofit2.Platform$Java8
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain declared checked exceptions for use by a Proxy instance.
+-keepattributes Exceptions
+
+##---------------End: ProGuard configuration for Retrofit ------------
+
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+-renamesourcefileattribute SourceFile

--- a/samples/Proguard/proguard_annotations.pro
+++ b/samples/Proguard/proguard_annotations.pro
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Keep our interfaces so they can be used by other ProGuard rules.
+# See http://sourceforge.net/p/proguard/bugs/466/
+-keep,allowobfuscation @interface com.facebook.proguard.annotations.DoNotStrip
+-keep,allowobfuscation @interface com.facebook.proguard.annotations.KeepGettersAndSetters
+
+# Do not strip any method/class that is annotated with @DoNotStrip
+-keep @com.facebook.proguard.annotations.DoNotStrip class *
+-keepclassmembers class * {
+    @com.facebook.proguard.annotations.DoNotStrip *;
+}
+
+-keepclassmembers @com.facebook.proguard.annotations.KeepGettersAndSetters class * {
+  void set*(***);
+  *** get*();
+}

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -375,9 +375,10 @@ class TestHeuristics < Minitest::Test
     })
   end
 
-  # Candidate languages = ["IDL", "Prolog", "QMake", "INI"]
+  # Candidate languages = ["IDL", "Proguard", "Prolog", "QMake", "INI"]
   def test_pro_by_heuristics
     assert_heuristics({
+      "Proguard" => all_fixtures("Proguard", "*.pro"),
       "Prolog" => all_fixtures("Prolog", "*.pro"),
       "IDL" => all_fixtures("IDL", "*.pro"),
       "INI" => all_fixtures("INI", "*.pro"),


### PR DESCRIPTION
## Description

* add Proguard language (#4705)
* add additional heuristic for .pro extension

Samples:
* proguard_annotations.pro (MIT) from:
  https://github.com/iperformance/react-native/blob/2b5f4de7eb4e5453e91d4956bcb0f58fe37b6562/ReactAndroid/src/main/java/com/facebook/proguard/annotations/proguard_annotations.pro
* proguard-rules.pro (Apache 2.0) from:
  https://github.com/JerrNeon/Kiku/blob/8bb2e3344174af8e8287506a99b6ac43d721db95/core/config/proguard-rules.pro (Apache 2.0)
* proguard-rules2.pro (Apache 2.0) from:
  https://github.com/jrgonzalezg/OpenLibraryApp/blob/aaa2c052d42a3e91d4c2038109939756a5dfd903/app/proguard-rules.pro
(Apache 2.0)

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension: https://github.com/search?q=proguard+extension%3Apro&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): (see above)
    - Sample license(s): (see above)
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/ (TODO)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension. (TODO)
