### PR TITLE
Update SHA used for repo tests

### DIFF
--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -104,7 +104,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_linguist_override_unvendored?
-    attr_commit = '933c687cb8c02035394979b2308e5120a9904fdf'
+    attr_commit = '01d6b9c637a7a6581fe456c600725b68f355b295'
     linguist_repo(attr_commit).read_index
 
     # lib/linguist/vendor.yml defines this as vendored.
@@ -118,7 +118,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_linguist_override_documentation?
-    attr_commit = "933c687cb8c02035394979b2308e5120a9904fdf"
+    attr_commit = "01d6b9c637a7a6581fe456c600725b68f355b295"
     linguist_repo(attr_commit).read_index
 
     readme = Linguist::LazyBlob.new(rugged_repository, attr_commit, "README.md")
@@ -133,7 +133,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_linguist_override_generated?
-    attr_commit = "933c687cb8c02035394979b2308e5120a9904fdf"
+    attr_commit = "01d6b9c637a7a6581fe456c600725b68f355b295"
     linguist_repo(attr_commit).read_index
 
     rakefile = Linguist::LazyBlob.new(rugged_repository, attr_commit, "Rakefile")
@@ -145,7 +145,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_linguist_override_detectable?
-    attr_commit = "933c687cb8c02035394979b2308e5120a9904fdf"
+    attr_commit = "01d6b9c637a7a6581fe456c600725b68f355b295"
     linguist_repo(attr_commit).read_index
 
     # markdown is overridden by .gitattributes to be detectable, html to not be detectable


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

When I merged https://github.com/github/linguist/pull/4780 I used a squash commit 🤦‍♂ which meant it stomped all over the `933c687cb8c02035394979b2308e5120a9904fdf` SHA I set for the tests.

This PR updates the SHA in the tests to use the squash commit's SHA. 

You can see the new SHA changes at https://github.com/github/linguist/commit/01d6b9c637a7a6581fe456c600725b68f355b295