### PR TITLE
Support CUE language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -998,6 +998,9 @@
 [submodule "vendor/grammars/vscode-codeql"]
 	path = vendor/grammars/vscode-codeql
 	url = https://github.com/github/vscode-codeql
+[submodule "vendor/grammars/vscode-cue"]
+	path = vendor/grammars/vscode-cue
+	url = https://github.com/betawaffle/vscode-cue
 [submodule "vendor/grammars/vscode-gcode-syntax"]
 	path = vendor/grammars/vscode-gcode-syntax
 	url = https://github.com/appliedengdesign/vscode-gcode-syntax

--- a/grammars.yml
+++ b/grammars.yml
@@ -858,6 +858,8 @@ vendor/grammars/vhdl:
 - source.vhdl
 vendor/grammars/vscode-codeql:
 - source.ql
+vendor/grammars/vscode-cue:
+- source.cue
 vendor/grammars/vscode-gcode-syntax:
 - source.gcode
 vendor/grammars/vscode-gedcom:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -669,6 +669,13 @@ CSV:
   extensions:
   - ".csv"
   language_id: 51
+CUE:
+  type: data
+  extensions:
+  - ".cue"
+  ace_mode: text
+  tm_scope: source.cue
+  language_id: 356063509
 CWeb:
   type: programming
   extensions:

--- a/samples/CUE/defaults.cue
+++ b/samples/CUE/defaults.cue
@@ -1,0 +1,46 @@
+package connectivity_check
+
+// Default parameters for echo clients (may be overridden).
+deployment: [ID=_]: {
+	// General pod parameters
+	if ID =~ "^pod-to-.*$" || ID =~ "^host-to-.*$" {
+		_image: "docker.io/byrnedo/alpine-curl:0.1.8"
+		_command: ["/bin/ash", "-c", "sleep 1000000000"]
+	}
+
+	// readinessProbe target name
+	if ID =~ "^pod-to-a.*$" || ID =~ "^host-to-a.*$" {
+		_probeTarget: *"echo-a" | string
+	}
+	if ID =~ "^pod-to-b.*$" || ID =~ "^host-to-b.*$" {
+		_probeTarget: *"echo-b" | string
+	}
+	if ID =~ "^pod-to-c.*$" || ID =~ "^host-to-c.*$" {
+		_probeTarget: *"echo-c" | string
+	}
+}
+
+// Default parameters for echo clients (final).
+deployment: [ID=_]: {
+	// Topology
+	if ID =~ "^.*intra-node.*$" {
+		metadata: labels: topology: "intra-node"
+	}
+	if ID =~ "^.*multi-node.*$" {
+		metadata: labels: topology: "multi-node"
+	}
+
+	// Affinity
+	if ID =~ "^.*to-a-intra-node-.*$" {
+		_affinity: "echo-a"
+	}
+	if ID =~ "^.*to-a-multi-node-.*$" {
+		_antiAffinity: "echo-a"
+	}
+	if ID =~ "^.*to-b-intra-node-.*$" {
+		_affinity: "echo-b"
+	}
+	if ID =~ "^.*to-b-multi-node-.*$" {
+		_antiAffinity: "echo-b"
+	}
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -59,6 +59,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **COLLADA:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)
 - **CSON:** [atom/language-coffee-script](https://github.com/atom/language-coffee-script)
 - **CSS:** [atom/language-css](https://github.com/atom/language-css)
+- **CUE:** [betawaffle/vscode-cue](https://github.com/betawaffle/vscode-cue)
 - **Cabal Config:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
 - **Cap'n Proto:** [textmate/capnproto.tmbundle](https://github.com/textmate/capnproto.tmbundle)
 - **CartoCSS:** [yohanboniface/carto-atom](https://github.com/yohanboniface/carto-atom)

--- a/vendor/licenses/grammar/vscode-cue.txt
+++ b/vendor/licenses/grammar/vscode-cue.txt
@@ -1,0 +1,6 @@
+---
+type: grammar
+name: vscode-cue
+version: a003fa43ce38348c28c0ce3f6b017d43c83f1dfc
+license: 
+---


### PR DESCRIPTION
This PR adds support for [the CUE language](https://cuelang.org/).

Draft because there is [another language using `.cue`](https://github.com/search?q=extension%3Acue+NOT+package), likely cue sheet. I will need to add a heuristic.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?q=extension%3Acue+package
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/cilium/cilium/blob/b7ffa0eb1fb9c59834c95f811c32eed1b4631f27/examples/kubernetes/connectivity-check/defaults.cue
    - Sample license(s): Apache v2.0 License
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fbetawaffle%2Fvscode-cue%2Fblob%2Fmaster%2Fsyntaxes%2Fcue.tmLanguage.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fcilium%2Fcilium%2Fblob%2Fb7ffa0eb1fb9c59834c95f811c32eed1b4631f27%2Fexamples%2Fkubernetes%2Fconnectivity-check%2Fdefaults.cue&code=
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.