### PR TITLE
Add nodejs interpreter to node

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2579,6 +2579,7 @@ JavaScript:
   - gjs
   - js
   - node
+  - nodejs
   - qjs
   - rhino
   - v8


### PR DESCRIPTION
On Ubuntu the binary is often called nodejs 🤷 