### PR TITLE
Use ruby:2-alpine for Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:2-alpine
 
 RUN apk --update add --virtual build_deps \
     build-base \


### PR DESCRIPTION
## Description

One Docker CI build has started failing because the default `alpine` Ruby version is now 3.0 and it appears charlock_holmes is having problems with this version of Ruby. From https://github.com/github/linguist/pull/5113/checks?check_run_id=1643086612

```
Building native extensions. This could take a while...
ERROR:  Error installing github-linguist:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/charlock_holmes-0.7.7/ext/charlock_holmes
/usr/local/bin/ruby -I /usr/local/lib/ruby/3.0.0 -r ./siteconf20210104-12-vqslut.rb extconf.rb
checking for -licui18n... yes
checking for unicode/ucnv.h... yes
checking for -lz... yes
checking for -licuuc... yes
checking for -licudata... yes
creating Makefile

current directory: /usr/local/bundle/gems/charlock_holmes-0.7.7/ext/charlock_holmes
make "DESTDIR=" clean

current directory: /usr/local/bundle/gems/charlock_holmes-0.7.7/ext/charlock_holmes
make "DESTDIR="
compiling converter.c
compiling encoding_detector.c
compiling ext.c
compiling transliterator.cpp
In file included from /usr/local/include/ruby-3.0.0/ruby/ruby.h:39,
                 from /usr/local/include/ruby-3.0.0/ruby.h:38,
                 from common.h:9,
                 from transliterator.cpp:1:
/usr/local/include/ruby-3.0.0/ruby/internal/memory.h:275:16: error: conflicting declaration of 'void* ruby_nonempty_memcpy(void*, const void*, size_t)' with 'C' linkage
  275 | #define memcpy ruby_nonempty_memcpy
      |                ^~~~~~~~~~~~~~~~~~~~
/usr/local/include/ruby-3.0.0/ruby/internal/memory.h:265:1: note: previous declaration with 'C++' linkage
  265 | ruby_nonempty_memcpy(void *dest, const void *src, size_t n)
      | ^~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:237: transliterator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /usr/local/bundle/gems/charlock_holmes-0.7.7 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux-musl/3.0.0/charlock_holmes-0.7.7/gem_make.out
The command '/bin/sh -c apk --update add --virtual build_deps     build-base     libc-dev     linux-headers     cmake     && apk --no-cache add icu-dev libressl-dev     && gem install github-linguist     && apk del build_deps build-base libc-dev linux-headers cmake' returned a non-zero code: 1
```

This PR fixes our build and gets things working again for those using the Dockerfile by pinning the Ruby version to 2.x, which is inline with what we test Linguist against.
