### PR TITLE
Register `.luacheckrc` as a Lua filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2904,6 +2904,8 @@ Lua:
   - ".rbxs"
   - ".rockspec"
   - ".wlua"
+  filenames:
+  - ".luacheckrc"
   interpreters:
   - lua
   language_id: 213

--- a/samples/Lua/filenames/.luacheckrc
+++ b/samples/Lua/filenames/.luacheckrc
@@ -1,0 +1,113 @@
+-- Disable unused self warnings.
+self = false;
+
+-- Allow unused arguments.
+unused_args = false;
+
+-- Limit line length to 78 characters.
+max_line_length = 78;
+max_code_line_length = 78;
+max_string_line_length = 78;
+max_comment_line_length = 78;
+
+-- Ignore generated files.
+exclude_files = {
+	".release",
+	"Exporter/casc",
+	"Exporter/Config",
+	"Exporter/Data",
+	"Exporter/Templates",
+	"LibRPMedia-*-1.0.lua",
+	"Libs",
+};
+
+-- The following globals are only read/written in non-packaged releases.
+globals = {
+	"LibRPMedia_BrowserMixin",
+	"LibRPMedia_BrowserTabMixin",
+	"LibRPMedia_IconBrowserMixin",
+	"LibRPMedia_IconContentMixin",
+	"LibRPMedia_IconPreviewMixin",
+	"LibRPMedia_MusicBrowserMixin",
+	"LibRPMedia_MusicColumnDisplayMixin",
+	"LibRPMedia_MusicItemRowMixin",
+	"LibRPMedia_MusicScrollMixin",
+	"LibRPMedia_PaginationBarMixin",
+	"LibRPMedia_SearchOptionsDropDownMixin",
+	"SLASH_LIBRPMEDIA_SLASHCMD1",
+	"SlashCmdList",
+	"UIPanelWindows",
+};
+
+read_globals = {
+	"LibRPMedia_BrowserFrame",
+};
+
+-- Add exceptions for external libraries.
+std = "lua51+libstub+wow+wowstd"
+
+stds.libstub = {
+	read_globals = {
+		"LibStub",
+	},
+};
+
+stds.wow = {
+	read_globals = {
+		"CallbackRegistryBaseMixin",
+		"CallErrorHandler",
+		"Clamp",
+		"ColumnDisplayMixin",
+		"CreateFramePool",
+		"CreateFromMixins",
+		"debugprofilestop",
+		"debugstack",
+		"FauxScrollFrame_GetOffset",
+		"FauxScrollFrame_OnVerticalScroll",
+		"FauxScrollFrame_SetOffset",
+		"FauxScrollFrame_Update",
+		"GameTooltip_AddInstructionLine",
+		"GameTooltip_AddNormalLine",
+		"GameTooltip_SetTitle",
+		"GameTooltip",
+		"GetMouseFocus",
+		"GREEN_FONT_COLOR",
+		"HideUIPanel",
+		"Mixin",
+		"PanelTemplates_ResizeTabsToFit",
+		"PanelTemplates_SetNumTabs",
+		"PanelTemplates_SetTab",
+		"PlayMusic",
+		"PlaySound",
+		"SecondsToTime",
+		"SetPortraitToTexture",
+		"ShowUIPanel",
+		"SOUNDKIT",
+		"StopMusic",
+		"tostringall",
+		"UIDropDownMenu_AddButton",
+		"UIDropDownMenu_CreateInfo",
+		"UIDropDownMenu_Initialize",
+		"UIParent",
+		"WOW_PROJECT_CLASSIC",
+		"WOW_PROJECT_ID",
+		"WOW_PROJECT_MAINLINE",
+		"WrapTextInColorCode",
+	},
+};
+
+stds.wowstd = {
+	read_globals = {
+		string = {
+			fields = {
+				"join",
+				"split",
+			},
+		},
+		table = {
+			fields = {
+				"wipe",
+			},
+		},
+	},
+};


### PR DESCRIPTION
## Description
This PR adds support for [`.luacheckrc`](https://luacheck.readthedocs.io/) files.

## Checklist:
- [x] **I am associating a language with a new filename.**
	- [x] **The new filename is used in hundreds of repositories:**
		- Total results: [2,502](https://github.com/search?q=filename%3Aluacheckrc+NOT+nothack&type=Code) ([2,156](https://github.com/Alhadis/Silos/blob/b9874b160c2ab3b9e810aa186685c08af149da88/urls.log) sampled)
		- Repositories: [1,801](https://github.com/Alhadis/Silos/blob/b9874b160c2ab3b9e810aa186685c08af149da88/repos.log)
		- Users: [1,039](https://github.com/Alhadis/Silos/blob/b9874b160c2ab3b9e810aa186685c08af149da88/users.log)
	- [x] **I have included a real-world usage sample:**
		- Source: [`wow-rp-addons/LibRPMedia`](https://github.com/wow-rp-addons/LibRPMedia/blob/9d37904836d8bab383c491e9a09cf100a70204d0/.luacheckrc)
		- License: [Public Domain](https://github.com/wow-rp-addons/LibRPMedia/blob/1a1e5519b3a11b3fd8d507ee3a764033d118c0ea/LICENSE)
