### PR TITLE
add BuildStream as a known language

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -73,6 +73,10 @@ disambiguations:
     pattern: '(<^\s*; |End Function)'
   - language: BitBake
     pattern: '^\s*(# |include|require)\b'
+- extensions: ['.bst']
+  rules:
+  - languages: BuildStream
+    pattern: '^*.'
 - extensions: ['.builds']
   rules:
   - language: XML

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6421,3 +6421,11 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+BuildStream:
+  type: programming
+  color: "#006bff"
+  tm_scope: none
+  extensions:
+  - ".bst"
+  ace_mode: text
+  language_id: 450

--- a/samples/BuildStream/first-project/elements/hello.bst
+++ b/samples/BuildStream/first-project/elements/hello.bst
@@ -1,0 +1,13 @@
+kind: import
+
+# Use a local source to stage our file
+sources:
+- kind: local
+  path: hello.world
+
+# Configure the import element
+config:
+
+  # Place the content staged by sources at the
+  # root of the output artifact
+  target: /

--- a/samples/BuildStream/first-project/project.conf
+++ b/samples/BuildStream/first-project/project.conf
@@ -1,0 +1,8 @@
+# Unique project name
+name: first-project
+
+# Minimum required BuildStream version
+min-version: 2.0
+
+# Subdirectory where elements are stored
+element-path: elements

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -98,6 +98,12 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_bst_by_heuristics
+    assert_heuristics({
+      "BuildStream" => all_fixtures("BuildStream", "*.bst")
+    })
+  end
+
   def test_builds_by_heuristics
     assert_heuristics({
       "Text" => all_fixtures("Text"),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -48,6 +48,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Boo:** [Shammah/boo-sublime](https://github.com/Shammah/boo-sublime)
 - **Brainfuck:** [Drako/SublimeBrainfuck](https://github.com/Drako/SublimeBrainfuck)
 - **Brightscript:** [cmink/BrightScript.tmbundle](https://github.com/cmink/BrightScript.tmbundle)
+- **BuildStream:** [BuildStream/buildstream](https://gitlab.com/BuildStream/buildstream)
 - **C:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **C#:** [atom/language-csharp](https://github.com/atom/language-csharp)
 - **C++:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Adds BuildStream as a known language, alternative to BitBake

Not sure on the pattern

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Abst+sources+kind+path
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://gitlab.com/freedesktop-sdk/freedesktop-sdk
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
