### PR TITLE
Disambiguate XML and Gosu for .gst extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6056,6 +6056,7 @@ XML:
   - ".gml"
   - ".gmx"
   - ".grxml"
+  - ".gst"
   - ".iml"
   - ".ivy"
   - ".jelly"

--- a/samples/XML/battlescribe.gst
+++ b/samples/XML/battlescribe.gst
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?><gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="f7896daf-884b-4236-8045-96e64cb5d92c" revision="1" battleScribeVersion="1.15" name="My GameSystem">
+  <forceTypes>
+    <forceType id="255b74b2-37e4-4042-8bd7-65ba9dc9fdef" name="Units" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
+      <categories>
+        <category id="3936ba0c-f066-445e-951d-f901c09580c1" name="Units" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
+          <modifiers/>
+        </category>
+      </categories>
+      <forceTypes/>
+    </forceType>
+  </forceTypes>
+  <profileTypes>
+    <profileType id="4a3a96c4-757b-4692-85ec-98e369565d3c" name="Unit">
+      <characteristics>
+        <characteristic id="cf826999-3ba2-4d75-94b3-4faf2333744d" name="WUT"/>
+      </characteristics>
+    </profileType>
+  </profileTypes>
+</gameSystem>


### PR DESCRIPTION
## Description

* [BattleScribe](https://battlescribe.net/) uses XML files with the .gst extension which are currently classified as Gosu. [See an example here](https://github.com/BSData/wh40k-heralds-of-ruin/blob/master/Warhammer%2040%2C000%20Heralds%20of%20Ruin%208th%20Edition.gst).
* Added .gst extension to the XML language. The XML strategy takes care of the disambiguation (if I got this right).
* Added a synthetic sample. I could not find a real world sample with a clearly defined license.

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com **Certainly not hundreds, more like ~100.**
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Agst+gamesystem+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR: **Included synthetic sample.**
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension. **AFAIK not required given the XML strategy?**
