### PR TITLE
Add the extensions .mac and .wxm for maxima sessions.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3125,6 +3125,15 @@ Max:
   codemirror_mode: javascript
   codemirror_mime_type: application/json
   language_id: 227
+Maxima-session:
+  type: programming
+  extensions:
+  - ".wxm"
+  - ".mac"
+  tm_scope: source.maxima
+  ace_mode: text
+  color: "#6aa7c1"
+  language_id: 435234
 MediaWiki:
   type: prose
   wrap: true

--- a/samples/Maxima-session/coolStuff.wxm
+++ b/samples/Maxima-session/coolStuff.wxm
@@ -1,0 +1,20 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 20.01.2-DevelopmentSnapshot ] */
+/* [wxMaxima: title   start ]
+Cool things to know
+   [wxMaxima: title   end   ] */
+
+
+/* [wxMaxima: section start ]
+Subscripts
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Maxima
+   [wxMaxima: comment end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 20.01.2-DevelopmentSnapshot"$

--- a/samples/Maxima-session/diffEquations.wxm
+++ b/samples/Maxima-session/diffEquations.wxm
@@ -1,0 +1,168 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 20.01.1-DevelopmentSnapshot ] */
+/* [wxMaxima: title   start ]
+Solving differential equations
+   [wxMaxima: title   end   ] */
+
+
+/* [wxMaxima: comment start ]
+If the equation that defines the shape of a curve references the steepness of the curve (diff('f(x),x)), the steepness of the steepness of the curve (diff('f(x),x,2)) or any other deviration if the curve the result is an differential equation that describes the general shapes the curve can have without describing its actual height.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+Often an differential equation has a solution that cannot be expressed symbolically as mathematics lacks the necessary functions. In other cases one has to guess the general form of the solution and the computer only helps in finding the values of the parameters this solution contains. In the simple cases an engineer encounters on a daily basis maxima can do this automatically, instead.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+An example
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+A circuit is provided with an input capacitance of C_In=100nF, provides a resistive load R_Load and is connected to a power supply U_Supply via a cable of the inductivity L_Cable. In this moment the circuit is destroyed by an overvoltage. Let's see if we can calculate how high this voltage was.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+First we describe the energy-storing circuit elements. The voltage over the inductivity of the cable is calculated as follows:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+eq1:U_Supply=U_In(t)+L_Cable*diff(I_Cable(t),t);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+The current into the input capacitance is:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+eq2:I_C(t)=C_In*diff(U_In(t),t);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Now we have enough information to calculate the input voltage itself:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+eq3:U_In(t)=R_Load*(I_Cable(t)-I_C(t));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+If we did everything right maxima now can determine the equation that defines the general shape of all possible loading curves:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+desolve([eq1,eq2,eq3],[U_In(t),I_Cable(t),I_C(t)]);
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: question  start ] */
+<mth><st>Is </st><munder altCopy="L_Cable"><mrow><mi>L</mi></mrow><mrow><mi>Cable</mi></mrow></munder><h>*</h><mrow><p><mn>4</mn><h>*</h><munder altCopy="C_In"><mrow><mi>C</mi></mrow><mrow><mi>In</mi></mrow></munder><h>*</h><msup><mrow><munder altCopy="R_Load"><mrow><mi>R</mi></mrow><mrow><mi>Load</mi></mrow></munder></mrow><mn>2</mn></msup><mi>-</mi><munder altCopy="L_Cable"><mrow><mi>L</mi></mrow><mrow><mi>Cable</mi></mrow></munder></p></mrow><st> positive, negative or zero?</st></mth>
+/* [wxMaxima: question  end   ] */
+/* [wxMaxima: answer  start ] */
+p;
+/* [wxMaxima: answer  end   ] */
+
+
+/* [wxMaxima: comment start ]
+In this case the answer to the question desolve() asks doesn't actually affect the shape of the result, but the way the result is expressed. The equations we get are very generic, though, still, as maxima knows the general set of shapes the function might have, but in order to draw actual curves lacks I_Cable(0) and U_In(0):
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+I_Cable(t=0)=atvalue(I_Cable(t),t=0,0);
+U_In(t=0)=atvalue(U_In(t),t=0,0);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Next let's avoid the question using assume():
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+assume(L_Cable>0,R_Load>0,C_In>0,(4*C_In*R_Load^2-L_Cable)>0);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Additionally we are interested only in the first item in the result list:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+sol1:desolve([eq1,eq2,eq3],[U_In(t),I_Cable(t),I_C(t)])[1];
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: question  start ] */
+<mth><st>Is </st><munder altCopy="L_Cable"><mrow><mi>L</mi></mrow><mrow><mi>Cable</mi></mrow></munder><h>*</h><mrow><p><mn>4</mn><h>*</h><munder altCopy="C_In"><mrow><mi>C</mi></mrow><mrow><mi>In</mi></mrow></munder><h>*</h><msup><mrow><munder altCopy="R_Load"><mrow><mi>R</mi></mrow><mrow><mi>Load</mi></mrow></munder></mrow><mn>2</mn></msup><mi>-</mi><munder altCopy="L_Cable"><mrow><mi>L</mi></mrow><mrow><mi>Cable</mi></mrow></munder></p></mrow><st> positive, negative or zero?</st></mth>
+/* [wxMaxima: question  end   ] */
+/* [wxMaxima: answer  start ] */
+p;
+/* [wxMaxima: answer  end   ] */
+
+
+/* [wxMaxima: comment start ]
+Let's specify the circuit values we might know about...
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+vals:[
+    U_Supply=5,
+    R_Load=100,
+    C_In=100*10^-9
+];
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+sol1_val:subst(vals,sol1);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+...and let's plot the result for different L_Cable:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("engineering-format")$
+engineering_format_floats: true$
+engineering_format_min: .01$
+engineering_format_max: 1000$
+fpprintprec: 6$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxplot_size:[1280,800]$
+wxanimate_autoplay:true$
+wxanimate_framerate:2$
+with_slider_draw(
+    L,makelist(i*10^-9*10,i,1,20),
+    title=sconcat("L_{Cable}=",float(L)),
+    explicit(
+        subst(
+            t=us*10^-6,
+            subst(
+                L_Cable=L,
+                rhs(sol1_val)
+            )
+        ),
+        us,0,20
+    ),
+    yrange=[0,10], grid=[2,1]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 20.01.1-DevelopmentSnapshot"$

--- a/samples/Maxima-session/displaying3DCurves.wxm
+++ b/samples/Maxima-session/displaying3DCurves.wxm
@@ -1,0 +1,181 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 20.01.2-DevelopmentSnapshot ] */
+/* [wxMaxima: title   start ]
+Visualizing 3D curves
+   [wxMaxima: title   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxplot_size:[1200,900]$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Standard curves
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Maxima's default way of displaying 3d surfaces is optimized on fast display. In order to get a feeling for the shape of the curve it might help to right-click on it and press on the "Pop-out interactively" button which opens a window the curve can be rotated in:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+curve1:z=sin(x)*cos(y);
+wxdraw3d(
+    explicit(
+        rhs(curve1),
+        x,-3,3,
+        y,-3,3
+    )
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Slower to draw, but easier to understand the curve is if the surface isn't transparent:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw3d(
+    surface_hide=true,
+    explicit(
+        rhs(curve1),
+        x,-3,3,
+        y,-3,3
+    )
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Alternatively the curve can be made more colorful:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw3d(
+    enhanced3d=true,
+    explicit(
+        rhs(curve1),
+        x,-3,3,
+        y,-3,3
+    )
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Contour lines
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+If not the shape, but the absolute heights are important maxima offers contour lines.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw3d(
+    surface_hide=true,
+    color="#a0a0a0",
+    key="curve_1",
+    explicit(
+        rhs(curve1),
+        x,-3,3,
+        y,-3,3
+    ),
+    contour='both,
+    contour_levels=[-1,.2,1]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+In many cases the actual curve actually isn't important while the height values are. In this case it is possible to generate a top view without drawing the actual surface:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw3d(
+    explicit(
+        rhs(curve1),
+        x,-3,3,
+        y,-3,3
+    ),
+    contour='map,
+    contour_levels=[-1,.1,1]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Moving pictures
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: subsect start ]
+In order to make the 3d shape easier to grasp
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+As can easily be seen if one pops out the above images interactively and moves them the human brain is quite efficient in grasping the complete shape of a moving picture. wxMaxima allows to embed such a thing into the worksheet:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxanimate_autoplay:true$
+wxanimate_framerate:10$
+with_slider_draw3d(
+    α,makelist(10*sin(2*π*t/20),t,0,40),
+    view=[60,30+α],
+    surface_hide=true,
+    key="curve_1",
+    explicit(
+        rhs(curve1),
+        x,-3,3,
+        y,-3,3
+    ),
+    contour='both,
+    contour_levels=[-1,.2,1]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+In order to allow to read values more easily
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+Sometimes it isn't actually necessary to display the whole 3D shape and the height of the curve is more easy to read if one assigns the mouse's scroll wheel to the y coordinate.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxanimate_autoplay:false;
+with_slider_draw(
+    y_coord,makelist(i,i,-2,2,.1),
+    key="z_{curve_1}",
+    explicit(
+        subst(y=y_coord,rhs(curve1)),
+        x,-3,3
+    ),
+    grid=[2,2],
+    title=sconcat("y=",y_coord),
+    xlabel="x",ylabel="z",
+    yrange=[-1,1]
+),fpprintprec=3$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+In order to view this picture just click on it and move the mouse wheel; The fact that y needs to substituted into the equation to plot manually is a long-standing bug in maxima's makelist() command.
+   [wxMaxima: comment end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 20.01.2-DevelopmentSnapshot"$

--- a/samples/Maxima-session/fittingEquations.wxm
+++ b/samples/Maxima-session/fittingEquations.wxm
@@ -1,0 +1,313 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 20.01.2-DevelopmentSnapshot ] */
+/* [wxMaxima: title   start ]
+Fitting equations to real measurement data
+   [wxMaxima: title   end   ] */
+
+
+/* [wxMaxima: comment start ]
+One place Maxima can show its full power at is where symbolical mathematics that describes a phenomenon is used for understanding real measurement data.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+As a first step normally the real measurement data is loaded from a .csv file using read_matrix:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+? read_matrix;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+For the sake of generating a self-contained example we generate this data synthetically. For the first example a parabola with a bit of measurement noise might be a good start:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+fun1(x):=3*x^2-2*x+7;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+time1:makelist(i,i,-10,10,.02)$
+data1:transpose(
+    matrix(
+        time1,
+        makelist(fun1(i)+random(32.0)-16,i,time1)
+    )
+)$
+wxdraw2d(grid=true,xlabel="x",ylabel="y",
+    points(data1)
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+The general approach
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Let's assume we have guessed that the curve might be something parabola-like:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+approach1:y=a*x^2+b*x+c;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Maxima now offers a simple, but powerful curve fitter that guesses the parameters a,b and c for us:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("lsquares")$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lsquares_estimates_approximate(
+    lsquares_mse(
+        data1,[x,y],approach1
+    ),
+    [a,b,c],
+    initial=[0,0,0]
+);
+params1:%[1];
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+In this example the "initial=" wasn't really necessary. But sometimes using the wrong starting point means that lsquares heads for the wrong local optimum of the problem.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+rec1:subst(params1,approach1);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw2d(
+    grid=true,xlabel="x",ylabel="y",
+    color=red,key="Reconstructed",
+    explicit(rhs(rec1),x,-10,10),
+    color=blue,key="Original",
+    explicit(fun1,x,-10,10)
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Besides lsquares_estimates_approximate the lsquares package also provides a command named lsquares_estimates that tries to find the exact optimum by running the problem through solve() before finding the answer numerically. But as it is always the case with computers if the problem that is to be solved is complex one does never know in advance how long it will take and if it ever will finish. lsquares_estimates_approximate doesn't have this drawback.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+Dealing with non-evenly-spaced data
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Sometimes the input data isn't evenly spaced.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+The places with a higher density of samples have more weight when fitting data to the curves. So let's add an error to the place with the highest data density and see if we can cope with it.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+time2:makelist(i^4*i/abs(i),i,-2,2,.02)$
+data2:transpose(
+    matrix(
+        time2,
+        makelist(fun1(i)+random(4.0)-2+50*sin(i)/i,i,time2)
+    )
+)$
+wxdraw2d(grid=true,xlabel="x",ylabel="y",
+    points(data2),
+    yrange=[0,800]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Since the biggest error occurs where we have the highest density of data the result of fitting the curve to this data directly will be suboptimal:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lsquares_estimates_approximate(
+    lsquares_mse(
+        data2,[x,y],approach1
+    ),
+    [a,b,c]
+);
+params2_1:%[1];
+wxdraw2d(
+    grid=true,xlabel="x",ylabel="y",
+    color=red,key="Reconstructed",
+    explicit(rhs(subst(params2_1,approach1)),x,-10,10),
+    color=blue,key="Original",
+    explicit(fun1,x,-10,10)
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Converting the data to an continuous curve
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+The interpol package allows to generate continuous and half-way smooth curves from any input data.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("interpol")$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+data2_cont:cspline(data2,'varname=x)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw2d(
+    explicit(data2_cont,x,-10,10),
+    grid=true,xlabel="x",ylabel="y"
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Generating evenly-spaced samples from this curve
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+First we generate the new data and time vector. As always the fact that a subst() is necessary in this step is caused by a bug in makelist.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+time_i:data2_i:makelist(i,i,-10,10,.05)$
+values2_i:makelist(subst(x=i,data2_cont),i,time_i)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Now we generate a matrix of values lsquares can deal with:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+data2_i:float(transpose(matrix(time_i,values2_i)))$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+The result is a still noisy and distorted, but more evenly-spaced curve:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw2d(
+    points(data2_i),
+    grid=true,xlabel="x",ylabel="y"
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Fitting this curve will yield a better result as the first attempt:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lsquares_estimates_approximate(
+    lsquares_mse(
+        data2_i,[x,y],approach1
+    ),
+    [a,b,c]
+);
+params2_2:%[1];
+wxdraw2d(
+    grid=true,xlabel="x",ylabel="y",
+    color=red,key="Reconstructed",
+    explicit(rhs(subst(params2_2,approach1)),x,-10,10),
+    color=blue,key="Original",
+    explicit(fun1,x,-10,10)
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Fitting data to a·exp(k·t)
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+The natural approach to fitting data to exponential curves would be:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+approach2:y=a*exp(k*t);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Unfortunately it is hard to fit to experimental data to this approach in many ways, for example:
+ * One part of this curve results in low values. Even small measurement noise on this part will yield widely incorrect results for the curve parameters as the fitter is trying to model the noise, too, and as noise in nonlinear systems tends not to be averanged out completely.
+ * Another part of this curve contains quite in high values and is sensitive to even small changes in k. As the fitter wants to keep the overall error low it will therefore respect this part much more than the lower, more good-natured part of the curve.
+ * Starting from the wrong point and optimizing a and k in the direction that reduces the error most in each step might lead to a point that is far from being the solution
+ * and trying to use lsquares_estimates to find the ideal solution often leads to numbers that exceed the floating-point range (or exact numbers longer than the computer's memory).
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+A better approach is therefore to use Caruana's approach for fitting:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+approach2/a;
+caruana:log(%);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+This approach is much more good-natured for finding the parameters (that can then be substituted into approach2).
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+The problem with noise causing finding erroneous parameters is still valid, though, in this case.  It can be partially eliminated by introducing a c_noise, as proposed by Guo.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(approach2)=rhs(approach2+c_noise);
+%-c_noise;
+%/a;
+approach_guo:log(%),logexpand=super;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Additionally https://ieeexplore.ieee.org/document/5999593 offers an iterative method that allows to reduce the influence of noise in each step:
+   [wxMaxima: comment end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 20.01.2-DevelopmentSnapshot"$

--- a/samples/Maxima-session/numberFormats.wxm
+++ b/samples/Maxima-session/numberFormats.wxm
@@ -1,0 +1,177 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 20.01.1 ] */
+/* [wxMaxima: title   start ]
+Number formats
+   [wxMaxima: title   end   ] */
+
+
+/* [wxMaxima: section start ]
+Floating-point numbers
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Most computers include floating-point units that make relatively-high-precision calculations very fast. If a number is input with a decimal dot or in the "1e3" notation maxima assumes one wants to use the kind of floats the machine supports out-of-the box:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+1.0;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+1000121012.10;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+1e9;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Any other number can be converted to a floating-point one using the float() keyword:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+float(10);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+float(10/3);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+The drawback the enhanced speed comes with is that using floating-point numbers come with inaccuracies that might hit when one least expects them. For example machine floats cannot exactly express seemingly simple numbers like 0.1:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+rationalize(0.1);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Another drawback is that mathematics is based on the fact that two things that cancel each other out actually do so:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+0.1+0.01-0.1-0.01;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Rump and Wilkinson have provided warning examples of simple polynoms where this adds up to catastrophic errors quickly and it is surprising how often one encounters similar in real live including a big fraction of the glitches one can find in computer games.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+Maxima allows to customize the format floating-point numbers are displayed in:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("engineering-format")$
+engineering_format_floats: true$
+engineering_format_min: .01$
+engineering_format_max: 1000$
+fpprintprec: 6$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+0.1+0.01-0.1-0.01;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+float(π);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+float(π*10000);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Bigfloats
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Maxima alternatively provides its own implementation of floating-point numbers that are slow (they have to be processed in software), but can be provided with any precision. Numbers can be converted to bifgfloats using the bfloat() command or by entering a "b" instead of an "e" when declaring the exponent:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+fpprintprec:0$
+fpprec:100$
+bfloat(%pi);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+rationalize(1b-1);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+If too low or to high a number of digits is displayed here when right-clicking on such a number opens up a menu that allows to customize this behavior.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+Exact numbers
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+The type of number maxima was written for is exact numbers instead. Maxima assumes any number that doesn't contain a decimal dot to be intended as being an exact number:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+1/10;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+π/4*3;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+sqrt(2)/2;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+exp(21/7);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+R_100=121*10^3;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Many hard-to-find errors can be avoided by using exact numbers. It is therefore wise to use exact numbers wherever possible and only to convert the results to floats using float() or bfloat():
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+sqrt(π)*3;
+float(%);
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 20.01.1"$

--- a/samples/Maxima-session/solvingEquations.wxm
+++ b/samples/Maxima-session/solvingEquations.wxm
@@ -1,0 +1,293 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 20.01.2-DevelopmentSnapshot ] */
+/* [wxMaxima: title   start ]
+Solving equations
+   [wxMaxima: title   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Mathematics can be seen as a language consisting only of a rather small set of words and only a handful of grammatical rules. Both sets are carefully chosen, though, that by simply reformulating the question in many cases the answer can be found.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+If you are studying mathematics the good news is that solving equations is an art a computer can help with in many special cases but that often relies on human creativity for finding algorithms and ways.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+Simple equations
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+For many problems Maxima's solve() program instantly finds a list of solutions:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+pyth:c^2=a^2+b^2;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+sol1:solve(pyth,a);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Both solutions solve() offers are valid. We can pick any of them manually, for example:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+sol2:sol1[2];
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+By having given this equation a name ("sol2") we gained a way to re-use this equation later.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+This time the type of solutions we can get depends on the value of a which is why maxima asked about it. One can avoid asking questions by telling the answers to maxima's assume database:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+assume(a>0, b>0, c>0);
+solve(sol2,b);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Solve also accepts lists as its arguments. In this case it will only find solutions if the following conditions are all met:
+ * The number of linearly independent equations matches the number of variables to solve to
+ * The solution doesn't completely change its form depending on the range one variable is in.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+eq2:a+2*b=10;
+solve(
+    [pyth,eq2],
+    [a,b]
+);
+rootscontract(%);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+By choosing [a,b] as the list of solution variables maxima is automatically told to eliminate these two variables on the right side of the equations, if possible.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+Re-using the solutions
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+As seen above the last equation displayed by maxima can be referenced by using the placeholder "%":
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+%;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Additionally have given nearly all equations names that allow to reference the whenever we need them. For example we can print them out again:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+sol2;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+We can use them as an input to solve:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+solve(sol2,b);
+/* [wxMaxima: input   end   ] */
+/* [wxMaxima: question  start ] */
+<mth><st>Is </st><mi>a</mi><st> positive, negative or zero?</st></mth>
+/* [wxMaxima: question  end   ] */
+/* [wxMaxima: answer  start ] */
+p;
+/* [wxMaxima: answer  end   ] */
+
+
+/* [wxMaxima: comment start ]
+We can introduce ("substitute") them into other equations:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+E=m*c^2;
+subst(pyth,%);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Additionally the left hand side and the right hand side can be extracted using the command lhs() and rhs() which allows to use the part left or right to to the "=" in a new equation:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(pyth);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+rhs(pyth);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+eq10:sin(δ)=rhs(pyth);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Boiling it down to numbers
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+If in mathematics two things cancel each other out they do so exactly. The same isn't true with IEEE floating-point numbers like the ones the computer uses:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+.1;
+%-.01;
+%-.1;
+%+.01;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Many computer programs are configured to show small numbers as "0" or only to show the first few digits after the decimal dot hoping that the rest is a rounding error that doesn't add up (see wilkinson's polynomial for an example where this happens quickly). Maxima's solve instead tries to replace floating-point numbers by the exact fraction it most likely means and warns about doing so:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+solve(x+.1=2,x);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Since it often is the general case that allows to learn about the fundamental mechanisms often a good approach is to solve everything symbolically and to keep the actual numerical input values in a separate list like the following one:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+vals:[
+    a=sqrt(1/2),
+    b=sqrt(1/2),
+    δ=π/2
+];
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Whenever a numerical value is needed this list can be introduced into any equation:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+subst(vals,pyth);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+subst(vals,eq10);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+What if there exists no symbolical solution?
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Some solutions have never been assigned a name in mathematics. One popular example would be:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+eq2:cos(x)=x;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+solve() which tries to find an symbolical solution is bound to fail here and tells us how far it got:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+solve(eq2,x);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+In this case maxima offers several options to at least find the numerical values, two examples are given below:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw2d(
+    explicit(
+        rhs(eq2)-lhs(eq2),
+        x,-1,1
+    ),
+    grid=true
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+mnewton
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+mnewton uses a modified version of newton's method for finding a solution of a nonlinear, but differentiable, stetical and monotonic function near to a point (in this example 0.1)
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("mnewton")$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+mnewton(eq2,x,.1);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+find_root
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+find_root even works if the equation isn't differentiable and searches for a solution in between two points.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+find_root(eq2,x,-.001,1);
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 20.01.2-DevelopmentSnapshot"$

--- a/samples/Maxima-session/toleranceCalculations.wxm
+++ b/samples/Maxima-session/toleranceCalculations.wxm
@@ -1,0 +1,376 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 20.01.2-DevelopmentSnapshot ] */
+/* [wxMaxima: title   start ]
+Tolerance calculations
+   [wxMaxima: title   end   ] */
+
+
+/* [wxMaxima: comment start ]
+If the outcome of an calculation depends on many factors determining manually which cases are the worst-case one is a manual and error-prone process. Alternatives to doing so are:
+ * Implementing a full-fledged interval arithmetics that automatically determines the range of the output depending on the ranges of the input parameters. Unfortunately doing so is so complex that any interval arithmetics is bound to work only in more or less trivial cases.
+ * Calculating the derivation of the result over the tolerance of each parameter hoping these derivations point to a global maximum, not only to a local one.
+ * A montecarlo analysis: All parameters are filled with random values out of their tolerance range. Then the calculation is repeated until the spread of the outcome can be seen.
+ * Or systematically trying out all combinations at the edges of the n-dimensional tolerance space. 
+The last two of these methods are described here.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+The problem
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+A simple voltage divider of R_1 and R_2 is powered by a voltage source U_In. In which range can U_Out lie?
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Mathematical description
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: input   start ] */
+eq1: I=U_In/(R_1+R_2);
+eq2: U_Out=I*R_2;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+These equations are simple enough that there is no need to use solve() to introduce them into each other:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+uout:subst(eq1,eq2);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Input values that include a tolerance
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+First we load the tolerance calculation package:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("wrstcse")$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+The tolerance calculation package lets tol[n] tolerate between -1 and 1. tol[n] with the same n are coupled tolerances that share the same value. In theory the "n" doesn't need to be a number. But if it is a symbolic name one has to make sure this name is never assigned a value else tol[name] will be replaced by tol[<value of the variable "name">]
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+Let's assume that R_1 is a 100Ω with 10% tolerance. R_2 is a 1000Ω resistor with 1% tolerance instead:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+vals1:[
+    R_1=100*(1+.1*tol[1]),
+    R_2=1000*(1+.01*tol[2])
+];
+wc_inputvalueranges(%);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+We can propose another set of values: Two resistors that are only 10% ones, but are guaranteed to always deviate into the same direction by the same percentage.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+vals2:[
+    R_1=100*(1+.1*tol[1]),
+    R_2=1000*(1+.1*tol[1])
+];
+wc_inputvalueranges(%);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Print out the results
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+Just substituting the values into the equations provides us with the equation containing the real values and the tolerances in wrstcse's notation:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+subst(vals1,uout);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+If we just want to know the typical value we can do the following:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wc_typicalvalues(subst(vals1,uout));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wc_typicalvalues(subst(vals2,uout));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+We now want to test all combinations of minimum, typical or maximum value, instead.
+First we tell maxima not to print a warning if a float is replaced by a fraction of the same value:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+ratprint:false;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Then we ask wrstcse to print out the tolerances of the right hand side of our equation "uout":
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(uout)=wc_mintypmax(subst(vals1,rhs(uout)));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+This result is still - well, hard to interpret, because Maxima didn't know the value of U_In which is necessary to decide which of all the terms is the minimum and which is the maximum. But we can inform maxima about the necessary facts:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+assume(U_In>0);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(uout)=wc_mintypmax(subst(vals1,rhs(uout)));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(uout)=wc_mintypmax(subst(vals2,rhs(uout)));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+As we have guessed the 2nd voltage divider was the better one.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+Specifying complex tolerances
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+Now we want to tell maxima that the voltage source provides a voltage between 4V and 6V, typically 4.5V. For doing this a specialized function exists:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+vals3:[
+    R_1=100*(1+.1*tol[1]),
+    R_2=1000*(1+.1*tol[1]),
+    U_In=wc_mintypmax2tol(tol[3],4,4.5,6)    
+];
+wc_inputvalueranges(%);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(uout)=wc_mintypmax(subst(vals3,rhs(uout)));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Appending lists of tolerances
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+If it is necessary to append two lists of values with tolerances to each other without risking a collision of tol[n] that happen to have the same n in the two lists the following function can be used:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+vals4:[
+    U_In=wc_mintypmax2tol(tol[1],4,4.5,6)    
+];
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+vals5:wc_tolappend(vals1,vals4);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+wc_tolappend() appends values with tolerances and renumbers the tol[n]
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: section start ]
+Using a bigger or lower number of samples
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+By default the wrstcse package tests all combinations of 3 values per tol[n]: The minimum, the maximum and the typical value. If we only want to test 2 values (the minimum and the maximum) that might speed up lengthy calculations with many values that contain tolerances:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(uout)=wc_mintypmax(subst(vals5,rhs(uout)),2);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+Monte carlo analysis
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: comment start ]
+This time we want the tolerance package to use 1000 random sets of values and to find the best and worst case that can be reached using these values:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(uout)=wc_mintypmax(subst(vals5,rhs(uout)),-1000);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+If this calculation is repeated it will naturally result in slightly different numeric values:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lhs(uout)=wc_mintypmax(subst(vals5,rhs(uout)),-1000);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: section start ]
+A ridicously advanced example
+   [wxMaxima: section end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Description of the problem
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: comment start ]
+Someone constructs a magic drill that is guaranteed to generate holes that exactly meet 3 points. But that points unfortunately all have tolerances. We now are asked to produce images of the possible outcome.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+Round holes can be described as follows:
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+hole1:(x-x_1)^2+(y-y_1)^2=r^2;
+hole2:(x-x_2)^2+(y-y_2)^2=r^2;
+hole3:(x-x_3)^2+(y-y_3)^2=r^2;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+solve([hole1,hole2,hole3],[x,y,r])$
+sol1:%[2];
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+The coordinates of the points the holes touch
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: input   start ] */
+coords:[
+    x_1=0+.04*tol[x1],y_1=0+.04*tol[y1],
+    x_2=1+.04*tol[x2],y_2=0+.04*tol[y2],
+    x_3=0+.04*tol[x3],y_3=1+.04*tol[y3]
+];
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Generating a list of 100 sets of possible values of "coords"
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: input   start ] */
+lstOfCoords:wc_montecarlo(coords,100)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: subsect start ]
+Plotting these lists
+   [wxMaxima: subsect end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxanimate_autoplay:true$
+wxanimate_framerate:5$
+with_slider_draw2d(
+    i,lstOfCoords,
+    point_type=2,grid=true,
+    proportional_axes='xy,
+    subst(
+        i,
+        [
+            key="The 3 coordinates",
+            points([x_1,x_2,x_3],[y_1,y_2,y_3]),
+            key="",fill_color="#000000FF",
+            subst(
+                sol1,
+                ellipse(x,y,r,r,0,360)
+            )
+        ]
+    ),
+    xrange=[-.55,1.55],
+    yrange=[-.55,1.55]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+wxdraw2d(
+    point_type=2,grid=true,
+    proportional_axes='xy,
+    makelist(
+        subst(
+            i,
+            [
+                points([x_1,x_2,x_3],[y_1,y_2,y_3]),
+                key="",fill_color="#000000FF",
+                subst(
+                    sol1,
+                    ellipse(x,y,r,r,0,360)
+                )
+            ]
+        ),i,lstOfCoords),
+    xrange=[-.55,1.55],
+    yrange=[-.55,1.55]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 20.01.2-DevelopmentSnapshot"$


### PR DESCRIPTION
Maxima is a full-fledged computer algebra system that can be found at https://maxima.sourceforge.net and is a full-fledged programming language, as well.

Traditionally maxima uses .mac files. .wxm files are ordinary .mac file with comments that contain enough information that the GUI wxMaxima will be able to reconstruct an entire worksheet from them. Surprisingly to me there are 3422 search results for github for .wxm:

 * https://github.com/search?q=extension%3Awxm+maxima&type=Code
 * https://github.com/search?q=extension%3Amac+maxima&type=Code

The samples have been written by myself. They come with wxMaxima and there are GPL2+. But if you want to use them under a MIT license feel free to do so; Maxima is a very old program (a few years ago a bug in the source function has been resolved that was introduced in 1963(!)) and some of lisp has been developed specifically for maxima. Maxima has been released to open source only about a decade ago, though and has been adopted by many schools, universities, firms and private users since then.

About adding grammars I haven't found enough documentation to be able to do so, unfortunately.