### PR TITLE
Add .terraformignore to ignore lists

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2275,6 +2275,7 @@ Ignore List:
   - ".npmignore"
   - ".prettierignore"
   - ".stylelintignore"
+  - ".terraformignore"
   - ".vscodeignore"
   - gitignore-global
   - gitignore_global

--- a/samples/Ignore List/filenames/.terraformignore
+++ b/samples/Ignore List/filenames/.terraformignore
@@ -1,0 +1,6 @@
+# When executing a remote plan or apply in a CLI-driven run, an archive of the
+# configuration directory is uploaded to Terraform Cloud. This file defines
+# paths to ignore from upload.
+
+*
+!terraform/


### PR DESCRIPTION
This PR adds the `.terraformignore` extension to the set of ignore lists. `.terraformignore` files define the set of files to exclude from upload when using the Terraform's remote backend.<sup>[\[1\]][1]</sup> This feature was introduced in Terraform v0.12.11, released on Oct 17, 2019.<sup>[\[1\]][1][\[2\]][2]</sup>

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - [`.terraformignore` search results][3]—this doesn't seem to have any indexed results (though I have definitely used it in private repositories), but Terraform files are used quite a lot ([864K+ search results for `.tf`][4]) and this works with those projects
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source:
      - [`samples/Ignore List/filenames/.terraformignore`](https://github.com/whymarrh/linguist/blob/2c3609b2eec5c6f434322af5672da0380fbb641c/samples/Ignore%20List/filenames/.terraformignore)
    - Sample license:
      - MIT
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

  [1]:https://www.terraform.io/docs/backends/types/remote.html#excluding-files-from-upload-with-terraformignore
  [2]:https://github.com/hashicorp/terraform/releases/tag/v0.12.11
  [3]:https://github.com/search?q=extension%3Aterraformignore+NOT+nothack&type=Code
  [4]:https://github.com/search?q=extension%3Atf+NOT+nothack&type=Code