### PR TITLE
Change Nim's colour to better match the logo

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3440,7 +3440,7 @@ Nginx:
   language_id: 248
 Nim:
   type: programming
-  color: "#ffe953"
+  color: "#ffdf00"
   extensions:
   - ".nim"
   - ".nim.cfg"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3440,7 +3440,7 @@ Nginx:
   language_id: 248
 Nim:
   type: programming
-  color: "#f3d400"
+  color: "#ffe953"
   extensions:
   - ".nim"
   - ".nim.cfg"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3440,7 +3440,7 @@ Nginx:
   language_id: 248
 Nim:
   type: programming
-  color: "#37775b"
+  color: "#f3d400"
   extensions:
   - ".nim"
   - ".nim.cfg"


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
This PR changes Nim language's colour to better match the logo - from `#37775b` to `#ffdf00`
## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
For a long time I wondered why Nim has the green colour on GitHub, and today I decided to dig deeper in it. Turns out Nim was made green by the initial commit which added colours - https://github.com/github/linguist/commit/c3d6fc5af8cf9d67afa572bba363bf0db256a900 and was never changed after that. 
With this PR I want to make the colour more consistent with the logo and branding (most of it is the goldish yellow)

## Checklist:
- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - I opened a forum thread to spread the info about that PR: https://forum.nim-lang.org/t/6350, shared this PR in IRC, the Telegram channel, the Discord server 
    - Official assets - https://github.com/nim-lang/assets