### PR TITLE
Ungroup EJS from HTML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1298,7 +1298,6 @@ ECLiPSe:
 EJS:
   type: markup
   color: "#a91e50"
-  group: HTML
   extensions:
   - ".ejs"
   - ".ect"


### PR DESCRIPTION
Ungroups EJS from HTML. Continuation of #4979 and similar PRs.

Colour already in place.

EJS is more similar to HTML and is comparable to Nunjucks (#5167) or Liquid's splits. (It's basically inline JS inside HTML files that returns HTML content.)