### PR TITLE
Update vendored path in .gitattributes to use double wildcard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@ Gemfile linguist-vendored=true
 lib/linguist.rb linguist-language=Java
 test/*.rb linguist-language=Java
 Rakefile linguist-generated
-test/fixtures/* linguist-vendored=false
+test/fixtures/** linguist-vendored=false
 README.md linguist-documentation=false
 samples/Arduino/* linguist-documentation
 samples/Markdown/*.md linguist-detectable=true


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
As reported in https://github.com/github/linguist/issues/4813, the `.gitattributes` test started failing in the last 24 hours. I worked this out to coincide with an update to Rugged. After discussing with @carlosmn we thought it was due to a regression in the upstream libgit2 code around the handling of the bad unicode char in the path and opened https://github.com/libgit2/libgit2/issues/5450. 

After some stellar digging, @carlosmn determined this was actually kind of expected:

> It turns out this is... erm.. expected... sort of.
> 
> git switched from fnmatch to wildmatch some time ago, and libgit2 only recently did so. What this does is change some of the rules around recursion. Linguist is expecting the old rules where `test/fixtures/*` covers everything under fixtures, but this is no longer the case.
>
 Switching the rule to `test/fixtures/**` does make it match again. See libgit2/libgit2#5450 for some more discussion.

... and sure enough, this does the trick.   This PR updates the `.gitattributes` file in the `test/attributes` branch.

The tests in this branch don't run but in turn require another PR against master to pull in the SHA from this PR, which I'll do next.

_[ Template removed as it doesn't apply ]_