### PR TITLE
Fix verilog misclassification (resurrection of #4751)

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -535,9 +535,9 @@ disambiguations:
 - extensions: ['.v']
   rules:
   - language: Coq
-    pattern: '\(\*.*?\*\)|(?:^|\s)(?:Proof|Qed)\.(?:$|\s)|(?:^|\s)Require[ \t]+Import\s'
+    pattern: '(?:^|\s)(?:Proof|Qed)\.(?:$|\s)|(?:^|\s)Require[ \t]+(Import|Export)\s'
   - language: Verilog
-    pattern: '^[ \t]*module\s+[^\s()]+\s+\#?\(|^[ \t]*`(?:ifdef|timescale)\s|^[ \t]*always[ \t]+@'
+    pattern: '^[ \t]*module\s+[^\s()]+\s+\#?\(|^[ \t]*`(?:define|ifdef|ifndef|include|timescale)|^[ \t]*always[ \t]+@|^[ \t]*initial[ \t]+(begin|@)'
   - language: V
     pattern: '\$(?:if|else)[ \t]|^[ \t]*fn\s+[^\s()]+\(.*?\).*?\{|^[ \t]*for\s*\{'
 - extensions: ['.vba']

--- a/samples/Verilog/ram.v
+++ b/samples/Verilog/ram.v
@@ -1,0 +1,81 @@
+/*--------------------
+Original Author: Yuma Ueda
+Contact Point: cyan@0x00a1e9.dev
+ram.v
+Created: 12/19/2019
+
+Copyright 2019 Yuma Ueda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+--------------------*/
+
+
+`include "defs.v"
+
+
+module RAM (
+    input wire [31:0] addr, write_data,
+    input wire memwrite,
+    input wire [1:0] storeops,
+    output wire [31:0] read_data,
+    input wire CLK, reset
+    );
+
+    reg [7:0] ram [`RAM_COL_MAX-1:0];
+
+    always @(posedge CLK) begin
+        if (reset) begin : rst
+            integer i;
+            for (i = 0; i < `RAM_COL_MAX; i = i + 1) begin
+                ram[i] <= 0;
+            end
+        end
+        else if (memwrite) begin
+            do_store();
+        end
+    end
+
+    assign read_data = {
+        ram[addr],
+        ram[addr+1],
+        ram[addr+2],
+        ram[addr+3]
+    };
+
+    task store_byte;
+    begin
+        ram[addr] <= write_data[7:0];
+    end
+    endtask
+
+    task store_half_word;
+    begin
+        ram[addr]   <= write_data[15:8];
+        ram[addr+1] <= write_data[7:0];
+    end
+    endtask
+
+    task store_word;
+    begin
+        ram[addr]   <= write_data[31:24];
+        ram[addr+1] <= write_data[23:16];
+        ram[addr+2] <= write_data[15: 8];
+        ram[addr+3] <= write_data[ 7: 0];
+    end
+    endtask
+
+    task do_store;
+    begin
+        (* full_case *)
+        case (storeops)
+            `STORE_B: store_byte();
+            `STORE_H: store_half_word();
+            `STORE_W: store_word();
+        endcase
+    end
+    endtask
+endmodule


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
This is the HEAD from #4751 rebased onto the latest master. It should fix #5041. All credit for this one goes to @yumaueda. cc @Alhadis

A larger sample, [Claire Wolf's picorv32 core](https://github.com/cliffordwolf/picorv32), is confirmed to be also fixed:

```
// BEFORE //
dev/linguist - [fix-verilog-misclassification] » github-linguist ~/u/dev/picorv32
24.97%  Verilog
21.29%  Assembly
**20.70%  Coq**
19.62%  C
5.89%   Makefile
2.86%   Shell
2.39%   Python
1.01%   Nix
0.92%   C++
0.35%   Tcl

// AFTER //
dev/linguist - [fix-verilog-misclassification] » bundle exec bin/github-linguist ~/u/dev/picorv32
45.67%  Verilog
21.29%  Assembly
19.62%  C
5.89%   Makefile
2.86%   Shell
2.39%   Python
1.01%   Nix
0.92%   C++
0.35%   Tcl
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - samples/Verilog/ram.v
    - Sample license(s): MIT
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/
  - New: https://github-lightshow.herokuapp.com/

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]