### PR TITLE
Add .dock extension to Dockerfile

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1183,6 +1183,7 @@ Dockerfile:
   tm_scope: source.dockerfile
   extensions:
   - ".dockerfile"
+  - ".dock"
   filenames:
   - Dockerfile
   ace_mode: dockerfile

--- a/samples/Dockerfile/compiler-zoo.Dockerfile
+++ b/samples/Dockerfile/compiler-zoo.Dockerfile
@@ -1,0 +1,38 @@
+#===- libcxx/utils/docker/debian9/Dockerfile --------------------------------------------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-------------------------------------------------------------------------------------------===//
+
+#===-------------------------------------------------------------------------------------------===//
+#  compiler-zoo
+#===-------------------------------------------------------------------------------------------===//
+FROM  ericwf/llvm-builder-base:latest AS compiler-zoo
+LABEL maintainer "libc++ Developers"
+
+# Copy over the GCC and Clang installations
+COPY --from=ericwf/compiler:gcc-4.8.5 /opt/gcc-4.8.5 /opt/gcc-4.8.5
+COPY --from=ericwf/compiler:gcc-4.9.4 /opt/gcc-4.9.4 /opt/gcc-4.9.4
+COPY --from=ericwf/compiler:gcc-5 /opt/gcc-5   /opt/gcc-5
+COPY --from=ericwf/compiler:gcc-6 /opt/gcc-6   /opt/gcc-6
+COPY --from=ericwf/compiler:gcc-7 /opt/gcc-7   /opt/gcc-7
+COPY --from=ericwf/compiler:gcc-8 /opt/gcc-8   /opt/gcc-8
+COPY --from=ericwf/compiler:gcc-9 /opt/gcc-9   /opt/gcc-9
+COPY --from=ericwf/compiler:gcc-tot /opt/gcc-tot /opt/gcc-tot
+
+COPY --from=ericwf/compiler:llvm-3.6 /opt/llvm-3.6 /opt/llvm-3.6
+COPY --from=ericwf/compiler:llvm-3.7 /opt/llvm-3.7 /opt/llvm-3.7
+COPY --from=ericwf/compiler:llvm-3.8 /opt/llvm-3.8 /opt/llvm-3.8
+COPY --from=ericwf/compiler:llvm-3.9 /opt/llvm-3.9 /opt/llvm-3.9
+COPY --from=ericwf/compiler:llvm-4 /opt/llvm-4 /opt/llvm-4
+COPY --from=ericwf/compiler:llvm-5 /opt/llvm-5 /opt/llvm-5
+COPY --from=ericwf/compiler:llvm-6 /opt/llvm-6 /opt/llvm-6
+COPY --from=ericwf/compiler:llvm-7 /opt/llvm-7 /opt/llvm-7
+COPY --from=ericwf/compiler:llvm-8 /opt/llvm-8 /opt/llvm-8
+COPY --from=ericwf/compiler:llvm-9 /opt/llvm-9 /opt/llvm-9
+COPY --from=ericwf/compiler:llvm-tot /opt/llvm-tot /opt/llvm-tot
+
+
+

--- a/samples/Dockerfile/gnuradio.dock
+++ b/samples/Dockerfile/gnuradio.dock
@@ -1,0 +1,29 @@
+#The MIT License (MIT)
+#
+#Copyright (c) 2015 Elliot Briggs
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+#
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+
+FROM ubuntu:14.04.1
+MAINTAINER Elliot Briggs <elliot.briggs@gmail.com>
+RUN apt-get update; apt-get upgrade
+RUN apt-get install -y build-essential git python cmake
+RUN mkdir /opt/github/; cd /opt/github/; git clone https://github.com/pybombs/pybombs.git
+RUN printf "[config]\ngituser = \nprefix = /usr/local/ \nsatisfy_order = deb,src\nforcepkgs = cmake,git,python\nforcebuild = gnuradio,uhd,gr-air-modes,gr-osmosdr,gr-iqbal,gr-fcdproplus,uhd,rtl-sdr,osmo-sdr,hackrf,gqrx,bladerf,airspy\ntimeout = 30\ncmakebuildtype = RelWithDebInfo\nbuilddocs = OFF\ncc = gcc\ncxx = g++\nmakewidth = 4" > /opt/github/pybombs/config.dat 
+RUN cd /opt/github/pybombs/; ./pybombs install gnuradio


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Add .dock extension to dockerfile

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
https://github.com/search?q=extension%3Adock+from&type=
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
https://github.com/teiryu/llvm/blob/4050b01ba9ece02721ec496383baee219ca8cc2b/libcxx/utils/docker/debian9/compilers/compiler-zoo.Dockerfile
https://github.com/hamgravy/dockerpile/blob/d90f883af617266c97d2d0bb4206042ee8f1cf65/gnuradio.dock
    - Sample license(s):
Apache License v2.0 (in the file)
MIT License (in the file)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
Does not apply