### PR TITLE
Ignore Yarn Plug'n'Play installation dependencies

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -384,14 +384,14 @@ module Linguist
     #
     # Returns true or false.
     def npm_shrinkwrap_or_package_lock?
-      name.match(/npm-shrinkwrap\.json/) || name.match(/package-lock\.json/)
+      !!name.match(/npm-shrinkwrap\.json/) || !!name.match(/package-lock\.json/)
     end
 
     # Internal: Is the blob a generated Yarn Plug'n'Play?
     #
     # Returns true or false.
     def generated_yarn_plugnplay?
-      name.match(/(^|\/)\.pnp\.(c|m)?js$/)
+      !!name.match(/(^|\/)\.pnp\.(c|m)?js$/)
     end
 
     # Internal: Is the blob part of Godeps/,
@@ -450,7 +450,7 @@ module Linguist
     #
     # Returns true or false.
     def pipenv_lock?
-      name.match(/Pipfile\.lock/)
+      !!name.match(/Pipfile\.lock/)
     end
 
     # Internal: Is it a KiCAD or GFortran module file?

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -391,7 +391,7 @@ module Linguist
     #
     # Returns true or false.
     def generated_yarn_plugnplay?
-      name.match(/^\.pnp\.(c|m)?js/)
+      name.match(/(^|\/)\.pnp\.(c|m)?js$/)
     end
 
     # Internal: Is the blob part of Godeps/,

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -64,6 +64,7 @@ module Linguist
       go_lock? ||
       esy_lock? ||
       npm_shrinkwrap_or_package_lock? ||
+      generated_yarn_plugnplay? ||
       godeps? ||
       generated_by_zephir? ||
       minified_files? ||
@@ -384,6 +385,13 @@ module Linguist
     # Returns true or false.
     def npm_shrinkwrap_or_package_lock?
       name.match(/npm-shrinkwrap\.json/) || name.match(/package-lock\.json/)
+    end
+
+    # Internal: Is the blob a generated Yarn Plug'n'Play?
+    #
+    # Returns true or false.
+    def generated_yarn_plugnplay?
+      name.match(/^\.pnp\.(c|m)?js/)
     end
 
     # Internal: Is the blob part of Godeps/,

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -45,11 +45,8 @@
 - (^|/)\.yarn/releases/
 - (^|/)\.yarn/plugins/
 
-# Yarn Plug'n'Play dependencies & installation state
-- (^|/)\.yarn/cache/
-- (^|/)\.yarn/unplugged/
-- (^|/)\.yarn/build-state.yml
-- (^|/)\.yarn/install-state.gz
+# Yarn Plug'n'Play dependency files
+- ^\.pnp\.(c|m)?js$
 
 # esy.sh dependencies
 - (^|/)_esy$

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -45,6 +45,12 @@
 - (^|/)\.yarn/releases/
 - (^|/)\.yarn/plugins/
 
+# Yarn Plug'n'Play dependencies & installation state
+- (^|/)\.yarn/cache/
+- (^|/)\.yarn/unplugged/
+- (^|/)\.yarn/build-state.yml
+- (^|/)\.yarn/install-state.gz
+
 # esy.sh dependencies
 - (^|/)_esy$
 

--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -45,9 +45,6 @@
 - (^|/)\.yarn/releases/
 - (^|/)\.yarn/plugins/
 
-# Yarn Plug'n'Play dependency files
-- ^\.pnp\.(c|m)?js$
-
 # esy.sh dependencies
 - (^|/)_esy$
 

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -93,6 +93,11 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data("Dummy/npm-shrinkwrap.json")
     generated_sample_without_loading_data("Dummy/package-lock.json")
 
+    # Yarn Plug'n'Play file
+    generated_sample_without_loading_data(".pnp.js")
+    generated_sample_without_loading_data(".pnp.cjs")
+    generated_sample_without_loading_data(".pnp.mjs")
+
     # Godep saved dependencies
     generated_sample_without_loading_data("Godeps/Godeps.json")
     generated_sample_without_loading_data("Godeps/_workspace/src/github.com/kr/s3/sign.go")


### PR DESCRIPTION
Yarn Plug'n'Play (a relatively recent package management tool typically used for managing JavaScript dependencies) dependencies and some other files are committed to the repository if you're using [Zero Installs](https://yarnpkg.com/features/zero-installs) guidelines. As such, whatever code you've installed as a dependency (i.e. Code that's not yours) ends up slightly skewing Linguist's analysis statistics.

For example, my [monorepo](https://github.com/PatrickShaw/monorepo/tree/70b24446932fc7f68893f6f500d5ca208be43b12) uses almost exclusively TypeScript, however, ~most of the dependencies in `.yarn/cache/*`~ `.pnp.js` is a giant JavaScript file generated by yarn and so it looks like my monorepo is primarily made up of JavaScript.

This PR should fix this issue for anyone using Yarn Plug'n'Play.

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]