### PR TITLE
Add .j2 extension to Django+HTML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2027,6 +2027,7 @@ HTML+Django:
   group: HTML
   extensions:
   - ".jinja"
+  - ".j2"
   - ".jinja2"
   - ".mustache"
   - ".njk"

--- a/samples/HTML+Django/home.j2
+++ b/samples/HTML+Django/home.j2
@@ -1,0 +1,66 @@
+{% extends "bootstrap/base.html" %}
+{% block title %}OAuth Helper - Home{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row pt-5"><h1>OAuth Client Helper</h1></div>
+    <p>This is here to help make getting, setting and pushing OAuth tokens easier</p>
+    <p>TODO: add some more notes about WTF is actually going on here....</p>
+
+    <a class="btn btn-primary" href="/add-client" role="button">New Client ID</a>
+
+    <hr>
+
+    <h3>List of current clients configured and status summary</h3>
+    {% if 'client_id' in colnames %}
+    {# <pre><code>{{ client_data }}</code></pre> #}
+    <table class="table table-hover w-auto small">
+        <thead>
+            <tr>
+                {# First column is always client_id #}
+                <th scope="col">client_id</th>
+                {% set col_client_index = colnames.index('client_id') %}
+                {% for col in colnames %}
+                {% if col != "client_id" %}
+                {# Skipping the client_id column because we already added it #}
+                <th scope="col">{{ col }}</th>
+                {% endif %}
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for client_id_list in data[0] %}
+            {% set outer_loop = loop %}
+            <tr>
+                {# First column is always client_id #}
+                <td><a href="/client-detail/{{ data[col_client_index][loop.index0] }}">{{ data[col_client_index][loop.index0] }}</a></td>
+                {% for item in data %}
+                {% if colnames[loop.index0] == 'client_id' %}
+                {# nothing #}
+                {% elif colnames[loop.index0] == 'qs_params'%}
+                <td>
+                    {% if item[outer_loop.index0] is mapping %}
+                    <ul class="list-group">
+                        {% for key, val in item[outer_loop.index0].items() %}
+                        <li><code><pre>{{key}}: '{{val}}'</pre></code></li>
+                        {% endfor %}
+                    </ul>
+                    {% else %}
+                    None
+                    {% endif %}
+                </td>
+                {% else %}
+                <td>{{ item[outer_loop.index0] }}</td>
+                {% endif %}
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    {# Seems there's no data #}
+    <p>No Data</p>
+    {% endif %}
+
+</div>
+{% endblock %}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Add .j2 extension to Django+HTML

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
https://github.com/search?p=3&q=extension%3Aj2+div&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
https://raw.githubusercontent.com/dedfriedly-inspirdev/oauth-client-helper/master/src/oauth_client/templates/home.j2
    - Sample license(s):
https://github.com/dedfriedly-inspirdev/oauth-client-helper/blob/master/LICENSE
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
Does not apply