### PR TITLE
remove '@@' pattern form T-SQL

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -453,7 +453,7 @@ disambiguations:
     pattern: '(?i:\$\$PLSQL_|XMLTYPE|sysdate|systimestamp|\.nextval|connect by|AUTHID (DEFINER|CURRENT_USER)|constructor\W+function)'
   # T-SQL
   - language: TSQL
-    pattern: '(?i:^\s*GO\b|@@[_A-Z]\w*\b|BEGIN( TRY| CATCH)|OUTPUT INSERTED|DECLARE\s+@)'
+    pattern: '(?i:^\s*GO\b|BEGIN( TRY| CATCH)|OUTPUT INSERTED|DECLARE\s+@)'
   # Generic SQL
   - language: SQL
     negative_pattern: '(?i:begin|boolean|package|exception)'

--- a/test/fixtures/SQL/set_at_at.sql
+++ b/test/fixtures/SQL/set_at_at.sql
@@ -1,0 +1,1 @@
+SET @@GLOBAL.max_connections = 1000;


### PR DESCRIPTION
## Description
@@ pattern was associated to T-SQL, but it is used in variables for more
dialects.

Added a simple fixture taken from MySQL 5.7 documentation:

https://dev.mysql.com/doc/refman/5.7/en/set-variable.html

## Checklist:
- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Simple fixture based on https://dev.mysql.com/doc/refman/5.7/en/set-variable.html
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
