### PR TITLE
Change Nim's colour

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3499,7 +3499,7 @@ Nginx:
   language_id: 248
 Nim:
   type: programming
-  color: "#deb012"
+  color: "#ffc200"
   extensions:
   - ".nim"
   - ".nim.cfg"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3499,7 +3499,7 @@ Nginx:
   language_id: 248
 Nim:
   type: programming
-  color: "#37775b"
+  color: "#deb012"
   extensions:
   - ".nim"
   - ".nim.cfg"


### PR DESCRIPTION
## Description
This PR is a follow-up to https://github.com/github/linguist/pull/4866 (https://github.com/github/linguist/pull/4871) with a different color

From `#37775b` to `#ffc200`

## Checklist:

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - See https://github.com/github/linguist/pull/4866 (https://forum.nim-lang.org/t/6350)

I hope this time this colour would be good enough since it was checked against the same algo as GitHub's color proximity.