### PR TITLE
Map .qhelp to XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5850,6 +5850,7 @@ XML:
   - ".ps1xml"
   - ".psc1"
   - ".pt"
+  - ".qhelp"
   - ".rdf"
   - ".resx"
   - ".rss"

--- a/samples/XML/Unused.qhelp
+++ b/samples/XML/Unused.qhelp
@@ -1,0 +1,29 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+
+<overview>
+<p>
+This query finds variables that are assigned a value but are never read. This is usually an indication of a variable that has been orphaned
+due to changes in code, or a defect in the code due to the omission of the unused variable. The unused variables should be
+removed to avoid misuse.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Examine the code to see if the variable is no longer needed. If it is unnecessary, remove the variable.
+Otherwise, update the relevant code to use the variable.
+</p>
+</recommendation>
+
+<example>
+<sample src="Unused.cpp" />
+</example>
+
+<references>
+<li>SEI CERT C Coding Standard: <a href="https://wiki.sei.cmu.edu/confluence/display/c/MSC13-C.+Detect+and+remove+unused+values">MSC13-C. Detect and remove unused values</a>.</li>
+</references>
+</qhelp>

--- a/test/test_strategies.rb
+++ b/test/test_strategies.rb
@@ -183,6 +183,7 @@ class TestStrategies < Minitest::Test
       "#{samples_path}/XML/some-ideas.mm",
       "#{samples_path}/XML/GMOculus.project.gmx",
       "#{samples_path}/XML/obj_control.object.gmx",
+      "#{samples_path}/XML/Unused.qhelp",
     ]
     assert_all_xml all_xml_fixtures("*") - no_root_tag
 


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Add `.qhelp` as an XML extension

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Aqhelp+qhelp&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/Semmle/ql/blob/master/cpp/ql/src/Critical/Unused.qhelp
    - Sample license(s): https://github.com/Semmle/ql/blob/master/LICENSE
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
