### PR TITLE
Enable soft-wrapping in Roff documents

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4321,6 +4321,7 @@ RUNOFF:
   extensions:
   - ".rnh"
   - ".rno"
+  wrap: true
   tm_scope: text.runoff
   ace_mode: text
   language_id: 315
@@ -4554,6 +4555,7 @@ Roff:
   - mdoc
   - nroff
   - troff
+  wrap: true
   ace_mode: text
   codemirror_mode: troff
   codemirror_mime_type: text/troff
@@ -4582,6 +4584,7 @@ Roff Manpage:
   - ".9"
   - ".man"
   - ".mdoc"
+  wrap: true
   tm_scope: text.roff
   ace_mode: text
   codemirror_mode: troff


### PR DESCRIPTION
## Description
This commit enables soft-wrapping in Roff documents by default. Although it's considered best-practice to start each sentence on a new line, many man-pages don't respect this, especially those which are generated from another format.

*Template removed as it doesn't apply.*