### PR TITLE
Add color to Org

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3867,6 +3867,7 @@ OpenType Feature File:
   language_id: 374317347
 Org:
   type: prose
+  color: "#77aa99"
   wrap: true
   extensions:
   - ".org"


### PR DESCRIPTION
As can be seen on the Org project homepage (https://orgmode.org/), this is the dominant colour used in the logo and across the page in representing the format - `#77aa99`. Currently, there is no color assigned to Org.

This PR adds this color to the Org format.