### PR TITLE
Updated README to more clearly state that linguist runs in a Git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ project.languages      #=> { "Ruby" => 119387 }
 
 ### Command line usage
 
+#### Git Repository
+
 A repository's languages stats can also be assessed from the command line using the `github-linguist` executable.
 Without any options, `github-linguist` will output the breakdown that correlates to what is shown in the language stats bar.
 The `--breakdown` flag will additionally show the breakdown of files by language.
@@ -102,7 +104,7 @@ github-linguist
 You can try running `github-linguist` on the root directory in this repository itself:
 
 ```console
-$ bundle exec bin/github-linguist --breakdown
+$ github-linguist --breakdown
 68.57%  Ruby
 22.90%  C
 6.93%   Go
@@ -120,6 +122,19 @@ lib/linguist.rb
 …
 ```
 
+#### Single file
+
+Alternatively you can find stats for a single file using the `github-linguist` executable.
+
+You can try running `github-linguist` on files in this repository itself:
+
+```console
+$ github-linguist grammars.yml
+grammars.yml: 884 lines (884 sloc)
+  type:      Text
+  mime type: text/x-yaml
+  language:  YAML
+```
 
 ## Troubleshooting
 
@@ -161,6 +176,15 @@ Linguist detects the language of a file but the actual syntax-highlighting is po
 If you experience an issue with the syntax-highlighting on GitHub, **please report the issue to the upstream grammar repository, not here.**
 Grammars are updated every time we build the Linguist gem so upstream bug fixes are automatically incorporated as they are fixed.
 
+### I get an error when using Linguist on a directory that is not a Git repository
+
+Linguist only works on Git repositories and individual files. Its primary use is on GitHub.com which uses bare
+repositories and thus changes need to be committed as individual files don't show on the filesystem.
+
+As a work around you could initialise a temporary Git repository in your directory as demonstrated in this
+[script](https://gist.github.com/PuZZleDucK/a45fd1fac3758235ffed9fe0e8aab643).
+
+Alternatively you can run Linguist on individual files, see [above](#single-file).
 
 ## Overrides
 


### PR DESCRIPTION
Attempt to help others avoid the same mistake I made https://github.com/github/linguist/issues/4854 .