### PR TITLE
Add CODEOWNERS and update maintainers list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# All pull requests need to be reviewed by someone from GitHub.
+# @github/linguist is a GitHub maintained team.
+#
+*     @github/linguist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,13 +191,9 @@ Here's our current build status: [![Actions Status](https://github.com/github/li
 Linguist is maintained with :heart: by:
 
 - **@Alhadis**
-- **@BenEddy** (GitHub staff)
-- **@Caged** (GitHub staff)
 - **@larsbrinkhoff**
 - **@lildude** (GitHub staff)
 - **@pchaigno**
-- **@rafer** (GitHub staff)
-- **@shreyasjoshis** (GitHub staff)
 
 As Linguist is a production dependency for GitHub we have a couple of workflow restrictions:
 


### PR DESCRIPTION
## Description

This PR adds a CODEOWNERS file to require an approval on all PRs from someone in GitHub's @github/linguist team - currently only me but this will change eventually.

I've also updated the list of maintainers in the CONTRIBUTING.md file.

_Template removed as it doesn't apply_