### PR TITLE
Register `.bibtex` as a BibTeX file-extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -431,6 +431,7 @@ BibTeX:
   group: TeX
   extensions:
   - ".bib"
+  - ".bibtex"
   tm_scope: text.bibtex
   ace_mode: tex
   codemirror_mode: stex

--- a/samples/BibTeX/deeplyaggrevated.bibtex
+++ b/samples/BibTeX/deeplyaggrevated.bibtex
@@ -1,0 +1,16 @@
+@article{DBLP:journals/corr/SunVGBB17,
+  author    = {Wen Sun and
+               Arun Venkatraman and
+               Geoffrey J. Gordon and
+               Byron Boots and
+               J. Andrew Bagnell},
+  title     = {Deeply AggreVaTeD: Differentiable Imitation Learning for Sequential
+               Prediction},
+  journal   = {CoRR},
+  volume    = {abs/1703.01030},
+  year      = {2017},
+  url       = {http://arxiv.org/abs/1703.01030},
+  timestamp = {Wed, 07 Jun 2017 14:41:53 +0200},
+  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/corr/SunVGBB17},
+  bibsource = {dblp computer science bibliography, http://dblp.org}
+}


### PR DESCRIPTION
## Description
Fairly self-explanatory. BibTeX's main file-extension is `.bib`, but [some folks use `.bibtex`](https://github.com/search?q=extension%3Abibtex+NOT+nothack&type=Code) instead.

## Usage

* [1,483 files](https://github.com/Alhadis/Silos/blob/640476a2ae6c69b1af018b46c22ea96662a6b0f5/urls.log)
* [489 repositories](https://github.com/Alhadis/Silos/blob/640476a2ae6c69b1af018b46c22ea96662a6b0f5/repos.log)
* [430 users](https://github.com/Alhadis/Silos/blob/640476a2ae6c69b1af018b46c22ea96662a6b0f5/users.log)

## Checklist:
- [x] **I am associating a language with a new file extension.**
	- [x] **The new extension is used in hundreds of repositories on GitHub**
	- [x] **I have included a real-world usage sample:**
		- Sample source: [`AJLiu/rll-site`](https://github.com/AJLiu/rll-site/blob/70a8dff23d9bca16e1afbc6b24f5738ecef383ae/publications/deeplyaggrevated.bibtex)
		- Sample license: [MIT](https://github.com/AJLiu/rll-site/blob/9b76385f721d7438ce3e35b9a2cfd44da63e73cc/LICENSE.txt)
	- [ ] ~~I have included a change to the heuristics to distinguish my language from others using the same extension.~~
