### PR TITLE
Add Cpcdosc+ language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -992,6 +992,9 @@
 [submodule "vendor/grammars/vscode-codeql"]
 	path = vendor/grammars/vscode-codeql
 	url = https://github.com/github/vscode-codeql
+[submodule "vendor/grammars/vscode-cpcdos"]
+	path = vendor/grammars/vscode-cpcdos
+	url = https://github.com/SPinti-Software/vscode-cpcdos
 [submodule "vendor/grammars/vscode-gcode-syntax"]
 	path = vendor/grammars/vscode-gcode-syntax
 	url = https://github.com/appliedengdesign/vscode-gcode-syntax

--- a/grammars.yml
+++ b/grammars.yml
@@ -845,6 +845,8 @@ vendor/grammars/vhdl:
 - source.vhdl
 vendor/grammars/vscode-codeql:
 - source.ql
+vendor/grammars/vscode-cpcdos:
+- source.cpc
 vendor/grammars/vscode-gcode-syntax:
 - source.gcode
 vendor/grammars/vscode-hack:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -946,6 +946,13 @@ Coq:
   tm_scope: source.coq
   ace_mode: text
   language_id: 69
+CpcdosC+:
+  type: programming
+  extensions:
+  - ".cpc"
+  tm_scope: source.cpc
+  ace_mode: text
+  language_id: 273943564
 Cpp-ObjDump:
   type: data
   extensions:

--- a/samples/CpcdosC+/hello.cpc
+++ b/samples/CpcdosC+/hello.cpc
@@ -1,0 +1,3 @@
+rem/ simple "Hello world" program
+
+txt/ Hello world !

--- a/samples/CpcdosC+/hello_gui.cpc
+++ b/samples/CpcdosC+/hello_gui.cpc
@@ -1,0 +1,34 @@
+Window/ My_Window
+    .title          = "My first application"
+    .px             = "100"
+    .py             = "20"
+    .sx             = "250"
+    .sy             = "150"
+    .Opacity        = "200"
+    .Parameters     = ""
+    .WindowColor    = "050,050,250"
+    .TitleColor     = "055,055,255"
+    .BackColor      = "050,050,250"
+    .event          = ""
+    @#Window_Handle Create/
+end/ window
+
+Button/ My_Button
+    .Handle         = "%Window_Handle%"
+    .Parameters     = "IMGAUTO:2"
+    .PX             = "20"
+    .PY             = "20"
+    .sx             = "100"
+    .sy             = "30"
+    .opacity        = "255"
+    .text           = "Clic moi!"
+    .Image          = "%OS_GUI%/Buttons/BTN_BLUE.png"
+    .event          = "%_EXE_PATH_%"
+    create/
+End/ Button
+
+Function/ My_Button.MouseClic()
+
+    msgbox/ Hello ! :-)
+
+End/ Function

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -82,6 +82,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Component Pascal:** [textmate/pascal.tmbundle](https://github.com/textmate/pascal.tmbundle)
 - **Cool:** [anunayk/cool-tmbundle](https://github.com/anunayk/cool-tmbundle)
 - **Coq:** [mkolosick/Sublime-Coq](https://github.com/mkolosick/Sublime-Coq)
+- **CpcdosC+:** [SPinti-Software/vscode-cpcdos](https://github.com/SPinti-Software/vscode-cpcdos)
 - **Cpp-ObjDump:** [nanoant/assembly.tmbundle](https://github.com/nanoant/assembly.tmbundle)
 - **Creole:** [Siddley/Creole](https://github.com/Siddley/Creole)
 - **Crystal:** [atom-crystal/language-crystal](https://github.com/atom-crystal/language-crystal)

--- a/vendor/licenses/grammar/vscode-cpcdos.txt
+++ b/vendor/licenses/grammar/vscode-cpcdos.txt
@@ -1,0 +1,35 @@
+---
+type: grammar
+name: vscode-cpcdos
+version: f61fd5958f82c0520898d550c66af59c44baff4b
+license: bsd-3-clause
+---
+BSD 3-Clause License
+
+Copyright (c) 2020, d0p1
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
# Add CpcdosC+ language

Cpcdos is a co-kernel made primarilly for beginners in the OS development world without having to necessarily know low-level programming. By implementing a language called Cpcdos C+, developers can quickly write programs and tools and essentially make a full distribution out of it.

## Description

this pull request aim to add support for CpcdosC+ language.

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?q=extension%3Acpc+txt+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://cpcdos.net/en/
    - Sample license(s): public domain
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: [lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FSPinti-Software%2Fvscode-cpcdos%2Fblob%2Fmaster%2Fsyntaxes%2Fcpc.tmLanguage.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2FSPinti-Software%2Flinguist%2Fblob%2Fcpcdos%2Fsamples%2FCpcdosC%252B%2Fhello_gui.cpc&code=)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
