### PR TITLE
D Language Alias Proposal

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1117,6 +1117,8 @@ Cython:
 D:
   type: programming
   color: "#ba595e"
+  aliases:
+  - Dlang
   extensions:
   - ".d"
   - ".di"


### PR DESCRIPTION
The D Language is also known as the Dlang, can not find an exact source but the languages homepage is an indicator of it- https://dlang.org/
