### PR TITLE
Add leex extension to HTML+EEX

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1996,6 +1996,7 @@ HTML+EEX:
   - eex
   extensions:
   - ".eex"
+  - ".leex"
   ace_mode: text
   codemirror_mode: htmlmixed
   codemirror_mime_type: text/html


### PR DESCRIPTION
The Elixir template language sometimes uses the extension `.leex`, when used with the LiveView library.

This is documented here https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-assigns-and-liveeex-templates

I've not added an example as it is the same file contents as the regular `.eex` version. Shall I add this?

## Checklist:

- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?q=extension%3Aleex+div&type=Code
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
