### PR TITLE
Group Maven POM under XML

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3305,6 +3305,7 @@ Mathematica:
   language_id: 224
 Maven POM:
   type: data
+  group: XML
   tm_scope: text.xml.pom
   filenames:
   - pom.xml


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Discussion at #5189. I don't know whether Maven POM should even be it's own language but may as well group it under XML in the meantime.

[The docs](https://maven.apache.org/guides/introduction/introduction-to-the-pom.html) say:
> A Project Object Model or POM is the fundamental unit of work in Maven. It is an XML file