### PR TITLE
Use new `mocha/minitest` require in test suite

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 require "minitest/autorun"
-require "mocha/setup"
+require "mocha/minitest"
 require "linguist"
 require 'color-proximity'
 require "linguist/blob"


### PR DESCRIPTION
Whilst looking into https://github.com/github/linguist/pull/4740 I noticed CI is now producing this deprecation warning:

```
Mocha deprecation warning at /Users/lildude/Downloads/trash/linguist/test/helper.rb:3:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
```

This PR adjusts our usage from `mocha/setup` to `mocha/minitest`.

_[ Template moved as it doesn't apply ]_