### PR TITLE
Add support for Lark grammar files

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -481,6 +481,7 @@ vendor/grammars/language-grammars:
 - source.abnf
 - source.bnf
 - source.ebnf
+- source.lark
 - source.lex
 - source.lex.regexp
 - source.yacc

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2823,6 +2823,17 @@ LabVIEW:
   codemirror_mode: xml
   codemirror_mime_type: text/xml
   language_id: 194
+Lark:
+  type: data
+  group: EBNF
+  color: "#0b130f"
+  extensions:
+  - ".lark"
+  tm_scope: source.lark
+  ace_mode: text
+  codemirror_mode: ebnf
+  codemirror_mime_type: text/x-ebnf
+  language_id: 758480799
 Lasso:
   type: programming
   color: "#999999"

--- a/samples/Lark/ebl_atf.lark
+++ b/samples/Lark/ebl_atf.lark
@@ -1,0 +1,16 @@
+?start: line
+
+?line: empty_line
+     | note_line
+     | text_line
+     | dollar_line
+     | at_line
+     | control_line
+
+empty_line: /\s+/?
+
+!control_line.-2: ("=:" | "&" | "#") /.+/?
+
+%import .ebl_atf_text_line (text_line, any_word, note_line)
+%import .ebl_atf_dollar_line (dollar_line)
+%import .ebl_atf_at_line (at_line)

--- a/samples/Lark/ebl_atf_common.lark
+++ b/samples/Lark/ebl_atf_common.lark
@@ -1,0 +1,18 @@
+%import common.DIGIT
+%import common.INT
+%import common.LCASE_LETTER
+
+seal : "seal "  INT
+
+free_text.-2 : /./+ " "*
+
+?object: OBJECT | generic_object | fragment
+OBJECT: "tablet" | "envelope" | "prism" | "bulla"
+fragment: "fragment " free_text
+generic_object : "object " free_text
+
+?surface: SURFACE | generic_surface | face | edge
+SURFACE: "obverse" | "reverse" | "left" | "right" | "top" | "bottom"
+face: "face " LCASE_LETTER
+edge: "edge" (" " LCASE_LETTER)?
+generic_surface : "surface " free_text

--- a/samples/Lark/lark.lark
+++ b/samples/Lark/lark.lark
@@ -1,0 +1,58 @@
+start: (_item? _NL)* _item?
+
+_item: rule
+     | token
+     | statement
+
+rule: RULE rule_params priority? ":" expansions
+token: TOKEN token_params priority? ":" expansions
+
+rule_params: ["{" RULE ("," RULE)* "}"]
+token_params: ["{" TOKEN ("," TOKEN)* "}"]
+
+priority: "." NUMBER
+
+statement: "%ignore" expansions                    -> ignore
+         | "%import" import_path ["->" name]       -> import
+         | "%import" import_path name_list         -> multi_import
+         | "%declare" name+                        -> declare
+
+!import_path: "."? name ("." name)*
+name_list: "(" name ("," name)* ")"
+
+?expansions: alias (_VBAR alias)*
+
+?alias: expansion ["->" RULE]
+
+?expansion: expr*
+
+?expr: atom [OP | "~" NUMBER [".." NUMBER]]
+
+?atom: "(" expansions ")"
+     | "[" expansions "]" -> maybe
+     | value
+
+?value: STRING ".." STRING -> literal_range
+      | name
+      | (REGEXP | STRING) -> literal
+      | name "{" value ("," value)* "}" -> template_usage
+
+name: RULE
+    | TOKEN
+
+_VBAR: _NL? "|"
+OP: /[+*]|[?](?![a-z])/
+RULE: /!?[_?]?[a-z][_a-z0-9]*/
+TOKEN: /_?[A-Z][_A-Z0-9]*/
+STRING: _STRING "i"?
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[imslux]*/
+_NL: /(\r?\n)+\s*/
+
+%import common.ESCAPED_STRING -> _STRING
+%import common.SIGNED_INT -> NUMBER
+%import common.WS_INLINE
+
+COMMENT: /\s*/ "//" /[^\n]/*
+
+%ignore WS_INLINE
+%ignore COMMENT

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -228,6 +228,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **LSL:** [textmate/secondlife-lsl.tmbundle](https://github.com/textmate/secondlife-lsl.tmbundle)
 - **LTspice Symbol:** [Alhadis/language-pcb](https://github.com/Alhadis/language-pcb)
 - **LabVIEW:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)
+- **Lark:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
 - **Lasso:** [bfad/Sublime-Lasso](https://github.com/bfad/Sublime-Lasso)
 - **Latte:** [textmate/php-smarty.tmbundle](https://github.com/textmate/php-smarty.tmbundle)
 - **Lean:** [leanprover/vscode-lean](https://github.com/leanprover/vscode-lean)


### PR DESCRIPTION
This PR adds support for [Lark grammar files](https://lark-parser.readthedocs.io/en/latest/grammar.html), a variant of EBNF used by the [Lark parsing library](https://github.com/lark-parser/lark). The format was brought to my attention by @ThatXliner in Alhadis/language-grammars#4; consult that issue for a more detailed overview of the format.

## Checklist:
- [x] **I am adding a new language.**
	-	[x] **The `.lark` extension is used in hundreds of repositories on GitHub:**  
		*	**Total search results:**
			[1,064 indexed](https://github.com/search?q=extension%3Alark+NOT+nothack&type=Code) and [sampled](https://github.com/Alhadis/Silos/blob/3fc87991215c0a3697d01477a2c1af32f4dbbc4e/total-results.log)
		*	**Related usage:**
			*	[802 files](https://github.com/Alhadis/Silos/blob/3fc87991215c0a3697d01477a2c1af32f4dbbc4e/related-files.log)
			*	[444 repositories](https://github.com/Alhadis/Silos/blob/3fc87991215c0a3697d01477a2c1af32f4dbbc4e/related-repos.log)
			*	[386 users](https://github.com/Alhadis/Silos/blob/3fc87991215c0a3697d01477a2c1af32f4dbbc4e/related-users.log)
		*	**Unrelated usage:**
			*	[259 files](https://github.com/Alhadis/Silos/blob/3fc87991215c0a3697d01477a2c1af32f4dbbc4e/unrelated-files.log)
			*	[3 repositories](https://github.com/Alhadis/Silos/blob/3fc87991215c0a3697d01477a2c1af32f4dbbc4e/unrelated-repos.log)
			*	[2 users](https://github.com/Alhadis/Silos/blob/3fc87991215c0a3697d01477a2c1af32f4dbbc4e/unrelated-users.log)
	-	[x] **I have included samples of real-world usage:**
			*	[`ebl_atf.lark`](https://github.com/ElectronicBabylonianLiterature/ebl-api/blob/373a2d6879857c5bf5cfcfc65908767ff2afc411/ebl/transliteration/domain/ebl_atf.lark): [MIT][1]
			*	[`ebl_atf_common.lark`](https://github.com/ElectronicBabylonianLiterature/ebl-api/blob/c270c55dae96e334460714605bc0a4388c120dfd/ebl/transliteration/domain/ebl_atf_common.lark): [MIT][1]
			*	[`lark.lark`](https://github.com/lark-parser/lark/blob/082e0f3de763bd3883e556390813a89fd139c44e/examples/lark.lark): [MIT][2]
	-	[x] **I have** ~~included~~ **_updated_ a syntax highlighting grammar:**  
		See [`Alhadis/language-grammars@32956c6`](https://github.com/Alhadis/language-grammars@32956c6)

[1]: https://github.com/ElectronicBabylonianLiterature/ebl-api/blob/f1d80bb7de25997b58d5afa47a1ec2d1638b8e93/LICENSE
[2]: https://github.com/lark-parser/lark/blob/2f6f3f9a31b6a0b9a1718c2cf557ac664be9e101/LICENSE
