### PR TITLE
Add 2 more JavaScript interpreters

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2507,9 +2507,13 @@ JavaScript:
   interpreters:
   - chakra
   - d8
+  - gjs
   - js
+  - mujs
   - node
+  - qjs
   - rhino
+  - slimerjs
   - v8
   - v8-shell
   language_id: 183

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2509,11 +2509,9 @@ JavaScript:
   - d8
   - gjs
   - js
-  - mujs
   - node
   - qjs
   - rhino
-  - slimerjs
   - v8
   - v8-shell
   language_id: 183


### PR DESCRIPTION
This PR registers ~~4~~ 2 more JavaScript interpreters:

- [Gnome JS](https://gitlab.gnome.org/GNOME/gjs/wikis/Home): `gjs`
- ~~[MuJS](https://www.mujs.com/): `mujs`~~ <sup>[[1]](#1)</sup>
- ~~[QuickJS](https://bellard.org/quickjs/): `qjs`~~ <sup>[[1]](#1)</sup>
- [SlimerJS](https://slimerjs.org/): `slimerjs`

*Template removed as it doesn't really apply.*

-------
<a name="1"><sup>[1]</sup></a> Removed after <a href="https://github.com/github/linguist/pull/4783#pullrequestreview-348321932">discussion</a> with @pchaigno