### PR TITLE
Move generic extensions list to a dedicated file

### DIFF
--- a/lib/linguist/generic.yml
+++ b/lib/linguist/generic.yml
@@ -1,0 +1,17 @@
+# This is a list of file extensions considered too common to safely associate
+# with only the formats Linguist recognises. In addition to the stipulated
+# extension requirement, candidate matches must also satisfy a heuristic
+# (or some other strategy) in order to be identified as any one language.
+
+---
+extensions:
+- ".1"
+- ".2"
+- ".3"
+- ".4"
+- ".5"
+- ".6"
+- ".7"
+- ".8"
+- ".9"
+- ".sol"

--- a/lib/linguist/strategy/extension.rb
+++ b/lib/linguist/strategy/extension.rb
@@ -1,9 +1,7 @@
+require 'yaml'
+
 module Linguist
   module Strategy
-    # Extensions considered too common for simple extension lookup.
-    # Languages which use such an extension must instead satisfy a
-    # heuristic (or some other strategy) to be matched on extension.
-    GENERIC = %w[.1 .2 .3 .4 .5 .6 .7 .8 .9 .sol]
 
     # Detects language based on extension
     class Extension
@@ -27,7 +25,17 @@ module Linguist
 
       # Public: Return true if filename uses a generic extension.
       def self.generic?(filename)
-        GENERIC.any? { |ext| filename.downcase.end_with? ext }
+        self.load()
+        @generic.any? { |ext| filename.downcase.end_with? ext }
+      end
+
+      @generic = []
+
+      # Internal: Load the contents of `generic.yml`
+      def self.load()
+        return if @generic.any?
+        data = YAML.load_file(File.expand_path("../../generic.yml", __FILE__))
+        @generic = data['extensions']
       end
     end
   end

--- a/lib/linguist/strategy/extension.rb
+++ b/lib/linguist/strategy/extension.rb
@@ -25,7 +25,7 @@ module Linguist
 
       # Public: Return true if filename uses a generic extension.
       def self.generic?(filename)
-        self.load()
+        self.load
         @generic.any? { |ext| filename.downcase.end_with? ext }
       end
 

--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -4,6 +4,7 @@ class TestPedantic < Minitest::Test
   filename = File.expand_path("../../lib/linguist/languages.yml", __FILE__)
   LANGUAGES = YAML.load(File.read(filename))
   GRAMMARS = YAML.load(File.read(File.expand_path("../../grammars.yml", __FILE__)))
+  GENERICS = YAML.load_file(File.expand_path("../../lib/linguist/generic.yml", __FILE__))
   HEURISTICS = YAML.load_file(File.expand_path("../../lib/linguist/heuristics.yml", __FILE__))
 
   def test_language_names_are_sorted
@@ -21,6 +22,10 @@ class TestPedantic < Minitest::Test
     LANGUAGES.each do |name, language|
       assert_sorted language['filenames'] if language['filenames']
     end
+  end
+
+  def test_generics_are_sorted
+    assert_sorted GENERICS.keys
   end
 
   def test_grammars_are_sorted


### PR DESCRIPTION
## Description
This PR moves our nascent list of generic file extensions to its own file, following [approval](https://github.com/github/linguist/pull/5059#issuecomment-716444008) from @lildude in #5059.

*Template removed as it doesn't apply.*
