### PR TITLE
Change `tm_scope` for `Fortran` to `source.fortran`

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1507,7 +1507,7 @@ Fortran:
   - ".f95"
   - ".for"
   - ".fpp"
-  tm_scope: source.fortran.modern
+  tm_scope: source.fortran
   ace_mode: text
   codemirror_mode: fortran
   codemirror_mime_type: text/x-fortran


### PR DESCRIPTION
Following a suggestion from @pchaigno to address issue #4694.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: [Lightshow: source.fortran.modern](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=source.fortran.modern&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Ftextmate%2Ffortran.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FFortran+-+Modern.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fjohannesgerer%2Fjburkardt-f77%2Fblob%2Fmaster%2Fasa032%2Fasa032.f%23L3-L34&code=)
  - New: [Lightshow: source.fortran](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Ftextmate%2Ffortran.tmbundle%2Fblob%2Fmaster%2FSyntaxes%2FFortran%2520-%2520Punchcard.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fjohannesgerer%2Fjburkardt-f77%2Fblob%2Fmaster%2Fasa032%2Fasa032.f%23L3-L34&code=)