### PR TITLE
Omit whitespace when generating JSON artefacts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ end
 
 task :samples => :compile do
   require 'linguist/samples'
-  json = Yajl.dump(Linguist::Samples.data, :pretty => true)
+  json = Yajl.dump(Linguist::Samples.data, :pretty => false)
   File.write 'lib/linguist/samples.json', json
 end
 

--- a/tools/grammars/compiler/converter.go
+++ b/tools/grammars/compiler/converter.go
@@ -186,7 +186,6 @@ func (conv *Converter) writeJSONFile(path string, rule *grammar.Rule) error {
 	defer j.Close()
 
 	enc := json.NewEncoder(j)
-	enc.SetIndent("", "  ")
 	return enc.Encode(rule)
 }
 


### PR DESCRIPTION
I'm not sure why Linguist ships with "pretty"-printed JSON files (shock quotes used, because 2-space indents are NOT pretty). If whitespace is omitted, several megabytes are shaved off the (unpacked) JSON files:

~~~
linguist-grammars.tar.gz (unpacked)  12 MBs  => 8.3 MBs
lib/linguist/samples.json            4.3 MBs => 2.7 MBs
~~~

These files aren't intended for human consumption, so I've no idea why they're being generated that way on purpose. If somebody *does* need to browse their contents, reformatting JSON is trivial to do in anything with a JavaScript engine attached:

~~~js
JSON.stringify(JSON.parse(jsonSourceCode), null, "\t");

// Or if you like to pretend an arbitrarily-long bunch of spaces is a tab:

JSON.stringify(JSON.parse(jsonSourceCode), null, pickHowManySpacesYouLikeSweetheart);
~~~

*Template removed as it doesn't apply.*