### PR TITLE
Add Wolfram Language as alias for Mathematica

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3299,8 +3299,8 @@ Mathematica:
   aliases:
   - mma
   - wolfram
-  - wolframlanguage
-  - wolframlang
+  - wolfram language
+  - wolfram lang
   - wl
   tm_scope: source.mathematica
   ace_mode: text

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3298,6 +3298,10 @@ Mathematica:
   - ".wlt"
   aliases:
   - mma
+  - wolfram
+  - wolframlanguage
+  - wolframlang
+  - wl
   tm_scope: source.mathematica
   ace_mode: text
   codemirror_mode: mathematica


### PR DESCRIPTION
Add "Wolfram Language" and abbreviated "wl" aliases for Mathematica.

## Description

In recent years, the language underpinning Mathematica has been called "Wolfram Language" (https://www.wolfram.com/language/), and Mathematica is just the GUI notebook application.

WL is a common abbreviation for Wolfram Language (as it is the `.wl` file extension, but can also be used as an abbreviated name for the language, so I also put it as an alias).

Disclaimer: I'm currently employed at Wolfram. I'm proposing this change by my own whim, so my actions don't reflect Wolfram as a company. Just a suggestion based on what I know about possible aliases.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

❓ I'm unsure if this is the only applicable item? I'm not sure if my changes apply to this though?

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
