### PR TITLE
Reconfigure Dart away from stale grammer repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -332,9 +332,9 @@
 [submodule "vendor/grammars/d.tmbundle"]
 	path = vendor/grammars/d.tmbundle
 	url = https://github.com/textmate/d.tmbundle
-[submodule "vendor/grammars/dartlang"]
-	path = vendor/grammars/dartlang
-	url = https://github.com/dart-atom/dartlang
+[submodule "vendor/grammars/dart-syntax-highlight"]
+	path = vendor/grammars/dart-syntax-highlight
+	url = https://github.com/dart-lang/dart-syntax-highlight
 [submodule "vendor/grammars/data-weave-tmLanguage"]
 	path = vendor/grammars/data-weave-tmLanguage
 	url = https://github.com/mulesoft-labs/data-weave-tmLanguage

--- a/grammars.yml
+++ b/grammars.yml
@@ -275,9 +275,8 @@ vendor/grammars/cython:
 - source.cython
 vendor/grammars/d.tmbundle:
 - source.d
-vendor/grammars/dartlang:
+vendor/grammars/dart-syntax-highlight:
 - source.dart
-- source.yaml-ext
 vendor/grammars/data-weave-tmLanguage:
 - source.data-weave
 vendor/grammars/desktop.tmbundle:

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -95,7 +95,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **DM:** [PJB3005/atomic-dreams](https://github.com/PJB3005/atomic-dreams)
 - **DNS Zone:** [sixty4k/st2-zonefile](https://github.com/sixty4k/st2-zonefile)
 - **DTrace:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
-- **Dart:** [dart-atom/dartlang](https://github.com/dart-atom/dartlang)
+- **Dart:** [dart-lang/dart-syntax-highlight](https://github.com/dart-lang/dart-syntax-highlight)
 - **DataWeave:** [mulesoft-labs/data-weave-tmLanguage](https://github.com/mulesoft-labs/data-weave-tmLanguage)
 - **Dhall:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
 - **Diff:** [textmate/diff.tmbundle](https://github.com/textmate/diff.tmbundle)


### PR DESCRIPTION
## Description

Reconfigure the highlighter for Dart away from Dart Atom which is no longer being maintained to a new highlighter under the dart-lang org.

## Checklist:


- [X] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fdart-atom%2Fdart%2Fblob%2Fmaster%2Fgrammars%2Fdart.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgist.githubusercontent.com%2Fmit-mit%2Fb8549d317f24e8b9cdd618fc92c11aa7%2Fraw%2Fe13f789d71b55c9767030bd448eefc2d49e4ff23%2Fnewfeatures.dart&code=

  - New: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fdart-lang%2Fdart-syntax-highlight%2Fblob%2Fmaster%2Fgrammars%2Fdart.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgist.githubusercontent.com%2Fmit-mit%2Fb8549d317f24e8b9cdd618fc92c11aa7%2Fraw%2Fe13f789d71b55c9767030bd448eefc2d49e4ff23%2Fnewfeatures.dart&code=

There are not a lot of changes right now (if any), but we're about to deprecate the dart-atom repo, and it will no longer be maintained.
