### PR TITLE
Add Unix Assembly samples

### DIFF
--- a/samples/Unix Assembly/gemm_kernel_1x4.S
+++ b/samples/Unix Assembly/gemm_kernel_1x4.S
@@ -1,0 +1,907 @@
+/*********************************************************************/
+/* Copyright 2009, 2010 The University of Texas at Austin.           */
+/* All rights reserved.                                              */
+/*                                                                   */
+/* Redistribution and use in source and binary forms, with or        */
+/* without modification, are permitted provided that the following   */
+/* conditions are met:                                               */
+/*                                                                   */
+/*   1. Redistributions of source code must retain the above         */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer.                                                  */
+/*                                                                   */
+/*   2. Redistributions in binary form must reproduce the above      */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer in the documentation and/or other materials       */
+/*      provided with the distribution.                              */
+/*                                                                   */
+/*    THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT    */
+/*    AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,    */
+/*    INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF    */
+/*    MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE    */
+/*    DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT    */
+/*    AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,    */
+/*    INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES    */
+/*    (INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE    */
+/*    GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR    */
+/*    BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF    */
+/*    LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT    */
+/*    (INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT    */
+/*    OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE    */
+/*    POSSIBILITY OF SUCH DAMAGE.                                    */
+/*                                                                   */
+/* The views and conclusions contained in the software and           */
+/* documentation are those of the authors and should not be          */
+/* interpreted as representing official policies, either expressed   */
+/* or implied, of The University of Texas at Austin.                 */
+/*********************************************************************/
+
+#define ASSEMBLER
+#include "common.h"
+
+#define STACK	16
+#define ARGS	16
+
+#define J	 0 + STACK(%esp)
+#define I	 4 + STACK(%esp)
+#define KK	 8 + STACK(%esp)
+#define KKK	12 + STACK(%esp)
+
+#define M	 4 + STACK + ARGS(%esp)
+#define N	 8 + STACK + ARGS(%esp)
+#define K	12 + STACK + ARGS(%esp)
+#define ALPHA	16 + STACK + ARGS(%esp)
+#ifdef DOUBLE
+#define STACK_A	24 + STACK + ARGS(%esp)
+#define STACK_B	28 + STACK + ARGS(%esp)
+#define C	32 + STACK + ARGS(%esp)
+#define STACK_LDC	36 + STACK + ARGS(%esp)
+#define OFFSET	40 + STACK + ARGS(%esp)
+#else
+#define STACK_A	20 + STACK + ARGS(%esp)
+#define STACK_B	24 + STACK + ARGS(%esp)
+#define C	28 + STACK + ARGS(%esp)
+#define STACK_LDC	32 + STACK + ARGS(%esp)
+#define OFFSET	36 + STACK + ARGS(%esp)
+#endif
+
+#define A	%edx
+#define B	%ecx
+#define BB	%ebx
+#define LDC	%ebp
+#define BX	%esi
+
+#define PREFETCHSIZE (8 * 5 + 4)
+
+#define AOFFSET   1
+#define BOFFSET  -7
+
+#ifdef HAVE_3DNOW
+#define PREFETCH	prefetch
+#else
+#define PREFETCH	prefetcht0
+#endif
+
+#define KERNEL \
+	PREFETCH	PREFETCHSIZE * SIZE + AOFFSET(A, %eax, 1);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	-15 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	-14 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	-13 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	-15 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	-12 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	-11 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	-10 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 -9 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	-14 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	 -8 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	 -7 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 -6 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 -5 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	-13 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	 -4 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	 -3 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 -2 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 -1 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	-12 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	  0 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	  1 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	  2 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	  3 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	-11 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	  4 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	  5 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	  6 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	  7 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	-10 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	  8 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	  9 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 10 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 11 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -9 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	 12 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	 13 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 14 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 15 * SIZE + BOFFSET(B, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	  8 * SIZE + AOFFSET(A, %eax, 1);\
+	fxch	%st(1);\
+	FLD	 16 * SIZE + BOFFSET(B, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	-15 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	PREFETCH	(PREFETCHSIZE + 8) * SIZE + AOFFSET(A, %eax, 1);\
+	faddp	%st, %st(5);\
+	FLD	-14 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	-13 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -7 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	-12 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	-11 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	-10 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 -9 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -6 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	 -8 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	 -7 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 -6 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 -5 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -5 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	 -4 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	 -3 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 -2 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 -1 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -4 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	  0 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	  1 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	  2 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	  3 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -3 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	  4 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	  5 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	  6 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	  7 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -2 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	  8 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	  9 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 10 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 11 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 -1 * SIZE + AOFFSET(A, %eax, 1);\
+	FLD	 12 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(4);\
+	FLD	 13 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(5);\
+	FLD	 14 * SIZE + BOFFSET(BB, %eax, 4);\
+	fmul	%st(1), %st;\
+	faddp	%st, %st(6);\
+	FMUL	 15 * SIZE + BOFFSET(BB, %eax, 4);\
+	faddp	%st, %st(6);\
+	FLD	 16 * SIZE + AOFFSET(A, %eax, 1);\
+	fxch	%st(2);\
+	FLD	 16 * SIZE + BOFFSET(BB, %eax, 4);\
+	subl	 $-16 * SIZE, %eax
+
+/*
+
+  A hint of scheduling is received from following URL
+
+  http://www.netlib.org/atlas/atlas-comm/msg00260.html
+
+*/
+
+	PROLOGUE
+
+	subl	$ARGS, %esp	# Generate Stack Frame
+
+	pushl	%ebp
+	pushl	%edi
+	pushl	%esi
+	pushl	%ebx
+
+	PROFCODE
+
+#if defined(TRMMKERNEL) && !defined(LEFT)
+	movl	OFFSET, %eax
+	negl	%eax
+	movl	%eax, KK
+#endif
+
+	movl	STACK_LDC, LDC
+	leal	(, LDC, SIZE), LDC
+
+	subl	$(AOFFSET - 16 * SIZE), STACK_A
+	subl	$(BOFFSET - 16 * SIZE), STACK_B
+
+	movl	M, %eax
+	testl	%eax, %eax
+	jle	.L999
+
+	movl	N, %eax
+	testl	%eax, %eax
+	jle	.L999
+
+	movl	K, %eax
+	testl	%eax, %eax
+	jle	.L999
+
+	movl	N,   %eax
+	sarl	$2,  %eax
+	movl	%eax, J
+	je	.L20
+	ALIGN_3
+
+.L11:
+#if defined(TRMMKERNEL) && defined(LEFT)
+	movl	OFFSET, %eax
+	movl	%eax, KK
+#endif
+
+	movl	STACK_A, A
+	movl	STACK_B, B
+	movl	C, %edi
+
+	movl	K, BX
+	sall	$BASE_SHIFT + 2, BX
+	addl	B, BX
+
+	movl	M, %eax
+	movl	%eax, I
+	ALIGN_3
+
+.L14:
+	prefetchnta	-16 * SIZE + BOFFSET(BX)
+	subl	$-8 * SIZE, BX
+
+	movl	STACK_B, B
+
+#if !defined(TRMMKERNEL) || \
+	(defined(TRMMKERNEL) &&  defined(LEFT) &&  defined(TRANSA)) || \
+	(defined(TRMMKERNEL) && !defined(LEFT) && !defined(TRANSA))
+#else
+	movl	KK,   %eax
+	leal	(, %eax, SIZE), %eax
+	leal	(A, %eax, 1), A
+	leal	(B, %eax, 4), B
+#endif
+
+	leal	(%edi, LDC, 2), %eax
+
+	fldz
+	fldz
+	fldz
+	fldz
+
+	FLD	   0 * SIZE + AOFFSET(A)
+	FLD	  -8 * SIZE + AOFFSET(A)
+	FLD	 -16 * SIZE + AOFFSET(A)
+	FLD	 -16 * SIZE + BOFFSET(B)
+
+#ifdef HAVE_3DNOW
+	prefetchw	1 * SIZE(%edi)
+	prefetchw	2 * SIZE(%edi, LDC)
+	prefetchw	1 * SIZE(%eax)
+	prefetchw	2 * SIZE(%eax, LDC)
+#elif defined(HAVE_SSE)
+	prefetcht0	1 * SIZE(%edi)
+	prefetcht0	2 * SIZE(%edi, LDC)
+	prefetcht0	1 * SIZE(%eax)
+	prefetcht0	2 * SIZE(%eax, LDC)
+#endif
+
+#ifndef TRMMKERNEL
+	movl	K,  %eax
+#elif (defined(LEFT) && !defined(TRANSA)) || (!defined(LEFT) && defined(TRANSA))
+	movl	K, %eax
+	subl	KK, %eax
+	movl	%eax, KKK
+#else
+	movl	KK, %eax
+#ifdef LEFT
+	addl	$1, %eax
+#else
+	addl	$4, %eax
+#endif
+	movl	%eax, KKK
+#endif
+
+	andl	$-16, %eax
+
+	leal	(, %eax, SIZE), %eax
+	leal	(A, %eax, 1), A
+	leal	32 * SIZE(B, %eax, 4), BB
+	leal	(B, %eax, 4), B
+	negl	%eax
+	NOBRANCH
+ 	je	.L16
+	ALIGN_4
+
+.L15:
+	KERNEL
+	jge	.L16
+	KERNEL
+	jge	.L16
+	KERNEL
+	jge	.L16
+	KERNEL
+	jl	.L15
+	ALIGN_4
+
+.L16:
+#ifndef TRMMKERNEL
+	movl	K, %eax
+#else
+	movl	KKK, %eax
+#endif
+	and	$15, %eax
+	je	.L19
+	ALIGN_4
+
+.L17:
+	fmul	%st(1), %st
+	faddp	%st, %st(4)
+
+	FLD	-15 * SIZE + BOFFSET(B)
+	fmul	%st(1), %st
+	faddp	%st, %st(5)
+
+	FLD	-14 * SIZE + BOFFSET(B)
+	fmul	%st(1), %st
+	faddp	%st, %st(6)
+
+	FMUL	-13 * SIZE + BOFFSET(B)
+	faddp	%st, %st(6)
+	FLD	-15 * SIZE + AOFFSET(A)
+	FLD	-12 * SIZE + BOFFSET(B)
+
+	addl	$1 * SIZE,A
+	addl	$4 * SIZE,B
+
+	decl	%eax
+	jne	 .L17
+	ALIGN_4
+
+.L19:
+	ffreep	%st(0)
+	ffreep	%st(0)
+	ffreep	%st(0)
+	ffreep	%st(0)
+
+	FLD	ALPHA
+
+	fmul	%st, %st(1)
+	fmul	%st, %st(2)
+	fmul	%st, %st(3)
+	fmulp	%st, %st(4)
+
+	leal	(%edi, LDC, 2), %eax
+
+#ifndef TRMMKERNEL
+	FADD	(%edi)
+	FST	(%edi)
+	FADD	(%edi,LDC)
+	FST	(%edi,LDC)
+	FADD	(%eax)
+	FST	(%eax)
+	FADD	(%eax,LDC)
+	FST	(%eax,LDC)
+#else
+	FST	(%edi)
+	FST	(%edi,LDC)
+	FST	(%eax)
+	FST	(%eax,LDC)
+#endif
+
+#if (defined(TRMMKERNEL) &&  defined(LEFT) &&  defined(TRANSA)) || \
+    (defined(TRMMKERNEL) && !defined(LEFT) && !defined(TRANSA))
+	movl	K, %eax
+	subl	KKK, %eax
+	leal	(,%eax, SIZE), %eax
+	leal	(A, %eax, 1), A
+	leal	(B, %eax, 4), B
+#endif
+
+#if defined(TRMMKERNEL) && defined(LEFT)
+	addl	$1, KK
+#endif
+
+	addl	$1 * SIZE, %edi
+	decl	I
+	jne	.L14
+
+#if defined(TRMMKERNEL) && !defined(LEFT)
+	addl	$4, KK
+#endif
+
+	leal	(, LDC, 4), %eax
+	addl	%eax, C
+	movl	B, STACK_B
+	decl	J
+	jne	.L11
+	ALIGN_4
+
+.L20:
+	movl	N,   %eax
+	andl	$2,  %eax
+	je	.L30
+	ALIGN_3
+
+.L21:
+#if defined(TRMMKERNEL) && defined(LEFT)
+	movl	OFFSET, %eax
+	movl	%eax, KK
+#endif
+
+	movl	STACK_A, A
+	movl	STACK_B, B
+	movl	C, %edi
+
+	movl	M, %eax
+	movl	%eax, I
+	ALIGN_3
+
+.L24:
+	movl	STACK_B, B
+
+#if !defined(TRMMKERNEL) || \
+	(defined(TRMMKERNEL) &&  defined(LEFT) &&  defined(TRANSA)) || \
+	(defined(TRMMKERNEL) && !defined(LEFT) && !defined(TRANSA))
+#else
+	movl	KK,   %eax
+	leal	(, %eax, SIZE), %eax
+	leal	(A, %eax, 1), A
+	leal	(B, %eax, 2), B
+#endif
+
+	fldz
+	fldz
+	fldz
+	fldz
+
+	FLD	 -16 * SIZE + AOFFSET(A)
+	FLD	 -16 * SIZE + BOFFSET(B)
+
+	prefetchw	1 * SIZE(%edi)
+	prefetchw	1 * SIZE(%edi, LDC)
+
+#ifndef TRMMKERNEL
+	movl	K,  %eax
+#elif (defined(LEFT) && !defined(TRANSA)) || (!defined(LEFT) && defined(TRANSA))
+	movl	K, %eax
+	subl	KK, %eax
+	movl	%eax, KKK
+#else
+	movl	KK, %eax
+#ifdef LEFT
+	addl	$1, %eax
+#else
+	addl	$2, %eax
+#endif
+	movl	%eax, KKK
+#endif
+	sarl	$3, %eax
+ 	je	.L26
+	ALIGN_3
+
+.L25:
+	fmul	%st(1), %st
+	faddp	%st, %st(2)
+
+	FMUL	-15 * SIZE + BOFFSET(B)
+	faddp	%st, %st(2)
+
+	FLD	-15 * SIZE + AOFFSET(A)
+	FLD	-14 * SIZE + BOFFSET(B)
+
+	fmul	%st(1), %st
+	faddp	%st, %st(4)
+
+	FMUL	-13 * SIZE + BOFFSET(B)
+	faddp	%st, %st(4)
+
+	FLD	-14 * SIZE + AOFFSET(A)
+	FLD	-12 * SIZE + BOFFSET(B)
+
+	fmul	%st(1), %st
+	faddp	%st, %st(2)
+
+	FMUL	-11 * SIZE + BOFFSET(B)
+	faddp	%st, %st(2)
+
+	FLD	-13 * SIZE + AOFFSET(A)
+	FLD	-10 * SIZE + BOFFSET(B)
+
+	fmul	%st(1), %st
+	faddp	%st, %st(4)
+
+	FMUL	 -9 * SIZE + BOFFSET(B)
+	faddp	%st, %st(4)
+
+	FLD	-12 * SIZE + AOFFSET(A)
+	FLD	 -8 * SIZE + BOFFSET(B)
+
+	fmul	%st(1), %st
+	faddp	%st, %st(2)
+
+	FMUL	 -7 * SIZE + BOFFSET(B)
+	faddp	%st, %st(2)
+
+	FLD	-11 * SIZE + AOFFSET(A)
+	FLD	 -6 * SIZE + BOFFSET(B)
+
+	fmul	%st(1), %st
+	faddp	%st, %st(4)
+
+	FMUL	 -5 * SIZE + BOFFSET(B)
+	faddp	%st, %st(4)
+
+	FLD	-10 * SIZE + AOFFSET(A)
+	FLD	 -4 * SIZE + BOFFSET(B)
+
+	fmul	%st(1), %st
+	faddp	%st, %st(2)
+
+	FMUL	 -3 * SIZE + BOFFSET(B)
+	faddp	%st, %st(2)
+
+	FLD	 -9 * SIZE + AOFFSET(A)
+	FLD	 -2 * SIZE + BOFFSET(B)
+
+	fmul	%st(1), %st
+	faddp	%st, %st(4)
+
+	FMUL	 -1 * SIZE + BOFFSET(B)
+	faddp	%st, %st(4)
+
+	FLD	 -8 * SIZE + AOFFSET(A)
+	FLD	  0 * SIZE + BOFFSET(B)
+
+	addl	$  8 * SIZE, A
+	subl	$-16 * SIZE, B
+
+	decl	%eax
+	jne	.L25
+	ALIGN_4
+
+.L26:
+#ifndef TRMMKERNEL
+	movl	K, %eax
+#else
+	movl	KKK, %eax
+#endif
+	and	$7, %eax
+	je	.L29
+	ALIGN_4
+
+.L27:
+	fmul	%st(1), %st
+	faddp	%st, %st(2)
+
+	FMUL	-15 * SIZE + BOFFSET(B)
+	faddp	%st, %st(2)
+
+	FLD	 -15 * SIZE + AOFFSET(A)
+	FLD	 -14 * SIZE + BOFFSET(B)
+
+	addl	$1 * SIZE,A
+	addl	$2 * SIZE,B
+
+	decl	%eax
+	jne	 .L27
+	ALIGN_4
+
+.L29:
+	ffreep	%st(0)
+	ffreep	%st(0)
+
+	faddp	%st, %st(2)
+	faddp	%st, %st(2)
+
+	FLD	ALPHA
+
+	fmul	%st, %st(1)
+	fmulp	%st, %st(2)
+
+#ifndef TRMMKERNEL
+	FADD	(%edi)
+	FST	(%edi)
+	FADD	(%edi,LDC)
+	FST	(%edi,LDC)
+#else
+	FST	(%edi)
+	FST	(%edi,LDC)
+#endif
+
+#if (defined(TRMMKERNEL) &&  defined(LEFT) &&  defined(TRANSA)) || \
+    (defined(TRMMKERNEL) && !defined(LEFT) && !defined(TRANSA))
+	movl	K, %eax
+	subl	KKK, %eax
+	leal	(,%eax, SIZE), %eax
+	leal	(A, %eax, 1), A
+	leal	(B, %eax, 2), B
+#endif
+
+#if defined(TRMMKERNEL) && defined(LEFT)
+	addl	$1, KK
+#endif
+
+	addl	$1 * SIZE, %edi
+	decl	I
+	jne	.L24
+
+#if defined(TRMMKERNEL) && !defined(LEFT)
+	addl	$2, KK
+#endif
+
+	leal	(, LDC, 2), %eax
+	addl	%eax, C
+	movl	B, STACK_B
+	ALIGN_4
+
+.L30:
+	movl	N,   %eax
+	andl	$1,  %eax
+	je	.L999
+	ALIGN_3
+
+.L31:
+#if defined(TRMMKERNEL) && defined(LEFT)
+	movl	OFFSET, %eax
+	movl	%eax, KK
+#endif
+
+	movl	STACK_A, A
+	movl	STACK_B, B
+	movl	C, %edi
+
+	movl	M, %eax
+	movl	%eax, I
+	ALIGN_3
+
+.L34:
+	movl	STACK_B, B
+
+#if !defined(TRMMKERNEL) || \
+	(defined(TRMMKERNEL) &&  defined(LEFT) &&  defined(TRANSA)) || \
+	(defined(TRMMKERNEL) && !defined(LEFT) && !defined(TRANSA))
+#else
+	movl	KK,   %eax
+	leal	(, %eax, SIZE), %eax
+	leal	(A, %eax, 1), A
+	leal	(B, %eax, 1), B
+#endif
+
+	fldz
+	fldz
+	fldz
+	fldz
+
+	prefetchw	1 * SIZE(%edi)
+
+#ifndef TRMMKERNEL
+	movl	K,  %eax
+#elif (defined(LEFT) && !defined(TRANSA)) || (!defined(LEFT) && defined(TRANSA))
+	movl	K, %eax
+	subl	KK, %eax
+	movl	%eax, KKK
+#else
+	movl	KK, %eax
+#ifdef LEFT
+	addl	$1, %eax
+#else
+	addl	$1, %eax
+#endif
+	movl	%eax, KKK
+#endif
+	sarl	$3, %eax
+ 	je	.L36
+	ALIGN_3
+
+.L35:
+	FLD	-16 * SIZE + AOFFSET(A)
+	FMUL	-16 * SIZE + BOFFSET(B)
+	faddp	%st, %st(1)
+
+	FLD	-15 * SIZE + AOFFSET(A)
+	FMUL	-15 * SIZE + BOFFSET(B)
+	faddp	%st, %st(2)
+
+	FLD	-14 * SIZE + AOFFSET(A)
+	FMUL	-14 * SIZE + BOFFSET(B)
+	faddp	%st, %st(3)
+
+	FLD	-13 * SIZE + AOFFSET(A)
+	FMUL	-13 * SIZE + BOFFSET(B)
+	faddp	%st, %st(4)
+
+	FLD	-12 * SIZE + AOFFSET(A)
+	FMUL	-12 * SIZE + BOFFSET(B)
+	faddp	%st, %st(1)
+
+	FLD	-11 * SIZE + AOFFSET(A)
+	FMUL	-11 * SIZE + BOFFSET(B)
+	faddp	%st, %st(2)
+
+	FLD	-10 * SIZE + AOFFSET(A)
+	FMUL	-10 * SIZE + BOFFSET(B)
+	faddp	%st, %st(3)
+
+	FLD	 -9 * SIZE + AOFFSET(A)
+	FMUL	 -9 * SIZE + BOFFSET(B)
+	faddp	%st, %st(4)
+
+	addl	$8 * SIZE, A
+	addl	$8 * SIZE, B
+
+	decl	%eax
+	jne	.L35
+	ALIGN_4
+
+.L36:
+#ifndef TRMMKERNEL
+	movl	K, %eax
+#else
+	movl	KKK, %eax
+#endif
+	and	$7, %eax
+	je	.L39
+	ALIGN_4
+
+.L37:
+	FLD	-16 * SIZE + AOFFSET(A)
+	FMUL	-16 * SIZE + BOFFSET(B)
+	faddp	%st, %st(1)
+
+	addl	$1 * SIZE,A
+	addl	$1 * SIZE,B
+	decl	%eax
+	jne	 .L37
+	ALIGN_4
+
+.L39:
+	faddp	%st, %st(2)
+	faddp	%st, %st(2)
+	faddp	%st, %st(1)
+
+	FMUL	ALPHA
+
+#ifndef TRMMKERNEL
+	FADD	(%edi)
+	FST	(%edi)
+#else
+	FST	(%edi)
+#endif
+
+#if (defined(TRMMKERNEL) &&  defined(LEFT) &&  defined(TRANSA)) || \
+    (defined(TRMMKERNEL) && !defined(LEFT) && !defined(TRANSA))
+	movl	K, %eax
+	subl	KKK, %eax
+	leal	(,%eax, SIZE), %eax
+	leal	(A, %eax, 1), A
+	leal	(B, %eax, 1), B
+#endif
+
+#if defined(TRMMKERNEL) && defined(LEFT)
+	addl	$1, KK
+#endif
+
+	addl	$1 * SIZE, %edi
+	decl	I
+	jne	.L34
+
+#if defined(TRMMKERNEL) && !defined(LEFT)
+	addl	$1, KK
+#endif
+
+	addl	LDC, C
+	movl	B, STACK_B
+	ALIGN_4
+
+.L999:
+	popl	%ebx
+	popl	%esi
+	popl	%edi
+	popl	%ebp
+	addl	$ARGS, %esp
+	ret
+
+	EPILOGUE

--- a/samples/Unix Assembly/support.S
+++ b/samples/Unix Assembly/support.S
@@ -1,0 +1,539 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2018, Matthew Macy <mmacy@freebsd.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$	
+ */
+
+/*
+ * Assembly variants of various functions, for those that don't need generic C
+ * implementations.  Currently this includes:
+ *
+ * - Direct-access versions of copyin/copyout methods.
+ *   - These are used by Radix AIM pmap (ISA 3.0), and Book-E, to avoid
+ *     unnecessary pmap_map_usr_ptr() calls.
+ */
+
+#include "assym.inc"
+#include "opt_sched.h"
+
+#include <sys/syscall.h>
+#include <sys/errno.h>
+	
+#include <machine/param.h>
+#include <machine/asm.h>
+#include <machine/spr.h>
+#include <machine/trap.h>
+#include <machine/vmparam.h>
+
+#ifdef _CALL_ELF
+.abiversion _CALL_ELF
+#endif
+
+#ifdef __powerpc64__
+#define	LOAD	ld
+#define	STORE	std
+#define	WORD	8
+#define	CMPI	cmpdi
+#define	CMPLI	cmpldi
+/* log_2(8 * WORD) */
+#define	LOOP_LOG	6
+#define	LOG_WORD	3
+#else
+#define	LOAD	lwz
+#define	STORE	stw
+#define	WORD	4
+#define	CMPI	cmpwi
+#define	CMPLI	cmplwi
+/* log_2(8 * WORD) */
+#define	LOOP_LOG	5
+#define	LOG_WORD	2
+#endif
+
+#ifdef AIM
+#define ENTRY_DIRECT(x) ENTRY(x ## _direct)
+#else
+#define	ENTRY_DIRECT(x)	ENTRY(x)
+#endif
+	
+#ifdef __powerpc64__
+#define	PROLOGUE		;\
+	mflr	%r0 		;\
+	std	%r0, 16(%r1)	;\
+
+#define	EPILOGUE		;\
+	ld	%r0, 16(%r1)	;\
+	mtlr	%r0		;\
+	blr			;\
+	nop
+
+#define	VALIDATE_TRUNCATE_ADDR_COPY	VALIDATE_ADDR_COPY
+#define	VALIDATE_ADDR_COPY(raddr, len)	\
+	srdi  %r0, raddr, 52		;\
+	cmpwi %r0, 1			;\
+	bge-	copy_fault		;\
+	nop
+
+#define	VALIDATE_ADDR_FUSU(raddr)	;\
+	srdi  %r0, raddr, 52		;\
+	cmpwi %r0, 1			;\
+	bge-	fusufault		;\
+	nop
+
+#else
+#define	PROLOGUE		;\
+	mflr	%r0 		;\
+	stw	%r0, 4(%r1)	;\
+
+#define	EPILOGUE		;\
+	lwz	%r0, 4(%r1)	;\
+	mtlr	%r0		;\
+	blr			;\
+	nop
+
+/* %r0 is temporary */
+/*
+ * Validate address and length are valid.
+ * For VALIDATE_ADDR_COPY() have to account for wraparound.
+ */
+#define	VALIDATE_ADDR_COPY(raddr, len)		\
+	lis	%r0, VM_MAXUSER_ADDRESS@h	;\
+	ori	%r0, %r0, VM_MAXUSER_ADDRESS@l	;\
+	cmplw	%r0, raddr			;\
+	blt-	copy_fault			;\
+	add	%r0, raddr, len			;\
+	cmplw	7, %r0, raddr			;\
+	blt-	7, copy_fault			;\
+	mtcrf	0x80, %r0			;\
+	bt-	0, copy_fault			;\
+	nop
+
+#define	VALIDATE_TRUNCATE_ADDR_COPY(raddr, len)		\
+	lis	%r0, VM_MAXUSER_ADDRESS@h	;\
+	ori	%r0, %r0, VM_MAXUSER_ADDRESS@l	;\
+	cmplw	%r0, raddr			;\
+	blt-	copy_fault			;\
+	sub	%r0, %r0, raddr			;\
+	cmplw	len, %r0			;\
+	isel	len, len, %r0, 0		;\
+
+#define	VALIDATE_ADDR_FUSU(raddr)		\
+	lis	%r0, VM_MAXUSER_ADDRESS@h	;\
+	ori	%r0, %r0, VM_MAXUSER_ADDRESS@l	;\
+	cmplw	%r0, raddr			;\
+	ble-	fusufault
+
+#endif
+
+#define PCPU(reg) mfsprg  reg, 0
+
+#define	SET_COPYFAULT(raddr, rpcb, len)	\
+	VALIDATE_ADDR_COPY(raddr, len)	;\
+	PCPU(%r9)			;\
+	li	%r0, COPYFAULT		;\
+	LOAD	rpcb, PC_CURPCB(%r9)	;\
+	STORE	%r0, PCB_ONFAULT(rpcb)	;\
+
+#define	SET_COPYFAULT_TRUNCATE(raddr, rpcb, len)\
+	VALIDATE_TRUNCATE_ADDR_COPY(raddr, len)	;\
+	PCPU(%r9)				;\
+	li	%r0, COPYFAULT			;\
+	LOAD	rpcb, PC_CURPCB(%r9)		;\
+	STORE	%r0, PCB_ONFAULT(rpcb)
+
+#define	SET_FUSUFAULT(raddr, rpcb)	\
+	VALIDATE_ADDR_FUSU(raddr)	;\
+	PCPU(%r9)			;\
+	li	%r0, FUSUFAULT		;\
+	LOAD	rpcb, PC_CURPCB(%r9)	;\
+	STORE	%r0, PCB_ONFAULT(rpcb)
+
+#define	CLEAR_FAULT_NO_CLOBBER(rpcb)	\
+	PCPU(%r9)			;\
+	LOAD	rpcb, PC_CURPCB(%r9)	;\
+	li	%r0, 0			;\
+	STORE	%r0, PCB_ONFAULT(rpcb)
+
+#define	CLEAR_FAULT(rpcb)		\
+	CLEAR_FAULT_NO_CLOBBER(rpcb)	;\
+	li	%r3, 0
+
+/*
+ *  bcopy(src, dst, len)
+ *        %r3  %r4  %r5
+ * 
+ *  %r7 is the pcb pointer
+ * 
+ *  %r0 and %r8-%r10 are volatile
+ *  %r11 and %r12 are generally volatile, used in linking and exception
+ *  handling.  Can be clobbered here.
+ *
+ * Does not allocate or use stack space, but clobbers all volatile registers.
+ */
+
+#define	rs	%r3
+#define	rd	%r4
+#define	rl	%r5
+
+#define	t1	%r6
+#define	t2	%r7
+#define	t3	%r8
+#define	t4	%r9
+#define	t5	%r10
+#define	t6	%r11
+#define	t7	%r12
+#define	t8	%r0
+
+#define Thresh	WORD * 8
+#define	W4	3
+#define	W2	2
+#define	W1	1
+#define	WORDS(n)	(32 - LOG_WORD - W##n)
+.text
+ENTRY(bcopy_generic)
+	CMPLI	0, %r5, 0
+	beq	.Lend
+	dcbtst	0, rd
+	dcbt	0, rs
+	CMPLI	rl, Thresh
+	blt	.Lsmall
+	b	.Llarge
+/* memcpy */
+/* ... */
+.Lsmall: 				/* < 8 words remaining */
+	mtcrf	0x3, rl
+.Lsmall_start:
+	bf	WORDS(4), 0f
+	LOAD	t1, 0(rs)
+	LOAD	t2, WORD*1(rs)
+	LOAD	t3, WORD*2(rs)
+	LOAD	t4, WORD*3(rs)
+	addi	rs, rs, WORD*4
+	STORE	t1, 0(rd)
+	STORE	t2, WORD*1(rd)
+	STORE	t3, WORD*2(rd)
+	STORE	t4, WORD*3(rd)
+	addi	rd, rd, WORD*4
+0:					/* < 4 words remaining */
+	bf	WORDS(2), 1f
+	LOAD	t1, 0(rs)
+	LOAD	t2, WORD*1(rs)
+	addi	rs, rs, WORD*2
+	STORE	t1, 0(rd)
+	STORE	t2, WORD*1(rd)
+	addi	rd, rd, WORD*2
+1:					/* < 2 words remaining */
+	bf	WORDS(1), 2f
+	LOAD	t1, 0(rs)
+	addi	rs, rs, WORD
+	STORE	t1, 0(rd)
+	addi	rd, rd, WORD
+2:					/* < 1 word remaining */
+#ifdef __powerpc64__
+	bf	29, 3f
+	lwz	t1, 0(rs)
+	addi	rs, rs, 4
+	stw	t1, 0(rd)
+	addi	rd, rd, 4
+3:					/* < 4 bytes remaining */
+#endif
+	bf	30, 4f
+	lhz	t1, 0(rs)
+	addi	rs, rs, 2
+	sth	t1, 0(rd)
+	addi	rd, rd, 2
+4:					/* < 2 bytes remaining */
+	bf	31, .Lout
+	lbz	t1, 0(rs)
+	addi	rs, rs, 1
+	stb	t1, 0(rd)
+	addi	rd, rd, 1
+	b	.Lout
+
+	.align 4
+.Llarge:
+	neg	t3, rd
+	andi.	t6, t3, WORD-1		/* Align rd to word size */
+	mtctr	t6
+	sub	rl, rl, t6
+	beq+	.Llargealigned
+1:
+	lbz	t1, 0(rs)
+	addi	rs, rs, 1
+	stb	t1, 0(rd)
+	addi	rd, rd, 1
+	bdnz	1b
+
+.Llargealigned:
+	srwi.	t2, rl, LOOP_LOG  /* length >> log_2(loop_size) => 8W iterations */
+	mtcrf	0x3, rl
+	beq	.Lsmall_start
+	mtctr	t2
+	b	1f
+
+	.align 5
+1:
+	LOAD	t1, 0(rs)
+	LOAD	t2, WORD(rs)
+	LOAD	t3, WORD*2(rs)
+	LOAD	t4, WORD*3(rs)
+	LOAD	t5, WORD*4(rs)
+	LOAD	t6, WORD*5(rs)
+	LOAD	t7, WORD*6(rs)
+	LOAD	t8, WORD*7(rs)
+	addi	rs, rs, WORD*8
+	STORE	t1, 0(rd)
+	STORE	t2, WORD*1(rd)
+	STORE	t3, WORD*2(rd)
+	STORE	t4, WORD*3(rd)
+	STORE	t5, WORD*4(rd)
+	STORE	t6, WORD*5(rd)
+	STORE	t7, WORD*6(rd)
+	STORE	t8, WORD*7(rd)
+	addi	rd, rd, WORD*8
+	bdnz	1b
+
+	b	.Lsmall_start
+.Lout:
+/* done */	
+.Lend:	
+	blr
+
+/*
+ * copyout(from_kernel, to_user, len)
+ *         %r3,        %r4,    %r5
+ */
+ENTRY_DIRECT(copyout)
+	PROLOGUE
+	SET_COPYFAULT(%r4, %r7, %r5)
+	bl bcopy_generic 
+	nop
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+
+/*
+ * copyin(from_user, to_kernel, len)
+ *        %r3,        %r4,    %r5
+ */
+ENTRY_DIRECT(copyin)
+	PROLOGUE
+	SET_COPYFAULT(%r3, %r7, %r5)
+	bl bcopy_generic
+	nop
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+/*
+ * copyinstr(const void *udaddr, void *kaddr, size_t len, size_t *done)
+ *			%r3          %r4         %r5        %r6 
+ */
+	
+ENTRY_DIRECT(copyinstr)
+	PROLOGUE
+	SET_COPYFAULT_TRUNCATE(%r3, %r7, %r5)
+	addi	%r9, %r5, 1
+	mtctr	%r9
+	mr	%r8, %r3
+	addi	%r8, %r8, -1
+	addi	%r4, %r4, -1
+	li	%r3, ENAMETOOLONG
+0:
+	bdz-	2f
+	lbzu	%r0, 1(%r8)
+	stbu	%r0, 1(%r4)
+
+	// NULL byte reached ?
+	CMPI	%r0, 0
+	beq-	1f
+	b	0b
+1:
+	li	%r3, 0
+2:
+	/* skip storing length if done is NULL */
+	CMPI	%r6, 0
+	beq-	3f
+	mfctr	%r0
+	sub	%r0, %r9, %r0
+	STORE	%r0, 0(%r6)
+3:
+	CLEAR_FAULT_NO_CLOBBER(%r7)
+	EPILOGUE
+
+ENTRY_DIRECT(subyte)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	stb  %r4, 0(%r3)
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+
+#ifndef __powerpc64__
+ENTRY_DIRECT(suword)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	stw  %r4, 0(%r3)
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+#endif	
+
+ENTRY_DIRECT(suword32)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	stw  %r4, 0(%r3)
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+
+#ifdef __powerpc64__	
+ENTRY_DIRECT(suword64)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	std  %r4, 0(%r3) 
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+ENTRY_DIRECT(suword)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	std  %r4, 0(%r3) 
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+#endif	
+	
+ENTRY_DIRECT(fubyte)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	lbz %r3, 0(%r3)
+	CLEAR_FAULT_NO_CLOBBER(%r7)
+	EPILOGUE
+
+ENTRY_DIRECT(fuword16)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	lhz %r3, 0(%r3)
+	CLEAR_FAULT_NO_CLOBBER(%r7)
+	EPILOGUE
+
+#ifndef __powerpc64__
+ENTRY_DIRECT(fueword)	
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	lwz  %r0, 0(%r3)
+	stw  %r0,  0(%r4)
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+#endif	
+ENTRY_DIRECT(fueword32)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	lwz  %r0, 0(%r3)
+	stw  %r0,  0(%r4)
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+
+#ifdef __powerpc64__
+ENTRY_DIRECT(fueword)	
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	ld  %r0, 0(%r3)
+	std %r0, 0(%r4)
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+
+ENTRY_DIRECT(fueword64)
+	PROLOGUE
+	SET_FUSUFAULT(%r3, %r7)
+	ld  %r0, 0(%r3)
+	std %r0, 0(%r4)
+	CLEAR_FAULT(%r7)
+	EPILOGUE
+#endif
+
+/*
+ * casueword(volatile u_long *base, u_long old, u_long *oldp, u_long new)
+ *			      %r3          %r4           %r5         %r6 
+ */
+
+#define	CASUEWORD32(raddr, rpcb)					;\
+	PROLOGUE							;\
+	SET_FUSUFAULT(raddr, rpcb)					;\
+	li	%r8, 0							;\
+1:									;\
+	lwarx	%r0, 0, %r3						;\
+	cmplw	%r4, %r0						;\
+	bne	2f							;\
+	stwcx.	%r6, 0, %r3						;\
+	bne-	3f							;\
+	b	4f							;\
+2:									;\
+	stwcx.	%r0, 0, %r3       	/* clear reservation (74xx) */	;\
+3:									;\
+	li	%r8, 1							;\
+4:									;\
+	stw	%r0, 0(%r5)						;\
+	CLEAR_FAULT_NO_CLOBBER(rpcb)					;\
+	mr	%r3, %r8						;\
+	EPILOGUE	
+	
+ENTRY_DIRECT(casueword32)
+	CASUEWORD32(%r3, %r7)
+
+#ifdef __powerpc64__
+#define	CASUEWORD64(raddr, rpcb)					;\
+	PROLOGUE							;\
+	SET_FUSUFAULT(raddr, rpcb)					;\
+	li	%r8, 0							;\
+1:									;\
+	ldarx	%r0, 0, %r3						;\
+	cmpld	%r4, %r0						;\
+	bne	2f							;\
+	stdcx.	%r6, 0, %r3						;\
+	bne-	3f							;\
+	b	4f							;\
+2:									;\
+	stdcx.	%r0, 0, %r3       	/* clear reservation (74xx) */	;\
+3:									;\
+	li	%r8, 1							;\
+4:									;\
+	std	%r0, 0(%r5)						;\
+	CLEAR_FAULT_NO_CLOBBER(rpcb)					;\
+	mr	%r3, %r8						;\
+	EPILOGUE
+
+ENTRY_DIRECT(casueword)
+	CASUEWORD64(%r3, %r7)
+
+ENTRY_DIRECT(casueword64)
+	CASUEWORD64(%r3, %r7)
+#else
+ENTRY_DIRECT(casueword)
+	CASUEWORD32(%r3, %r7)
+#endif
+	
+_NAKED_ENTRY(fusufault)
+	CLEAR_FAULT_NO_CLOBBER(%r7)
+	li %r3, -1
+	EPILOGUE
+
+_NAKED_ENTRY(copy_fault)
+	CLEAR_FAULT_NO_CLOBBER(%r7)
+	li %r3, EFAULT
+	EPILOGUE


### PR DESCRIPTION
## Description

Add Unix Assembly samples, including GCC preprocessor syntax. These help
classifying many assembly files (e.g. FreeBSD, OpenBLAS) as Unix
Assembly instead of Motorola 68k Assembly.

* Unix Assembly/support.S
  * Source: https://github.com/freebsd/freebsd/blob/f38c52a875446ee056288f64b33b68cbdb2a46d3/sys/powerpc/powerpc/support.S
  * License: BSD-2-Clause-FreeBSD
* Unix Assembly/gemm_kernel_1x4.S
  * Source: https://github.com/jqlin888/OpenBLAS/blob/30ab84891ced6cb00d402e3be8eec907ed9cc6ee/kernel/x86/gemm_kernel_1x4.S
  * License: BSD-2-Clause


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language: (see description above)
  - ~I have included a change to the heuristics to distinguish my language from others using the same extension.~
