### PR TITLE
Add Yarn releases to vendored list

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -41,6 +41,9 @@
 # Node dependencies
 - node_modules/
 
+# Yarn releases
+- .yarn/releases
+
 # esy.sh dependencies
 - (^|/)_esy$
 

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -42,7 +42,7 @@
 - node_modules/
 
 # Yarn releases
-- .yarn/releases
+- (^|/)\.yarn/releases/
 
 # esy.sh dependencies
 - (^|/)_esy$


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

Yarn 1 and 2 allow developers to check in a specific version of Yarn for their project ([`yarn policies set-version`](https://legacy.yarnpkg.com/en/docs/cli/policies) in v1 and [`yarn set version`](https://yarnpkg.com/cli/set/version) in v2). This ensures all developers use the same version of Yarn when working on the project. This adds ~147k lines of JavaScript to the project, skewing the project's language stats. 

This change ensures the generated files stored under `.yarn/releases` are vendored from Linguist's perspective.

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.