### PR TITLE
Ignore files in src directories of grammars

### DIFF
--- a/tools/grammars/compiler/loader_fs.go
+++ b/tools/grammars/compiler/loader_fs.go
@@ -69,6 +69,11 @@ func (l *fsLoader) load() {
 			return
 		}
 
+		// Ignore all files under src directories
+		if ok, _ := filepath.Match("*/src/*", rel); ok {
+			continue
+		}
+
 		if IgnoredFiles[rel] {
 			continue
 		}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

The directory structure in the Kotlin grammar changed in https://github.com/nishtahir/language-kotlin/pull/22 and subsequent PRs which in turn has led to the grammar compiler finding and attempting to use those files directly.  This results in errors like this which I completely missed when updating the grammars for v7.12.0:

```
- [ ] repository `vendor/grammars/language-kotlin` (from https://github.com/nishtahir/language-kotlin) (11 errors)
    - [ ] Grammar conversion failed. File `src/ident.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/ident.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/keywords.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/keywords.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/literals.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/literals.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/objects.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/objects.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/annotations.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/annotations.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/functions.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/functions.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/package.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/package.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/types.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/types.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/classes.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/classes.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/comments.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/comments.YAML-tmLanguage` has no scope name
    - [ ] Grammar conversion failed. File `src/imports.YAML-tmLanguage` failed to parse: Undeclared scope in grammar: `src/imports.YAML-tmLanguage` has no scope name
```

As I missed this, I ended up shipping an incomplete grammar in v7.12.0 which broke all hightlighting of Kotlin files.

Multiple grammar-side fixes are possible like using a different extension or adding scopes to each of the split out files, but it's probably best to ignore all files unders `src` dirs in grammars as they're almost never directly used by the grammars so by ignoring them we skip over a lot of files we don't need to look at which in turn resolves the issue with Kotlin without any changes to the grammar or grammar-specific changes in Linguist.

I used these changes to generate new grammars and compared to those used by 7.12.0 and the only difference is with the Kotlin grammar which is now correctly compiled.
