### PR TITLE
charlock_holmes 0.7.7

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables = ['github-linguist', 'git-linguist']
   s.extensions = ['ext/linguist/extconf.rb']
 
-  s.add_dependency 'charlock_holmes', '~> 0.7.6'
+  s.add_dependency 'charlock_holmes', '~> 0.7.7'
   s.add_dependency 'escape_utils',    '~> 1.2.0'
   s.add_dependency 'mini_mime',       '~> 1.0'
   s.add_dependency 'rugged',          '>= 0.25.1'


### PR DESCRIPTION
This bumps charlock_holmes to a minimum of 0.7.7. This version has some improvements to the binary build, but no actual code changes.

/cc @febuiles 