### PR TITLE
.sql heuristic falls back to SQL

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -452,16 +452,15 @@ disambiguations:
     pattern: '(?i:^\\i\b|AS \$\$|LANGUAGE ''?plpgsql''?|BEGIN( WORK )?;)'
   # IBM db2
   - language: SQLPL
-    pattern: "(?i:alter module|MODE DB2SQL)"
+    pattern: '(?i:alter module|MODE DB2SQL|\bSYSCAT\.\b|\bSYSPROC\.\b|ASSOCIATE RESULT SET|\bEND!\s*$)'
   # Oracle
   - language: PLSQL
     pattern: '(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|connect by|AUTHID (DEFINER|CURRENT_USER)|constructor\W+function)'
   # T-SQL
   - language: TSQL
-    pattern: '(?i:^\s*GO\b|BEGIN( TRY| CATCH)|OUTPUT INSERTED|DECLARE\s+@)'
-  # Generic SQL
+    pattern: '(?i:^\s*GO\b|BEGIN( TRY| CATCH)|OUTPUT INSERTED|DECLARE\s+@|\[dbo\])'
+  # Fallback to SQL
   - language: SQL
-    negative_pattern: '(?i:begin|boolean|package|exception)'
 - extensions: ['.srt']
   rules:
   - language: SubRip Text

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -449,17 +449,16 @@ disambiguations:
   rules:
    # Postgres
   - language: PLpgSQL
-    pattern: '(?i:^\\i\b|AS \$\$|LANGUAGE ''?plpgsql''?|BEGIN( WORK )?;)'
+    pattern: '(?i:^\\i\b|AS\s+\$\$|LANGUAGE\s+''?plpgsql''?|BEGIN(\s+WORK)?\s*;)'
   # IBM db2
   - language: SQLPL
-    pattern: '(?i:alter module|MODE DB2SQL|\bSYSCAT\.\b|\bSYSPROC\.\b|ASSOCIATE RESULT SET|\bEND!\s*$)'
+    pattern: '(?i:ALTER\s+MODULE|MODE\s+DB2SQL|\bSYS(CAT|PROC)\.|ASSOCIATE\s+RESULT\s+SET|\bEND!\s*$)'
   # Oracle
   - language: PLSQL
-    pattern: '(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|connect by|AUTHID (DEFINER|CURRENT_USER)|constructor\W+function)'
+    pattern: '(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|CONNECT\s+BY|AUTHID\s+(DEFINER|CURRENT_USER)|constructor\W+function)'
   # T-SQL
   - language: TSQL
-    pattern: '(?i:^\s*GO\b|BEGIN( TRY| CATCH)|OUTPUT INSERTED|DECLARE\s+@|\[dbo\])'
-  # Fallback to SQL
+    pattern: '(?i:^\s*GO\b|BEGIN(\s+TRY|\s+CATCH)|OUTPUT\s+INSERTED|DECLARE\s+@|\[dbo\])'
   - language: SQL
 - extensions: ['.srt']
   rules:


### PR DESCRIPTION
## Description
This is part of a series of PRs for SQL, see #4884.

Do not use the classifier strategy for `.sql`, fallback to SQL. The premise here is that classifying any SQL variant as SQL is less wrong than classifying it as the wrong variant.

Adds some new patterns to SQL PL and T-SQL to keep everything working, at least for current samples.

## Checklist:
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
