### PR TITLE
Revert "Allow update head on master to fix CI runs on master"

### DIFF
--- a/script/ci/install_deps
+++ b/script/ci/install_deps
@@ -7,7 +7,7 @@ gem uninstall -v '>= 2' -ax bundler || true
 gem install bundler -v '< 2'
 
 # Fetch all commits/refs needed to run our tests.
-git fetch -u origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
+git fetch origin master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
 
 # Replace SSH links to submodules by HTTPS links.
 sed -i 's|git@github.com:|https://github.com/|' .gitmodules


### PR DESCRIPTION
Reverts github/linguist#4732

This got us past that step but hasn't pulled in the necessary changes. Annoyingly, this works perfectly locally so I've reached out to the GitHub Actions team to get more help. Until then, I'm putting things back the way they were.