### PR TITLE
Ungroup Closure Templates from HTML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -852,7 +852,7 @@ Clojure:
   language_id: 62
 Closure Templates:
   type: markup
-  group: HTML
+  color: "#0d948f"
   ace_mode: soy_template
   codemirror_mode: soy
   codemirror_mime_type: text/x-soy


### PR DESCRIPTION
Ungroups Closure Templates from HTML. Continuation of #4979 and similar PRs. Should be the last HTML ungrouping, I think.

This is a language by Google ([repo](https://github.com/google/closure-templates)) that treats HTML as JS-like, it seems.

[Example file](https://github.com/google/closure-templates/blob/master/examples/features.soy); note that the syntax highlighting of inline comments seems broken.

Color `#0d948f` from official site theme: https://developers.google.com/closure