### PR TITLE
Re-add removed colour attributes

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -303,6 +303,7 @@ Apex:
   language_id: 17
 Apollo Guidance Computer:
   type: programming
+  color: "#0B3D91"
   group: Assembly
   extensions:
   - ".agc"
@@ -470,6 +471,7 @@ BibTeX:
   language_id: 982188347
 Bison:
   type: programming
+  color: "#6A463F"
   group: Yacc
   tm_scope: source.yacc
   extensions:
@@ -905,6 +907,7 @@ ColdFusion:
   language_id: 64
 ColdFusion CFC:
   type: programming
+  color: "#ed2cd6"
   group: ColdFusion
   ace_mode: coldfusion
   aliases:
@@ -1276,6 +1279,7 @@ ECLiPSe:
   language_id: 94
 EJS:
   type: markup
+  color: "#a91e50"
   group: HTML
   extensions:
   - ".ejs"
@@ -2419,6 +2423,7 @@ J:
   language_id: 172
 JFlex:
   type: programming
+  color: "#DBCA00"
   group: Lex
   extensions:
   - ".flex"
@@ -3626,6 +3631,7 @@ Nu:
   language_id: 253
 NumPy:
   type: programming
+  color: "#9C8AF9"
   group: Python
   extensions:
   - ".numpy"
@@ -5708,6 +5714,7 @@ TypeScript:
   language_id: 378
 Unified Parallel C:
   type: programming
+  color: "#4e3617"
   group: C
   ace_mode: c_cpp
   codemirror_mode: clike


### PR DESCRIPTION
## Description

Reverts https://github.com/github/linguist/pull/3280 as no longer necessary with the latest Linguist version and changes in GitHub's language UI. Most were already reverted by the PR that landed in the current release.

I checked Apollo Guidance Computer after release and saw it was now (well for ~3 years) grey instead of blue 😛

## Checklist:
- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - N/A - these were already colours in Linguist that were removed for being data languages (now shown in GitHub UI since removal PR) or conflicting with more popular languages' colour proximity (removed in latest version)