### PR TITLE
Associate .simplecov file with Ruby

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4805,6 +4805,7 @@ Ruby:
   filenames:
   - ".irbrc"
   - ".pryrc"
+  - ".simplecov"
   - Appraisals
   - Berksfile
   - Brewfile

--- a/samples/Ruby/filenames/.simplecov
+++ b/samples/Ruby/filenames/.simplecov
@@ -1,0 +1,7 @@
+SimpleCov.add_group 'db', '/lib/mygem/db/'
+SimpleCov.add_group 'utils', '/lib/mygem/utils/'
+SimpleCov.add_group 'spec', '/spec/'
+
+SimpleCov.coverage_dir ENV.fetch('COVERAGE_DIR', 'coverage')
+SimpleCov.command_name $PROGRAM_NAME
+SimpleCov.merge_timeout 3600


### PR DESCRIPTION
Associate the [`.simplecov` configuration file](https://github.com/simplecov-ruby/simplecov/blame/9cd3a46169943f2c79d688d96e93871cd7febe2d/README.md#L267-L287) to the Ruby language.

## Description

`.simplecov` files are [loaded as Ruby source code](https://github.com/simplecov-ruby/simplecov/blob/80700ec9f9b5ae426c22d06f62620f7e7b71ff42/lib/simplecov/defaults.rb#L36-L41), thus must contain valid Ruby syntax.

They are currently unhighlighted for the most part: https://github.com/search?q=filename%3A.simplecov

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file name.**
  - [x] The new file name is used in hundreds of repositories on GitHub.com
    - Search results for each file name:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=filename%3A.simplecov
  - [x] I have included a real-world usage sample for all file names added in this PR:
    - Sample source(s): `samples/Ruby/filenames/.simplecov`
    - Sample license(s): My own project. I agree to publish `samples/Ruby/filenames/.simplecov` under MIT.