### PR TITLE
Add common .vscode config filenames as JSON with Comments

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2489,8 +2489,12 @@ JSON with Comments:
   - ".jscsrc"
   - ".jshintrc"
   - ".jslintrc"
+  - extensions.json
   - jsconfig.json
   - language-configuration.json
+  - launch.json
+  - settings.json
+  - tasks.json
   - tsconfig.json
   - tslint.json
   language_id: 423

--- a/samples/JSON with Comments/filenames/extensions.json
+++ b/samples/JSON with Comments/filenames/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/samples/JSON with Comments/filenames/launch.json
+++ b/samples/JSON with Comments/filenames/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${file}"
+        }
+    ]
+}

--- a/samples/JSON with Comments/filenames/settings.json
+++ b/samples/JSON with Comments/filenames/settings.json
@@ -1,0 +1,16 @@
+{
+	// Controls whether the editor shows CodeLens.
+	"diffEditor.codeLens": false,
+
+	// When enabled, the diff editor ignores changes in leading or trailing whitespace.
+	"diffEditor.ignoreTrimWhitespace": true,
+
+	// Timeout in milliseconds after which diff computation is cancelled. Use 0 for no timeout.
+	"diffEditor.maxComputationTime": 5000,
+
+	// Controls whether the diff editor shows +/- indicators for added/removed changes.
+	"diffEditor.renderIndicators": true,
+
+	// Controls whether the diff editor shows the diff side by side or inline.
+    "diffEditor.renderSideBySide": true
+}

--- a/samples/JSON with Comments/filenames/tasks.json
+++ b/samples/JSON with Comments/filenames/tasks.json
@@ -1,0 +1,24 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
Visual Studio Code uses/generates several JSON with Comments config files under folders named `.vscode` with fixed names and a `.json` extension. This PR registers them as "JSON with Comments" instead of the current "JSON".

## Description
Checking in these `.vscode` configs is extremely common (>100k search results each), but some of these filenames are pretty generic and overlap with non-vscode scenarios that might not support comments, so I don't think it would be unreasonable to push back on this PR looking for it to use something that more specifically looks for these files underneath `.vscode` folders.

I wanted to send out the simple version first to start any discussion about that before writing code for it, since that sort of path-based heuristic for language detection didn't seem to fit the pattern of any of the existing languages (though it does match vendor-detection). I would want to use a path-based heuristic for this rather than a content-based heuristic if we wanted to be more specific; particularly, I would want to avoid adding a `heuristics.yml` entry for `.json` that's based on the presence of `//` or `/*` tokens, because I think "a developer uses a comment in a JSON file that *doesn't* support it" is likely to be such a common error that it makes sense for us to highlight it in pull requests if we aren't extremely confident that the file really does support comments.

Manaully looking over the first ~10 pages of search results for [`extension:json in:path "settings.json" NOT nothack`](https://github.com/search?p=6&q=extension%3Ajson+in%3Apath+%22settings.json%22+NOT+nothack&type=Code), it looks like about 80% of results are VS Code config files, and about 20% are a varied assortment of others. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new ~file extension~ filenames.**
  - [x] The new ~extension~ filenames are used in hundreds of repositories on GitHub.com
    - Search results for each ~extension~ case:
      - All .vscode JSON files: https://github.com/search?q=extension%3Ajson+in%3Apath+.vscode+NOT+nothack&type=Code
      - launch.json: https://github.com/search?p=6&q=extension%3Ajson+in%3Apath+%22launch.json%22+NOT+nothack&type=Code
      - extensions.json: https://github.com/search?p=6&q=extension%3Ajson+in%3Apath+%22extensions.json%22+NOT+nothack&type=Code
      - settings.json: https://github.com/search?p=6&q=extension%3Ajson+in%3Apath+%22settings.json%22+NOT+nothack&type=Code
      - tasks.json: https://github.com/search?p=6&q=extension%3Ajson+in%3Apath+%22tasks.json%22+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all ~extensions~ cases added in this PR:
    - Sample source(s):
      - `extensions.json`: default generated by VS Code ([generator source](https://github.com/microsoft/vscode/blob/a45fa6ed50858306e5510742414887371d218a52/src/vs/workbench/contrib/extensions/common/extensionsFileTemplate.ts#L40))
      - `launch.json`: default generated by VS Code for a node project ([generator source](https://github.com/microsoft/vscode/blob/f74e473238aca7b79c08be761d99a0232838ca4c/src/vs/workbench/contrib/debug/common/debugger.ts#L148))
      - `settings.json`: a snippet of the default output from the VS Code "Preferences: Open Default Settings (JSON)" command, contents of which is generated ([generator source](https://github.com/microsoft/vscode/blob/f74e473238aca7b79c08be761d99a0232838ca4c/src/vs/editor/common/config/commonEditorConfig.ts#L457))
      - `tasks.json`: default generated by VS Code for a dotnet build ([generator source](https://github.com/microsoft/vscode/blob/f74e473238aca7b79c08be761d99a0232838ca4c/src/vs/workbench/contrib/tasks/common/taskTemplates.ts#L16))
    - Sample license(s):
      - All samples are generated by default configuration of VS Code, which uses the [MIT license](https://github.com/microsoft/vscode/blob/master/LICENSE.txt)
  - [n/a] I have included a change to the heuristics to distinguish my language from others using the same extension.
