### PR TITLE
Add Cake aliases to the C# language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -583,6 +583,8 @@ C#:
   color: "#178600"
   aliases:
   - csharp
+  - cake
+  - cakescript
   extensions:
   - ".cs"
   - ".cake"


### PR DESCRIPTION
Add the aliases `cake` and `cakescript` to the C# language (which already include `.cake` files added years ago).

Cake (C# Make) is a free and open source cross-platform build automation system with a C# DSL for tasks such as compiling code, copying files and folders, running unit tests, compressing files and building NuGet packages.

You can find out out more about Cake on the website: http://cakebuild.net
