### PR TITLE
Add ".postcss" to PostCSS language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3957,6 +3957,7 @@ PostCSS:
   group: CSS
   extensions:
   - ".pcss"
+  - ".postcss"
   ace_mode: text
   language_id: 262764437
 PostScript:

--- a/samples/PostCSS/sample.postcss
+++ b/samples/PostCSS/sample.postcss
@@ -1,0 +1,13 @@
+@define-mixin size $size {
+  width: $size;
+}
+
+$big: 100px;
+
+/* Main block */
+.block {
+  &_logo {
+    background: inline("./logo.png");
+    @mixin size $big;
+  }
+}

--- a/samples/PostCSS/sample.postcss
+++ b/samples/PostCSS/sample.postcss
@@ -1,13 +1,165 @@
-@define-mixin size $size {
-  width: $size;
-}
+.markdown {
+  @apply overflow-hidden;
 
-$big: 100px;
+  img {
+    @apply inline-block;
 
-/* Main block */
-.block {
-  &_logo {
-    background: inline("./logo.png");
-    @mixin size $big;
+    &.ally-bg {
+      @apply bg-gray-200 rounded p-2;
+
+      &.avatar {
+        @apply p-0 rounded-lg;
+      }
+    }
+
+    &[align="left"] {
+      @apply mr-5;
+    }
+
+    &[align="right"] {
+      @apply ml-5;
+    }
+  }
+
+  a {
+    @apply text-purple-500;
+
+    &:hover {
+      @apply text-purple-400;
+    }
+  }
+
+  h1 {
+    @apply text-3xl mt-8 mb-4 text-gray-600;
+
+    @media (max-width: 640px) {
+      @apply text-2xl;
+    }
+  }
+
+  h2 {
+    @apply text-2xl;
+
+    @media (max-width: 640px) {
+      @apply text-xl;
+    }
+  }
+
+  h3 {
+    @apply text-xl;
+
+    @media (max-width: 640px) {
+      @apply text-lg;
+    }
+  }
+
+  h1, h2 {
+    @apply pb-2 border-b border-gray-800;
+  }
+
+  h2, h3 {
+    @apply mt-8 mb-3 text-gray-500;
+  }
+
+  h4, h5, h6 {
+    @apply text-lg mt-6;
+
+    @media (max-width: 640px) {
+      @apply text-base;
+    }
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply flex flex-wrap items-center whitespace-pre-wrap font-bold;
+
+    &:first-child {
+      @apply mt-0;
+    }
+
+    &[align="center"] {
+      @apply justify-center;
+    }
+
+    &[align="right"] {
+      @apply justify-end;
+    }
+
+    &:hover {
+      .anchor {
+        @apply visible;
+      }
+    }
+  }
+
+  p {
+    @apply my-4;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  tr {
+    &:nth-child(2n) {
+      @apply bg-gray-850;
+    }
+  }
+
+  td, th {
+    @apply border border-gray-800 p-2;
+  }
+
+  hr {
+    @apply border-gray-800;
+  }
+
+  ul {
+    @apply list-disc;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+
+  ul, ol {
+    @apply my-2 pl-2;
+  }
+
+  li {
+    @apply ml-6;
+  }
+
+  pre {
+    @apply text-white bg-gray-850 rounded p-4 my-4 overflow-x-auto;
+    font-size: 14px;
+  }
+
+  code {
+    @apply text-white bg-gray-850 rounded px-2 py-1 break-words;
+  }
+
+  blockquote {
+    @apply pl-4 my-4 border-l-4 border-purple-700 text-gray-500;
+
+    p {
+      &:first-child {
+        @apply mt-0;
+      }
+
+      &:last-child {
+        @apply mb-0;
+      }
+    }
+  }
+
+  .markdown-body {
+    @apply p-0;
+  }
+
+  .anchor {
+    @apply invisible text-gray-600 pr-1 -ml-5 h-6 flex items-center;
+    svg {
+      @apply fill-current;
+    }
   }
 }


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Apostcss+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/Akryum/awesomejs.dev/blob/e59a65f6d318cfad9f340681e843d2de20d032fb/packages/frontend/src/assets/styles/components/markdown.postcss#L1
    - Sample license(s):
      - MIT
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
