### PR TITLE
add Linqpad script extension .linq to C#

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -553,6 +553,7 @@ C#:
   - ".cs"
   - ".cake"
   - ".csx"
+  - ".linq"
   language_id: 42
 C++:
   type: programming

--- a/samples/C#/chart-process-memory.linq
+++ b/samples/C#/chart-process-memory.linq
@@ -1,0 +1,44 @@
+<Query Kind="Program">
+  <GACReference>System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</GACReference>
+  <Namespace>System</Namespace>
+  <Namespace>System.Dynamic</Namespace>
+  <Namespace>System.Management.Automation</Namespace>
+  <Namespace>System.Runtime.Serialization.Formatters</Namespace>
+  <Namespace>System.Xml.Linq</Namespace>
+</Query>
+
+void Main()
+{
+	/*
+	 * chart process memory
+	 * Authored by zyonet
+	 * No waranties provided what soever, use at your own risk or benefit ;D
+	 * MIT license
+	 * https://raw.githubusercontent.com/zyonet/PowerLinqPadScripts/master/LinqPad5/chart-process-memory.linq
+	 */
+	
+	//To Test:  open this file in LinqPad 5 (https://www.linqpad.net)
+	//refence System.Management.Automation dll in GAC
+	//and set language to C# in vscode for the current editor
+	
+	var ps = PowerShell.Create();
+	var _1m = 1024 * 1024;
+	
+	var script = @"get-process | Select Name,WS | Sort-Object -Descending WS | Where-Object {$_.WS -gt 10 * 1024 * 1024}";
+	ps.AddScript(script);
+	var res = ps.Invoke();
+	
+	var processes = res.Select( x => new {
+		Name = (string) x.Properties["Name"].Value,
+		WSInMb = (long) x.Properties["WS"].Value / _1m
+	});
+	
+	//now chart it
+	Util.Chart(processes
+	.Where( p => p.WSInMb >= 100), //replace with your filter 
+	(p) => p.Name, (p) => p.WSInMb,
+	Util.SeriesType.Pie)
+	.Dump("Processes Where WS > 100M (unit = 1Mb)");
+}
+
+// Define other methods and classes here


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
[LInqPad](https://www.linqpad.net) scripts are written in C# language with some linqpad related metadata added.  Linqpad scripts have extension .linq and linqpad scripts in GitHub are not properly syntax highlighted.  adding .linq extension to the C# language in languages.yml will fix this.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?p=100&q=extension%3Alinq+query+Statements+NOT+nothack&ref=searchresults&type=Code&utf8=%E2%9C%93
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/zyonet/PowerLinqPadScripts/blob/master/LinqPad5/chart-process-memory.linq
    - Sample license(s): MIT
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

