### PR TITLE
Revert "Change Nim's colour to better match the logo"

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3480,7 +3480,7 @@ Nginx:
   language_id: 248
 Nim:
   type: programming
-  color: "#ffdf00"
+  color: "#37775b"
   extensions:
   - ".nim"
   - ".nim.cfg"


### PR DESCRIPTION
Reverts github/linguist#4866

The new colour is failing the proximity test:

```
  1) Failure:
TestColorProximity#test_color_proximity [/home/runner/work/linguist/linguist/test/test_color_proximity.rb:21]:
The following 1 languages have failing color thresholds. Please modify the hex color.
- Nim (#ffdf00) is too close to ["FFEC25", "ffdf00"]
```

I've now worked out why the passed before: Dafny got the `#FFEC25` colour before Nim's change so it was merged first.

@Yardanico please feel free to submit a new PR with a tweaked colour that passes the proximity test. It'll be best to run the test locally repeatedly as you tweak the colour until you find one that doesn't fail. Sorry for the inconvenience.