### PR TITLE
Fix links to lib/overrides.yml and other source files in Overrides documentation

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -102,7 +102,7 @@ vim: set ft=cpp:
 -*- c++ -*-
 ```
 
-[`documentation.yml`]: lib/linguist/documentation.yml
-[`languages.yml`]:     lib/linguist/languages.yml
-[`generated.yml`]:     lib/linguist/generated.yml
-[`vendor.yml`]:        lib/linguist/vendor.yml
+[`documentation.yml`]: https://github.com/github/linguist/blob/master/lib/linguist/documentation.yml
+[`languages.yml`]:     https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
+[`generated.yml`]:     https://github.com/github/linguist/blob/master/lib/linguist/generated.yml
+[`vendor.yml`]:        https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -102,7 +102,7 @@ vim: set ft=cpp:
 -*- c++ -*-
 ```
 
-[`documentation.yml`]: https://github.com/github/linguist/blob/master/lib/linguist/documentation.yml
-[`languages.yml`]:     https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
-[`generated.yml`]:     https://github.com/github/linguist/blob/master/lib/linguist/generated.yml
-[`vendor.yml`]:        https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml
+[`documentation.yml`]: /lib/linguist/documentation.yml
+[`languages.yml`]:     /lib/linguist/languages.yml
+[`generated.yml`]:     /lib/linguist/generated.yml
+[`vendor.yml`]:        /lib/linguist/vendor.yml


### PR DESCRIPTION
#5202 split up parts of the README into separate files located in `docs/`. The new ["Overrides" file](https://github.com/github/linguist/blob/master/docs/overrides.md) includes [relative links to source files](https://github.com/github/linguist/commit/b2834449f1dd9dd9b76652092bad9fc593f687d3#diff-297a606eeb6aa1d342e20ec58b24b0dda0d41ab32cc1f27c657a57a724923a39R105-R108) like `lib/overrides.yml`:

```markdown
 [`documentation.yml`]: lib/linguist/documentation.yml
 [`languages.yml`]:     lib/linguist/languages.yml
 [`generated.yml`]:     lib/linguist/generated.yml
 [`vendor.yml`]:        lib/linguist/vendor.yml
```

Although, GitHub routes these relative links correctly when they're in the README, they now route to https://github.com/github/linguist/blob/master/docs/lib/linguist/languages.yml, which result in a 404.

## Description

This PR replaces the relative links with absolute links, which amounts to prepending <del>`https://github.com/github/linguist/blob/master/`</del><ins>`/`</ins>.

## Checklist
_(Removed since it doesn't apply)_