### PR TITLE
Add color for Liquid

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2930,6 +2930,7 @@ Linux Kernel Module:
   language_id: 203
 Liquid:
   type: markup
+  color: "#67b8de"
   extensions:
   - ".liquid"
   tm_scope: text.html.liquid


### PR DESCRIPTION
Adds a color for Liquid, `#67b8de`, taken from https://shopify.github.io/liquid/