### PR TITLE
Update list of popular languages

### DIFF
--- a/lib/linguist/popular.yml
+++ b/lib/linguist/popular.yml
@@ -2,28 +2,28 @@
 #
 # This file should only be edited by GitHub staff
 
-- ActionScript
 - C
 - C#
 - C++
-- CSS
-- Clojure
 - CoffeeScript
+- CSS
+- Dart
+- DM
+- Elixir
 - Go
+- Groovy
 - HTML
-- Haskell
 - Java
 - JavaScript
-- Lua
-- MATLAB
+- Kotlin
 - Objective-C
-- PHP
 - Perl
+- PHP
+- PowerShell
 - Python
-- R
 - Ruby
+- Rust
 - Scala
 - Shell
 - Swift
-- TeX
-- Vim script
+- TypeScript


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

As per the title, this updates the list of popular languages to those most popular today. The list was last updated over 6 years ago in https://github.com/github/linguist/pull/2207.

Fixes https://github.com/github/linguist/issues/4966

_Template removed as it doesn't apply_