### PR TITLE
Update CI: Add Ruby 2.7, remove 2.4 and cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.6.x', '2.5.x', '2.4.x' ]
+        ruby: [ '2.7.x', '2.6.x', '2.5.x' ]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
         ruby: [ '2.7.x', '2.6.x', '2.5.x' ]
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

General CI improvements:

- Added testing against Ruby 2.7 as it is now generally available and in full use on GitHub.com.
- Removed testing against Ruby 2.4 is it now EOL.
- Added dependency caching to speed up CI a little bit in future.

_Template removed as it doesn't apply_