### PR TITLE
Add syntax highlighting to M4 files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2900,7 +2900,7 @@ M4:
   type: programming
   extensions:
   - ".m4"
-  tm_scope: none
+  tm_scope: source.m4
   ace_mode: text
   language_id: 215
 M4Sugar:
@@ -2912,7 +2912,7 @@ M4Sugar:
   - ".m4"
   filenames:
   - configure.ac
-  tm_scope: none
+  tm_scope: source.m4
   ace_mode: text
   language_id: 216
 MATLAB:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -231,6 +231,8 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **LookML:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **LoomScript:** [ambethia/Sublime-Loom](https://github.com/ambethia/Sublime-Loom)
 - **Lua:** [textmate/lua.tmbundle](https://github.com/textmate/lua.tmbundle)
+- **M4:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
+- **M4Sugar:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **MATLAB:** [mathworks/MATLAB-Language-grammar](https://github.com/mathworks/MATLAB-Language-grammar)
 - **MAXScript:** [Alhadis/language-maxscript](https://github.com/Alhadis/language-maxscript)
 - **MLIR:** [jpienaar/mlir-grammar](https://github.com/jpienaar/mlir-grammar)

--- a/vendor/licenses/grammar/language-etc.txt
+++ b/vendor/licenses/grammar/language-etc.txt
@@ -1,7 +1,7 @@
 ---
 type: grammar
 name: language-etc
-version: cdbe4f76a48eecc1331486767e732bd851ddea13
+version: bdd07fa5526c2abf2c270c26d73ba6e78b35bb57
 license: isc
 ---
 Copyright (c) 2018-2019, John Gardner


### PR DESCRIPTION
## Description
This PR [adds syntax highlighting to M4 files](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FAlhadis%2Flanguage-etc%2Fblob%2Fmaster%2Fgrammars%2Fm4.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fstrace%2Fstrace%2Fblob%2Fmaster%2Fconfigure.ac&code=), which I managed to [finish](https://github.com/Alhadis/language-etc/commit/482ec6e8d08b3b5a54e84872e45891b5527a906d) (hopefully) in the nick-of-time for the next release.

/cc @pchaigno

*Template removed as it doesn't really apply.*