### PR TITLE
Update TeX heuristic to fix #5219

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -107,7 +107,7 @@ disambiguations:
 - extensions: ['.cls']
   rules:
   - language: TeX
-    pattern: '\\ProvidesClass{'
+    pattern: '^\s*\\ProvidesClass{'
   - language: ObjectScript
     pattern: '^Class\s'
 - extensions: ['.cmp']

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -107,7 +107,7 @@ disambiguations:
 - extensions: ['.cls']
   rules:
   - language: TeX
-    pattern: '^\s*\\ProvidesClass{'
+    pattern: '^\s*\\(?:NeedsTeXFormat|ProvidesClass){'
   - language: ObjectScript
     pattern: '^Class\s'
 - extensions: ['.cmp']

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -107,7 +107,7 @@ disambiguations:
 - extensions: ['.cls']
   rules:
   - language: TeX
-    pattern: '\\\w+{'
+    pattern: '\\ProvidesClass{'
   - language: ObjectScript
     pattern: '^Class\s'
 - extensions: ['.cmp']


### PR DESCRIPTION
Fix for [VBA appearing as TeX](https://github.com/github/linguist/issues/5219#issuecomment-781983475).

It was identified that all TeX cls/class files require the line `\\ProvidesClass{...}`. This is much less ambiguous than `\\\w+{`, and will likely lead to matching of my VBA files.

## Checklist:
- [X] **I am fixing a misclassified language**
  - I don't believe a sample is required, but if wanted you can use [this](https://github.com/sancarn/stdVBA/blob/940c768326366308c659c4387331f3c047454867/src/stdRegex.cls) sample
  - [X] I have included a change to the heuristics to distinguish my language from others using the same extension.