### PR TITLE
Remove ocaml from Reason interepreters

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4633,8 +4633,6 @@ Reason:
   extensions:
   - ".re"
   - ".rei"
-  interpreters:
-  - ocaml
   tm_scope: source.reason
   language_id: 869538413
 Rebol:


### PR DESCRIPTION
It's little stretched to say ocaml is interpreter of ocaml, to say the least...

I'm using  languages.yml for filetype detection of scripts in vim-polyglot and this messes things up. Nobody programming in Reason would set ocaml as interpreter