### PR TITLE
Add Verifpal language extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5756,6 +5756,16 @@ Verilog:
   codemirror_mode: verilog
   codemirror_mime_type: text/x-verilog
   language_id: 387
+Verilog:
+  type: programming
+  color: "#D9D8A4"
+  extensions:
+  - ".vp"
+  tm_scope: source.verifpal
+  ace_mode: verifpal
+  codemirror_mode: verifpal
+  codemirror_mime_type: text/x-verifpal
+  language_id: 1337
 Vim Snippet:
   type: markup
   aliases:

--- a/samples/Verifpal/lc-dp-3t.vp
+++ b/samples/Verifpal/lc-dp-3t.vp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2019-2020 Nadim Kobeissi <nadim@symbolic.software>
+// SPDX-License-Identifier: GPL-3.0-only
+
+attacker[active]
+
+// All lines that start with "//" are treated as comments and ignored by Verifpal
+// A principal block looks like the following
+principal SmartphoneA[
+	// In the line below we state that Alice knows the public BroadcastKey
+	
+	knows public BroadcastKey
+	
+	// SK is going to be a secret random value
+	// To define it we use the "generates" keyword
+	// We will use the following template for SK variable names
+	// SK[day number][principal initial]
+	
+	generates SK0A
+	
+	// We will use the following template for EphID variable names
+	// EphID[day number][value number][principal initial]
+	
+	EphID00A, EphID01A, EphID02A = HKDF(nil, SK0A, BroadcastKey)
+]
+
+principal SmartphoneB[
+	knows public BroadcastKey
+	generates SK0B
+	EphID00B, EphID01B, EphID02B = HKDF(nil, SK0B, BroadcastKey)
+]
+
+principal SmartphoneC[
+	knows public BroadcastKey
+	generates SK0C
+	EphID00C, EphID01C, EphID02C = HKDF(nil, SK0C, BroadcastKey)
+]
+
+// Sender -> Recipient : Name of Value
+
+SmartphoneA -> SmartphoneB: EphID00A
+SmartphoneB -> SmartphoneA: EphID00B
+
+SmartphoneC -> SmartphoneB: EphID01C
+SmartphoneB -> SmartphoneC: EphID01B
+
+// A server is just like any other principal
+
+principal BackendServer[
+	// Let's assume that infectedPatients0 is the list of infected patients on day 0
+	knows private infectedPatients0
+]
+
+BackendServer -> SmartphoneA: infectedPatients0
+BackendServer -> SmartphoneB: infectedPatients0
+BackendServer -> SmartphoneC: infectedPatients0
+
+principal SmartphoneA[
+	SK1A = HASH(SK0A)
+	EphID10A, EphID11A, EphID12A = HKDF(nil, SK1A, BroadcastKey)
+]
+
+principal SmartphoneB[
+	SK1B = HASH(SK0B)
+	EphID10B, EphID11B, EphID12B = HKDF(nil, SK1B, BroadcastKey)
+]
+
+principal SmartphoneC[
+	SK1C = HASH(SK0C)
+	EphID10C, EphID11C, EphID12C = HKDF(nil, SK1C, BroadcastKey)
+]
+
+principal SmartphoneA[
+	SK2A = HASH(SK1A)
+	EphID20A, EphID21A, EphID22A = HKDF(nil, SK2A, BroadcastKey)
+]
+
+principal HealthCareAuthority[
+	generates triggerToken
+	knows private ephemeral_sk
+	m1 = ENC(ephemeral_sk, triggerToken)
+]
+
+// The brackets around m1 here mean that the value is guarded
+// ie: an active attacker cannot inject a value in its place
+HealthCareAuthority -> BackendServer : [m1]
+HealthCareAuthority -> SmartphoneA : m1
+
+principal SmartphoneA[
+	knows private ephemeral_sk
+	m1_dec = DEC(ephemeral_sk, m1)
+	m2 = ENC(ephemeral_sk, SK1A)
+]
+
+SmartphoneA -> BackendServer: m2
+
+principal BackendServer [
+	knows private ephemeral_sk
+	m2_dec = DEC(ephemeral_sk, m2)
+	infectedPatients1 = CONCAT(infectedPatients0, m2_dec)
+]
+
+BackendServer -> SmartphoneA: infectedPatients1
+BackendServer -> SmartphoneB: infectedPatients1
+BackendServer -> SmartphoneC: infectedPatients1
+
+queries[
+	// Would someone who shared a value 15 days before they got tested get flagged?
+	confidentiality? EphID02A
+	// Is the server able to Authenticate Alice as the sender of m2?
+	authentication? SmartphoneA -> BackendServer: m2
+	unlinkability? EphID02A, EphID00A, EphID01A
+]

--- a/samples/Verifpal/scuttlebutt.vp
+++ b/samples/Verifpal/scuttlebutt.vp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2019-2020 Nadim Kobeissi <nadim@symbolic.software>
+// SPDX-License-Identifier: GPL-3.0-only
+
+attacker[active]
+
+// Setup
+
+principal Alice[
+	knows public n
+	knows private longTermA
+	generates ephemeralA
+	longTermAPub = G^longTermA
+	ephemeralAPub = G^ephemeralA
+]
+
+principal Bob[
+	knows public n
+	knows private longTermB
+	generates ephemeralB
+	longTermBPub = G^longTermB
+	ephemeralBPub = G^ephemeralB
+]
+
+Bob -> Alice: longTermBPub
+
+// 1. Client Hello
+
+principal Alice[
+	nMacAlice = MAC(n, ephemeralAPub)
+]
+
+Alice -> Bob: ephemeralAPub, nMacAlice
+
+// 2. Server Hello
+
+principal Bob[
+	nMacAliceValid = ASSERT(MAC(n, ephemeralAPub), nMacAlice)?
+	nMacBob = MAC(n, ephemeralBPub)
+]
+
+Bob -> Alice: ephemeralBPub, nMacBob
+
+// 3. Client Authenticate
+
+principal Alice[
+	nMacBobValid = ASSERT(MAC(n, ephemeralBPub), nMacBob)?
+	ephemeralSecretAlice = ephemeralBPub^ephemeralA
+	longTermSecretAlice = longTermBPub^ephemeralA
+	masterSecret1Alice = HASH(n, ephemeralSecretAlice, longTermSecretAlice)
+	sig1Alice = SIGN(longTermA, HASH(n, longTermBPub, ephemeralSecretAlice))
+	secretBox1Alice = AEAD_ENC(masterSecret1Alice, sig1Alice, nil)
+	secretBox2Alice = AEAD_ENC(masterSecret1Alice, longTermAPub, nil)
+	longEphemeralSecretAlice = ephemeralBPub^longTermA
+	masterSecret2Alice = HASH(n, ephemeralSecretAlice, longTermSecretAlice, longEphemeralSecretAlice)
+]
+
+// TODO: Concatentation
+Alice -> Bob: secretBox1Alice, secretBox2Alice
+
+principal Bob[
+	ephemeralSecretBob = ephemeralAPub^ephemeralB
+	longTermSecretBob = ephemeralAPub^longTermB
+	masterSecret1Bob = HASH(n, ephemeralSecretBob, longTermSecretBob)
+	sig1Bob = AEAD_DEC(masterSecret1Bob, secretBox1Alice, nil)?
+	longTermAPub_Bob = AEAD_DEC(masterSecret1Bob, secretBox2Alice, nil)?
+	sig1Valid = SIGNVERIF(longTermAPub_bob, HASH(n, longTermBPub, ephemeralSecretBob), sig1Bob)?
+	longEphemeralSecretBob = longTermAPub_Bob^ephemeralB
+]
+
+// 4. Server Accept
+
+principal Bob[
+	sig2Bob = SIGN(longTermB, HASH(n, sig1Bob, longTermAPub_Bob, ephemeralSecretBob))
+	masterSecret2Bob = HASH(n, ephemeralSecretBob, longTermSecretBob, longEphemeralSecretBob)
+	secretBox1Bob = AEAD_ENC(masterSecret2Bob, sig2Bob, nil)
+]
+
+Bob -> Alice: secretBox1Bob
+
+// 5. Send a message
+
+principal Alice[
+	knows private m1
+	sig2Alice = AEAD_DEC(masterSecret2Alice, secretBox1Bob, nil)?
+	sig2Valid = SIGNVERIF(longTermBPub, HASH(n, sig1Alice, longTermAPub, ephemeralSecretAlice), sig2Alice)?
+	secretBoxM1Alice = AEAD_ENC(masterSecret2Alice, m1, nil)
+]
+
+Alice -> Bob: secretBoxM1Alice
+
+principal Bob[
+	knows private m2
+	m1Bob = AEAD_DEC(masterSecret2Bob, secretBoxM1Alice, nil)?
+	secretBoxM2Bob = AEAD_ENC(masterSecret2Bob, m2, nil)
+]
+
+Bob -> Alice: secretBoxM2Bob
+
+principal Alice [
+	m2Alice = AEAD_DEC(masterSecret2Alice, secretBoxM2Bob, nil)?
+]
+
+queries[
+	confidentiality? n
+	confidentiality? m1
+	confidentiality? m2
+	confidentiality? longTermAPub
+	authentication? Alice -> Bob: secretBox1Alice
+	authentication? Alice -> Bob: secretBox2Alice
+	authentication? Bob -> Alice: secretBox1Bob
+	authentication? Alice -> Bob: secretBoxM1Alice
+	authentication? Bob -> Alice: secretBoxM2Bob
+]

--- a/samples/Verifpal/signal.vp
+++ b/samples/Verifpal/signal.vp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2019-2020 Nadim Kobeissi <nadim@symbolic.software>
+// SPDX-License-Identifier: GPL-3.0-only
+
+attacker[active]
+
+principal Alice[
+	knows public c0, c1, c2, c3, c4
+	knows private alongterm
+	galongterm = G^alongterm
+]
+
+principal Bob[
+	knows public c0, c1, c2, c3, c4
+	knows private blongterm, bs
+	generates bo
+	gblongterm = G^blongterm
+	gbs = G^bs
+	gbo = G^bo
+	gbssig = SIGN(blongterm, gbs)
+]
+
+Bob -> Alice: [gblongterm], gbssig, gbs, gbo
+
+principal Alice[
+	generates ae1
+	gae1 = G^ae1
+	amaster = HASH(c0, gbs^alongterm, gblongterm^ae1, gbs^ae1, gbo^ae1)
+	arkba1, ackba1 = HKDF(amaster, c1, c2)
+]
+
+principal Alice[
+	generates m1, ae2
+	gae2 = G^ae2
+	_ = SIGNVERIF(gblongterm, gbs, gbssig)?
+	akshared1 = gbs^ae2
+	arkab1, ackab1 = HKDF(akshared1, arkba1, c2)
+	akenc1, akenc2 = HKDF(MAC(ackab1, c3), c1, c4)
+	e1 = AEAD_ENC(akenc1, m1, HASH(galongterm, gblongterm, gae2))
+]
+
+Alice -> Bob: [galongterm], gae1, gae2, e1
+
+principal Bob[
+	bmaster = HASH(c0, galongterm^bs, gae1^blongterm, gae1^bs, gae1^bo)
+	brkba1, bckba1 = HKDF(bmaster, c1, c2)
+]
+
+principal Bob[
+	bkshared1 = gae2^bs
+	brkab1, bckab1 = HKDF(bkshared1, brkba1, c2)
+	bkenc1, bkenc2 = HKDF(MAC(bckab1, c3), c1, c4)
+	m1_d = AEAD_DEC(bkenc1, e1, HASH(galongterm, gblongterm, gae2))
+]
+
+principal Bob[
+	generates m2, be
+	gbe = G^be
+	bkshared2 = gae2^be
+	brkba2, bckba2 = HKDF(bkshared2, brkab1, c2)
+	bkenc3, bkenc4 = HKDF(MAC(bckba2, c3), c1, c4)
+	e2 = AEAD_ENC(bkenc3, m2, HASH(gblongterm, galongterm, gbe))
+]
+
+Bob -> Alice: gbe, e2
+
+principal Alice[
+	akshared2 = gbe^ae2
+	arkba2, ackba2 = HKDF(akshared2, arkab1, c2)
+	akenc3, akenc4 = HKDF(MAC(ackba2, c3), c1, c4)
+	m2_d = AEAD_DEC(akenc3, e2, HASH(gblongterm, galongterm, gbe))
+]
+
+principal Alice[
+	generates m3, ae3
+	gae3 = G^ae3
+	akshared3 = gbe^ae3
+	arkab3, ackab3 = HKDF(akshared3, arkba2, c2)
+	akenc5, akenc6 = HKDF(MAC(ackab3, c3), c1, c4)
+	e3 = AEAD_ENC(akenc5, m3, HASH(gblongterm, galongterm, gae3))
+]
+
+Alice -> Bob: gae3, e3
+
+principal Bob[
+	bkshared3 = gae3^be
+	brkab3, bckab3 = HKDF(bkshared3, brkba2, c2)
+	bkenc5, bkenc6 = HKDF(MAC(bckab3, c3), c1, c4)
+	m3_d = AEAD_DEC(bkenc5, e3, HASH(gblongterm, galongterm, gae3))
+]
+
+phase[1]
+
+principal Alice[leaks alongterm]
+principal Bob[leaks blongterm]
+
+queries[
+	confidentiality? m1
+	authentication? Alice -> Bob: e1
+	confidentiality? m2
+	authentication? Bob -> Alice: e2
+	confidentiality? m3
+	authentication? Alice -> Bob: e3
+]

--- a/samples/Verifpal/simple.vp
+++ b/samples/Verifpal/simple.vp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2019-2020 Nadim Kobeissi <nadim@symbolic.software>
+// SPDX-License-Identifier: GPL-3.0-only
+
+attacker[active]
+
+principal Bob[]
+
+principal Alice[
+	knows public c0
+	generates a
+	ga = G^a
+]
+
+Alice -> Bob: ga
+
+principal Bob[
+	knows public c0
+	generates m1, b
+	gb = G^b
+	gab = ga^b
+	e1 = AEAD_ENC(gab, m1, c0)
+]
+
+Bob -> Alice: gb, e1
+
+principal Alice[
+	gba = gb^a
+	e1_dec = AEAD_DEC(gba, e1, c0)?
+]
+
+queries[
+	confidentiality? m1
+	authentication? Bob -> Alice: e1
+]


### PR DESCRIPTION
This adds the Verifpal language to Linguist.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in about a dozen repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Avp+attacker&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - examples/Verifpal
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
