### PR TITLE
Add `.exrc` to Vim script filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5892,6 +5892,7 @@ Vim script:
   - ".vba"
   - ".vmb"
   filenames:
+  - ".exrc"
   - ".gvimrc"
   - ".nvimrc"
   - ".vimrc"

--- a/samples/Vim script/filenames/.exrc
+++ b/samples/Vim script/filenames/.exrc
@@ -1,0 +1,11 @@
+set extended
+set iclower
+set leftright
+set report=1
+set ruler
+set searchincr
+set shiftwidth=4
+set showmatch
+set showmode
+set tabstop=4
+set verbose


### PR DESCRIPTION
## Description
Some low-hanging fruit before we launch the next Linguist release.

[`.exrc`](http://man.openbsd.org/ex#FILES) is the configuration file loaded by `vi(1)` and `ex(1)`, neither of which should need an introduction.

## Checklist:
- [x] **I am associating a language with a new filename**
	- [x] **The new filename is used in hundreds of repositories**
		- [~5,301](https://github.com/search?q=filename%3Aexrc+NOT+nothack&type=Code) results
	- [x] **I have included a real-world usage sample:**
		- My own `vi(1)` settings on OpenBSD (though I never committed them to version control, for some reason…)
