### PR TITLE
Update tests for latest mini_mime update

### DIFF
--- a/test/test_blob.rb
+++ b/test/test_blob.rb
@@ -14,7 +14,7 @@ class TestBlob < Minitest::Test
   end
 
   def test_mime_type
-    assert_equal "application/postscript", fixture_blob_memory("Binary/octocat.ai").mime_type
+    assert_equal "application/pdf", fixture_blob_memory("Binary/octocat.ai").mime_type
     assert_equal "application/x-ruby", sample_blob_memory("Ruby/grit.rb").mime_type
     assert_equal "application/x-sh", sample_blob_memory("Shell/script.sh").mime_type
     assert_equal "text/plain", fixture_blob_memory("Data/README").mime_type

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -28,7 +28,7 @@ class TestFileBlob < Minitest::Test
   end
 
   def test_mime_type
-    assert_equal "application/postscript", fixture_blob("Binary/octocat.ai").mime_type
+    assert_equal "application/pdf", fixture_blob("Binary/octocat.ai").mime_type
     assert_equal "application/x-ruby", sample_blob("Ruby/grit.rb").mime_type
     assert_equal "application/x-sh", sample_blob("Shell/script.sh").mime_type
     assert_equal "application/xml", sample_blob("XML/bar.xml").mime_type


### PR DESCRIPTION

<!--- Briefly describe your changes in the field above. -->

## Description

I noticed merging #5287 today resulted in [two unrelated test failures](https://github.com/github/linguist/runs/2203011407) that didn't occur before yesterday:

```
  1) Failure:
TestBlob#test_mime_type [/home/runner/work/linguist/linguist/test/test_blob.rb:17]:
Expected: "application/postscript"
  Actual: "application/pdf"

  2) Failure:
TestFileBlob#test_mime_type [/home/runner/work/linguist/linguist/test/test_file_blob.rb:31]:
Expected: "application/postscript"
  Actual: "application/pdf"
```

MiniMime released a new version yesterday which has pulled in the latest updates from https://github.com/mime-types/mime-types-data which has in turn pulled in @Alhadis's fix to correctly classify `.ai` files as PDFs in https://github.com/mime-types/mime-types-data/issues/22

This PR updates our tests to reflect these changes.

_[ Checklist removed as it doesn't apply ]_