### PR TITLE
Accept and encourage "minus-prefix" for unset gitattributes as per gitattributes documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Use the `linguist-vendored` attribute to vendor or un-vendor paths:
 
 ```gitattributes
 special-vendored-path/* linguist-vendored
-jquery.js linguist-vendored=false
+jquery.js -linguist-vendored
 ```
 
 #### Documentation
@@ -205,7 +205,7 @@ Use the `linguist-documentation` attribute to mark or unmark paths as documentat
 
 ```gitattributes
 project-docs/* linguist-documentation
-docs/formatter.rb linguist-documentation=false
+docs/formatter.rb -linguist-documentation
 ```
 
 #### Generated code
@@ -218,7 +218,7 @@ As an added bonus, unlike vendored and documentation files, these files are supp
 Use the `linguist-generated` attribute to mark or unmark paths as generated.
 
 ```gitattributes
-Api.elm linguist-generated=true
+Api.elm linguist-generated
 ```
 
 #### Detectable
@@ -229,9 +229,9 @@ Languages of a different type (as defined in [`languages.yml`](/lib/linguist/lan
 Use the `linguist-detectable` attribute to mark or unmark paths as detectable:
 
 ```gitattributes
-*.kicad_pcb linguist-detectable=true
-*.sch linguist-detectable=true
-tools/export_bom.py linguist-detectable=false
+*.kicad_pcb linguist-detectable
+*.sch linguist-detectable
+tools/export_bom.py -linguist-detectable
 ```
 
 ### Using Emacs or Vim modelines

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -38,24 +38,24 @@ module Linguist
     end
 
     def documentation?
-      if attr = git_attributes['linguist-documentation']
-        boolean_attribute(attr)
+      unless git_attributes['linguist-documentation'].nil?
+        boolean_attribute(git_attributes['linguist-documentation'])
       else
         super
       end
     end
 
     def generated?
-      if attr = git_attributes['linguist-generated']
-        boolean_attribute(attr)
+      unless git_attributes['linguist-generated'].nil?
+        boolean_attribute(git_attributes['linguist-generated'])
       else
         super
       end
     end
 
     def vendored?
-      if attr = git_attributes['linguist-vendored']
-        return boolean_attribute(attr)
+      unless git_attributes['linguist-vendored'].nil?
+        boolean_attribute(git_attributes['linguist-vendored'])
       else
         super
       end
@@ -72,8 +72,8 @@ module Linguist
     end
 
     def detectable?
-      if attr = git_attributes['linguist-detectable']
-        return boolean_attribute(attr)
+      unless git_attributes['linguist-detectable'].nil?
+        boolean_attribute(git_attributes['linguist-detectable'])
       else
         nil
       end
@@ -100,9 +100,9 @@ module Linguist
 
     protected
 
-    # Returns true if the attribute is present and not the string "false".
+    # Returns true if the attribute is present and not the string "false" or the false boolean.
     def boolean_attribute(attribute)
-      attribute != "false"
+      attribute != "false" && attribute != false
     end
 
     def load_blob!

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -38,7 +38,7 @@ module Linguist
     end
 
     def documentation?
-      unless git_attributes['linguist-documentation'].nil?
+      if not git_attributes['linguist-documentation'].nil?
         boolean_attribute(git_attributes['linguist-documentation'])
       else
         super
@@ -46,7 +46,7 @@ module Linguist
     end
 
     def generated?
-      unless git_attributes['linguist-generated'].nil?
+      if not git_attributes['linguist-generated'].nil?
         boolean_attribute(git_attributes['linguist-generated'])
       else
         super
@@ -54,7 +54,7 @@ module Linguist
     end
 
     def vendored?
-      unless git_attributes['linguist-vendored'].nil?
+      if not git_attributes['linguist-vendored'].nil?
         boolean_attribute(git_attributes['linguist-vendored'])
       else
         super
@@ -72,7 +72,7 @@ module Linguist
     end
 
     def detectable?
-      unless git_attributes['linguist-detectable'].nil?
+      if not git_attributes['linguist-detectable'].nil?
         boolean_attribute(git_attributes['linguist-detectable'])
       else
         nil

--- a/lib/linguist/lazy_blob.rb
+++ b/lib/linguist/lazy_blob.rb
@@ -100,7 +100,7 @@ module Linguist
 
     protected
 
-    # Returns true if the attribute is present and not the string "false" or the false boolean.
+    # Returns true if the attribute is present and not the string "false" and not the false boolean.
     def boolean_attribute(attribute)
       attribute != "false" && attribute != false
     end

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -55,6 +55,14 @@ class TestRepository < Minitest::Test
     # test/*.rb linguist-language=Java
     # Rakefile linguist-generated
     # test/fixtures/* linguist-vendored=false
+    # README.md linguist-documentation=false
+    # samples/Arduino/* linguist-documentation
+    # samples/Markdown/*.md linguist-detectable=true
+    # samples/HTML/*.html linguist-detectable=false
+    # samples/CSS/bootstrap.css -linguist-vendored
+    # samples/CSS/bootstrap.min.css -linguist-generated
+    # LICENSE -linguist-documentation
+    # samples/CoffeeScript/browser.coffee -linguist-detectable
 
     attr_commit = 'c20ebee0ebf33f73313d4694680521f80635d477'
     repo = linguist_repo(attr_commit)
@@ -96,47 +104,58 @@ class TestRepository < Minitest::Test
   end
 
   def test_linguist_override_unvendored?
-    attr_commit = 'c20ebee0ebf33f73313d4694680521f80635d477'
+    attr_commit = '933c687cb8c02035394979b2308e5120a9904fdf'
     linguist_repo(attr_commit).read_index
 
     # lib/linguist/vendor.yml defines this as vendored.
     override_unvendored = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'test/fixtures/foo.rb')
+    # test -linguist-vendored attribute method
+    override_unvendored_minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'samples/CSS/bootstrap.css')
 
     # overridden .gitattributes
-    assert !override_unvendored.vendored?
+    refute override_unvendored.vendored?
+    refute override_unvendored_minus.vendored?
   end
 
   def test_linguist_override_documentation?
-    attr_commit = "d4c8fb8a28e91f97a7e53428a365c0abbac36d3d"
+    attr_commit = "933c687cb8c02035394979b2308e5120a9904fdf"
     linguist_repo(attr_commit).read_index
 
     readme = Linguist::LazyBlob.new(rugged_repository, attr_commit, "README.md")
     arduino = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/Arduino/hello.ino")
+    # test -linguist-documentation attribute method
+    minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, "LICENSE")
 
     # overridden by .gitattributes
     refute_predicate readme, :documentation?
     assert_predicate arduino, :documentation?
+    refute_predicate minus, :documentation?
   end
 
   def test_linguist_override_generated?
-    attr_commit = "c20ebee0ebf33f73313d4694680521f80635d477"
+    attr_commit = "933c687cb8c02035394979b2308e5120a9904fdf"
     linguist_repo(attr_commit).read_index
 
     rakefile = Linguist::LazyBlob.new(rugged_repository, attr_commit, "Rakefile")
-
+    # test  -linguist-generated attribute method
+    minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/CSS/bootstrap.min.css")
     # overridden .gitattributes
     assert rakefile.generated?
+    refute minus.generated?
   end
 
   def test_linguist_override_detectable?
-    attr_commit = "8f86998866f6f2c8aa14e0dd430e61fd25cff720"
+    attr_commit = "933c687cb8c02035394979b2308e5120a9904fdf"
     linguist_repo(attr_commit).read_index
 
     # markdown is overridden by .gitattributes to be detectable, html to not be detectable
     markdown = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/Markdown/tender.md")
     html = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/HTML/pages.html")
+    # test  -linguist-detectable attribute method
+    minus = Linguist::LazyBlob.new(rugged_repository, attr_commit, "samples/CoffeeScript/browser.coffee")
 
     assert_predicate markdown, :detectable?
     refute_predicate html, :detectable?
+    refute_predicate minus, :detectable?
   end
 end


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

@cespare rightly pointed out in https://github.com/github/linguist/pull/4624 that we're being "special" by requiring people to use the `false` string to negate or unset a behaviour via `.gitattributes` and really should accept and encourage the "minus-prefixed" `-linguist-whatever` method for unsetting/negating.

As per the [gitattributes documentation](https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Unset):

> Unset
>
>    The path has the attribute with special value "false"; this is specified by listing the name of the attribute prefixed with a dash - in the attribute list.

@cespare got the ball rolling with updating the documentation and I've now implemented the necessary code changes in this PR for the negation to work. This covers both the gitattributes documented behaviour and our old `=false` behaviour so we don't catch anyone by surprise.

The setting/enabling part already works so no changes on that side.

This PR needs the changes in https://github.com/github/linguist/pull/4779.

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
