### PR TITLE
Add support for Extensible Metadata Platform files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6363,6 +6363,7 @@ XML:
   - ".xliff"
   - ".xmi"
   - ".xml.dist"
+  - ".xmp"
   - ".xproj"
   - ".xsd"
   - ".xspec"

--- a/samples/XML/psd-data.xmp
+++ b/samples/XML/psd-data.xmp
@@ -1,0 +1,40 @@
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 6.0-c006 79.164753, 2021/02/15-11:52:13        ">
+	<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+		<rdf:Description rdf:about=""
+			xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+			xmlns:dc="http://purl.org/dc/elements/1.1/"
+			xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/"
+			xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+			xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+			xmlns:tiff="http://ns.adobe.com/tiff/1.0/"
+			xmlns:exif="http://ns.adobe.com/exif/1.0/">
+			<xmp:CreatorTool>Adobe Photoshop CC (Macintosh)</xmp:CreatorTool>
+			<xmp:CreateDate>2018-05-05T02:56:22+10:00</xmp:CreateDate>
+			<xmp:ModifyDate>2018-05-05T02:57:06+10:00</xmp:ModifyDate>
+			<xmp:MetadataDate>2018-05-05T02:57:06+10:00</xmp:MetadataDate>
+			<dc:format>application/vnd.adobe.photoshop</dc:format>
+			<photoshop:ColorMode>3</photoshop:ColorMode>
+			<photoshop:ICCProfile>sRGB IEC61966-2.1</photoshop:ICCProfile>
+			<xmpMM:InstanceID>xmp.iid:d75f214d-dda3-4967-a014-42ffbff2dbeb</xmpMM:InstanceID>
+			<xmpMM:DocumentID>xmp.did:d75f214d-dda3-4967-a014-42ffbff2dbeb</xmpMM:DocumentID>
+			<xmpMM:OriginalDocumentID>xmp.did:d75f214d-dda3-4967-a014-42ffbff2dbeb</xmpMM:OriginalDocumentID>
+			<xmpMM:History>
+				<rdf:Seq>
+					<rdf:li rdf:parseType="Resource">
+						<stEvt:action>created</stEvt:action>
+						<stEvt:instanceID>xmp.iid:d75f214d-dda3-4967-a014-42ffbff2dbeb</stEvt:instanceID>
+						<stEvt:when>2018-05-05T02:56:22+10:00</stEvt:when>
+						<stEvt:softwareAgent>Adobe Photoshop CC (Macintosh)</stEvt:softwareAgent>
+					</rdf:li>
+				</rdf:Seq>
+			</xmpMM:History>
+			<tiff:Orientation>1</tiff:Orientation>
+			<tiff:XResolution>720000/10000</tiff:XResolution>
+			<tiff:YResolution>720000/10000</tiff:YResolution>
+			<tiff:ResolutionUnit>2</tiff:ResolutionUnit>
+			<exif:ColorSpace>1</exif:ColorSpace>
+			<exif:PixelXDimension>321</exif:PixelXDimension>
+			<exif:PixelYDimension>290</exif:PixelYDimension>
+		</rdf:Description>
+	</rdf:RDF>
+</x:xmpmeta>

--- a/test/test_strategies.rb
+++ b/test/test_strategies.rb
@@ -26,6 +26,7 @@ class TestStrategies < Minitest::Test
 
   def all_xml_fixtures(file="*")
     fixs = Dir.glob("#{samples_path}/XML/#{file}") -
+             ["#{samples_path}/XML/psd-data.xmp"] -
              ["#{samples_path}/XML/filenames"]
     fixs.reject { |f| File.symlink?(f) }
   end


### PR DESCRIPTION
## Description
This PR adds support for the eXtensible Metadata Platform format, an XML-based format predominantly used by Adobe photo-editing apps.

## Checklist:
-	[x] **I am associating a language with a new file extension.**
	-	[x] **The new extension is used in hundreds of repositories on GitHub.com**  
		Search results: [~34,228](https://github.com/search?q=extension%3Axmp+NOT+nothack&type=Code)
	-	[x] **I have included a real-world usage sample for all extensions added in this PR:**  
		-	**Sample license(s):** ISC
		-	**Sample source:** I pulled it out of a [random Photoshop file](https://github.com/file-icons/assets/blob/e2ea750146f671eb81b0a53bd520ef1ff51325f1/elements/Drop%20Shadow.psd) of mine.
			Both PSDs and AIs embed large chunks of XMP data when they're saved, which contains exactly the same as a physical, [real-world `.xmp` file](https://github.com/5Dco/5D/blob/fe6c0e7235d0c075bdec7b6c1e83379edf6790e7/assets/moonwalk.webm.xmp).
	-	[x] **I have included a change to the heuristics to** ~~distinguish~~ **_fix_ my language**.  
		XMP files don't seem to use the required XML header, which I assume is causing the failure.
