### PR TITLE
Add GraphQL color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1954,6 +1954,7 @@ Graph Modeling Language:
   language_id: 138
 GraphQL:
   type: data
+  color: "#e10098"
   extensions:
   - ".graphql"
   - ".gql"


### PR DESCRIPTION
## Description

Adds a color to `GraphQL`.

The color is `#e10098` which is a color from the GraphQL logo.

https://graphql.org/

## Checklist:

- [x] **I am changing the color associated with a language**
  - [ ] I have obtained agreement from the wider language community on this color change.
    - #general-tech channel on ReactiFlux Discord (http://join.reactiflux.com/)
    - Channel message link (https://discordapp.com/channels/102860784329052160/547620660482932737/753701937689526365)

The reason I'm not checking is because I'll wait for more people to give their opinion