### PR TITLE
Use newest .gitattributes SHA from test/attributes branch

### DIFF
--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -47,7 +47,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_repo_git_attributes
-    # See https://github.com/github/linguist/blob/f912648ad8d4bc8b0b9f3fba209deda4c4abb77e/.gitattributes
+    # See https://github.com/github/linguist/blob/72a89fc9dcd3585250056ab591f9d7e2411d5fa1/.gitattributes
     #
     # It looks like this:
     # Gemfile linguist-vendored=true
@@ -64,7 +64,7 @@ class TestRepository < Minitest::Test
     # LICENSE -linguist-documentation
     # samples/CoffeeScript/browser.coffee -linguist-detectable
 
-    attr_commit = 'f912648ad8d4bc8b0b9f3fba209deda4c4abb77e'
+    attr_commit = '72a89fc9dcd3585250056ab591f9d7e2411d5fa1'
     repo = linguist_repo(attr_commit)
 
     assert repo.breakdown_by_file.has_key?("Java")
@@ -94,7 +94,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_linguist_override_vendored?
-    attr_commit = 'f912648ad8d4bc8b0b9f3fba209deda4c4abb77e'
+    attr_commit = '72a89fc9dcd3585250056ab591f9d7e2411d5fa1'
     linguist_repo(attr_commit).read_index
 
     override_vendored = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'Gemfile')

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -54,7 +54,7 @@ class TestRepository < Minitest::Test
     # lib/linguist.rb linguist-language=Java
     # test/*.rb linguist-language=Java
     # Rakefile linguist-generated
-    # test/fixtures/* linguist-vendored=false
+    # test/fixtures/** linguist-vendored=false
     # README.md linguist-documentation=false
     # samples/Arduino/* linguist-documentation
     # samples/Markdown/*.md linguist-detectable=true

--- a/test/test_repository.rb
+++ b/test/test_repository.rb
@@ -47,7 +47,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_repo_git_attributes
-    # See https://github.com/github/linguist/blob/c20ebee0ebf33f73313d4694680521f80635d477/.gitattributes
+    # See https://github.com/github/linguist/blob/f912648ad8d4bc8b0b9f3fba209deda4c4abb77e/.gitattributes
     #
     # It looks like this:
     # Gemfile linguist-vendored=true
@@ -64,7 +64,7 @@ class TestRepository < Minitest::Test
     # LICENSE -linguist-documentation
     # samples/CoffeeScript/browser.coffee -linguist-detectable
 
-    attr_commit = 'c20ebee0ebf33f73313d4694680521f80635d477'
+    attr_commit = 'f912648ad8d4bc8b0b9f3fba209deda4c4abb77e'
     repo = linguist_repo(attr_commit)
 
     assert repo.breakdown_by_file.has_key?("Java")
@@ -94,7 +94,7 @@ class TestRepository < Minitest::Test
   end
 
   def test_linguist_override_vendored?
-    attr_commit = 'c20ebee0ebf33f73313d4694680521f80635d477'
+    attr_commit = 'f912648ad8d4bc8b0b9f3fba209deda4c4abb77e'
     linguist_repo(attr_commit).read_index
 
     override_vendored = Linguist::LazyBlob.new(rugged_repository, attr_commit, 'Gemfile')


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
This PR pulls in the SHA from https://github.com/github/linguist/pull/4814 to ensure we test against the latest version of the `.gitattributes` file in the `test/attributes` file.

The SHA in this PR will need to be updated again once https://github.com/github/linguist/pull/4814 has been merged as we squash merge so the SHA will change.

Fixes https://github.com/github/linguist/issues/4813

_[ Template removed as it doesn't apply ]_