### PR TITLE
Fix Pascal aliases

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -971,9 +971,6 @@ Component Pascal:
   - ".cp"
   - ".cps"
   tm_scope: source.pascal
-  aliases:
-  - delphi
-  - objectpascal
   ace_mode: pascal
   codemirror_mode: pascal
   codemirror_mime_type: text/x-pascal
@@ -4041,6 +4038,9 @@ Parrot Internal Representation:
 Pascal:
   type: programming
   color: "#E3F171"
+  aliases:
+  - delphi
+  - objectpascal
   extensions:
   - ".pas"
   - ".dfm"


### PR DESCRIPTION
## Description
Move `delphi` and `objectpascal` aliases to Pascal instead of Component Pascal. Both aliases are used for Object Pascal dialects, which is a Pascal extension, not derived from Component Pascal.

This was discussed in the past (https://github.com/github/linguist/issues/905#issuecomment-216281058 https://github.com/github/linguist/pull/3753). Object Pascal could be introduced as a standalone language, although it would present problems similar to C/C++ distinction. In the absence of a standalone language for Object Pascal, these aliases belong to Pascal, not Component Pascal.

## Checklist:

- [x] **I am fixing a misclassified language** (using a delphi or objectpascal modeline makes linguist to identify the file as Component Pascal)
  - ~I have included a new sample for the misclassified language:~ (probably not required?)
