### PR TITLE
Feature: Add .esql extension under PLSQL language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4002,6 +4002,7 @@ PLSQL:
   - ".pls"
   - ".bdy"
   - ".ddl"
+  - ".esql"
   - ".fnc"
   - ".pck"
   - ".pkb"


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Simple change to add .esql file extension under the PLSQL language to allow syntax highlighting. ESQL is used by IBM to define and manipulate data within a message flow in IIB. https://www.ibm.com/support/knowledgecenter/SSMKHH_10.0.0/com.ibm.etools.mft.doc/ak00990_.html
This is heavily used in our on-premise GitHub Enterprise, therefore I have no examples that can be shared publicly. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.