### PR TITLE
Allow update head on master to fix CI runs on master

### DIFF
--- a/script/ci/install_deps
+++ b/script/ci/install_deps
@@ -7,7 +7,7 @@ gem uninstall -v '>= 2' -ax bundler || true
 gem install bundler -v '< 2'
 
 # Fetch all commits/refs needed to run our tests.
-git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
+git fetch -u origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
 
 # Replace SSH links to submodules by HTTPS links.
 sed -i 's|git@github.com:|https://github.com/|' .gitmodules


### PR DESCRIPTION
I noticed that the builds kicked off against master when merging PRs has started failing in the last week at the "Install dependencies" stage as follows:

```
Gem 'bundler' is not installed
Successfully installed bundler-1.17.3
Parsing documentation for bundler-1.17.3
Installing ri documentation for bundler-1.17.3
Done installing documentation for bundler after 2 seconds
1 gem installed
fatal: Refusing to fetch into current branch refs/heads/master of non-bare repository
##[error]Process completed with exit code 128.
```

I'm not really sure what has changed on the GitHub Actions side in the last week, but this appears to be because we're trying to fetch master into master, which is a bit redundant as we're already on master, but this should be made possible by adding the `-u` flag to the `git fetch`.