### PR TITLE
Add support for HEY language

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -424,6 +424,10 @@ disambiguations:
   - language: Python
     pattern: '(?m:^(import|from|class|def)\s)'
   - language: "Ren'Py"
+- extensions: ['.hey']
+  rules:
+  - language: HEY
+    pattern: '(?m:^(compile|class|func|hey)\s)'
 - extensions: ['.rs']
   rules:
   - language: Rust

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2178,6 +2178,18 @@ Haxe:
   - ".hxsl"
   tm_scope: source.hx
   language_id: 158
+HEY:
+  type: programming
+  extensions:
+  - ".hey"
+  aliases:
+  - hey
+  interpreters:
+  - hey
+  color: "#3572A5"
+  ace_mode: text
+  tm_scope: none
+  language_id: 8080
 HiveQL:
   type: programming
   extensions:

--- a/samples/HEY/HelloWorld.hey
+++ b/samples/HEY/HelloWorld.hey
@@ -1,0 +1,1 @@
+hey("Hello, world!")

--- a/samples/HEY/arrays.hey
+++ b/samples/HEY/arrays.hey
@@ -1,0 +1,20 @@
+arr = []
+for i : range(0, 9)
+    arr.push(i)
+end
+for i : range(0, 9)
+    hey(arr[i])
+end
+
+hey(arr) # ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+arr.push(10)
+hey(arr) # ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+
+arr.pop()
+hey(arr) # ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+arr.push("it will be removed")
+hey(arr) # ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'it will be removed']
+arr.remove(10)
+hey(arr) # ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']

--- a/samples/HEY/functions.hey
+++ b/samples/HEY/functions.hey
@@ -1,0 +1,15 @@
+func sum(x, y)
+    return x + y
+end
+
+func imul(x, y)
+    return x * y
+end
+
+sum(1, 1)
+sum(100, 1)
+sum(5, 5)
+
+imul(2, 2)
+imul(5, 2)
+imul(8, 39)

--- a/samples/HEY/io.hey
+++ b/samples/HEY/io.hey
@@ -1,0 +1,2 @@
+line = read()
+hey(line)


### PR DESCRIPTION
**Add support for HEY programming language.**

## Description

HEY is a lightweight **dynamically** typed embedded scripting language with **simple** and **natural** syntax. HEY supports **imperative programming**, **object-oriented programming** and **functional programming**.

URL to the project, compiled binaries, online compiler and reference manual of HEY is here:
https://enty8080.github.io/hey

Test the power of HEY language at **HEY online**:
https://enty8080.github.io/hey/online

**highlighting grammar coming soon, idk how to add it**

## Checklist:

- [x] **I am adding a new language.**
  - [x] I have included a real-world usage sample for all extensions added in this PR:
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/ **idk how to do it :(**
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.