### PR TITLE
Relax PL/SQL heuristic: remove SYSDATE

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -450,7 +450,7 @@ disambiguations:
     pattern: "(?i:(alter module)|(language sql)|(begin( NOT)+ atomic)|signal SQLSTATE '[0-9]+')"
   # Oracle
   - language: PLSQL
-    pattern: '(?i:\$\$PLSQL_|XMLTYPE|sysdate|systimestamp|\.nextval|connect by|AUTHID (DEFINER|CURRENT_USER)|constructor\W+function)'
+    pattern: '(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|connect by|AUTHID (DEFINER|CURRENT_USER)|constructor\W+function)'
   # T-SQL
   - language: TSQL
     pattern: '(?i:^\s*GO\b|BEGIN( TRY| CATCH)|OUTPUT INSERTED|DECLARE\s+@)'

--- a/test/fixtures/SQL/sysdate.sql
+++ b/test/fixtures/SQL/sysdate.sql
@@ -1,0 +1,1 @@
+SELECT SYSDATE();


### PR DESCRIPTION
## Description
This is part of a series of PRs for SQL, see #4884.

SYSDATE is also a valid MySQL function.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
