### PR TITLE
Make shebang detection cheaper

### DIFF
--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -24,7 +24,7 @@ module Linguist
     # Returns a String or nil
     def self.interpreter(data)
       # First line must start with #!
-      return unless data.b.match?(/\A#!/n)
+      return unless data.b.start_with?("#!")
 
       shebang = data[/\A[^#{$/}]*#{$/}/].chomp
 

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -23,10 +23,10 @@ module Linguist
     #
     # Returns a String or nil
     def self.interpreter(data)
-      shebang = data.lines.first
-
       # First line must start with #!
-      return unless shebang && shebang.start_with?("#!")
+      return unless data.b.match?(/\A#!/n)
+
+      shebang = data[/\A[^#{$/}]*#{$/}/].chomp
 
       s = StringScanner.new(shebang)
 

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Linguist
   class Shebang
     # Public: Use shebang to detect language of the blob.
@@ -24,7 +26,7 @@ module Linguist
     # Returns a String or nil
     def self.interpreter(data)
       # First line must start with #!
-      return unless data.b.start_with?("#!")
+      return unless data.start_with?("#!")
 
       shebang = data[0, data.index($/) || data.length]
 

--- a/lib/linguist/shebang.rb
+++ b/lib/linguist/shebang.rb
@@ -26,7 +26,7 @@ module Linguist
       # First line must start with #!
       return unless data.b.start_with?("#!")
 
-      shebang = data[/\A[^#{$/}]*#{$/}/].chomp
+      shebang = data[0, data.index($/) || data.length]
 
       s = StringScanner.new(shebang)
 


### PR DESCRIPTION
String#lines can potentially allocate *many* strings depending on the
number of newlines in the string.  That might be OK if the file we're
looking at is actually a file with a shebang in it (because we might
eventually use every line).  But it is not OK when the file isn't a
shebang file because we end up allocating many objects for no reason.

This commit reduces the number of allocations it takes to determine
whether or not the string is interesting to the Shebang class.

Here is a benchmark:

```ruby
require "linguist/shebang"

def allocs
  x = GC.stat(:total_allocated_objects)
  yield
  GC.stat(:total_allocated_objects) - x
end

file = "foo\n" * 1000

p allocs {
  Linguist::Shebang.interpreter(file)
}
```

Before this commit:

```
$ bundle _1.17.2_ exec ruby -I lib:test thing.rb
1003
```

After this commit:

```
$ bundle _1.17.2_ exec ruby -I lib:test thing.rb
2
```