### PR TITLE
Update link to new GitHub documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Hi there!
 We're thrilled that you'd like to contribute to this project.
 Your help is essential for keeping it great.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
+Contributions to this project are [released](https://docs.github.com/github/site-policy/github-terms-of-service#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
 This project adheres to the [Contributor Covenant Code of Conduct](http://contributor-covenant.org/).
 By participating, you are expected to uphold this code.
@@ -240,4 +240,4 @@ If you are the current maintainer of this gem:
 [new-issue]: https://github.com/github/linguist/issues/new
 [samples]: /samples
 [search-example]: https://github.com/search?utf8=%E2%9C%93&q=extension%3Aboot+NOT+nothack&type=Code&ref=searchresults
-[gpr]: https://help.github.com/en/articles/configuring-rubygems-for-use-with-github-package-registry
+[gpr]: https://docs.github.com/packages/using-github-packages-with-your-projects-ecosystem/configuring-rubygems-for-use-with-github-packages

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If the language stats bar is reporting a language that you don't expect:
    You can also use the [manual overrides](#overrides) feature to correctly classify them in your repository.
 1. If there are no reported issues of this misclassification, [open an issue][new-issue] and include a link to the repository or a sample of the code that is being misclassified.
 
-[search-limits]: https://help.github.com/articles/searching-code/#considerations-for-code-search
+[search-limits]: https://docs.github.com/github/searching-for-information-on-github/searching-code#considerations-for-code-search
 
 Keep in mind that the repository language stats are only [updated when you push changes](#how-linguist-works-on-githubcom), and the results are cached for the lifetime of your repository.
 If you have not made any changes to your repository in a while, you may find pushing another change will correct the stats.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The language of each remaining file is then determined using the following strat
 - naïve Bayesian classification
 
 The result of this analysis is used to produce the language stats bar which displays the languages percentages for the files in the repository.
-The percentages are calculated based on the bytes of code for each language as reported by the [List Languages](https://developer.github.com/v3/repos/#list-languages) API.
+The percentages are calculated based on the bytes of code for each language as reported by the [List Languages](https://docs.github.com/rest/reference/repos#list-repository-languages) API.
 
 ![language stats bar](https://user-images.githubusercontent.com/2346707/91533656-9768b300-e953-11ea-808d-994cd50e6273.png)
 


### PR DESCRIPTION
We've unified all of GitHub's product documentation in one place! 
For the most accurate and up-to-date content, visit the updated link.