### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Only check for Ruby gem updates
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I enabled automatic security updates on this repo a while ago and one side-effect of this is Dependabot is opening PRs to update vulnerabilities detected in files included in the samples.

This PR should address this by configuring Dependabot to only update our Ruby gems. This explicit configuration should mean everything under `samples` is ignored 🤞 .

[ Template removed as it doesn't apply ]