### PR TITLE
Use actions/checkout@v1 to fix master builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         ruby: [ '2.6.x', '2.5.x', '2.4.x' ]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:


### PR DESCRIPTION
Second attempt at fixing the issue detailed in https://github.com/github/linguist/pull/4732 now I've heard from those in the know.

The problem is likely to be because we're using `actions/checkout@master` to checkout the repo. The master branch was updated two days ago in https://github.com/actions/checkout/pull/70 to start allowing peeps to test the beta of v2 which changes quite a few things.

This PR puts us back to the old behaviour by enforcing the use of v1.