### PR TITLE
update nim grammar to support the new number literals

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,7 +66,8 @@
 	url = https://github.com/github-linguist/NSIS
 [submodule "vendor/grammars/NimLime"]
 	path = vendor/grammars/NimLime
-	url = https://github.com/Varriount/NimLime
+	url = https://github.com/timotheecour/NimLime
+	branch = master2
 [submodule "vendor/grammars/Nixinova-tmLanguage"]
 	path = vendor/grammars/Nixinova-tmLanguage
 	url = https://github.com/Nixinova/tmLanguage

--- a/samples/Nim/main.nim
+++ b/samples/Nim/main.nim
@@ -1,0 +1,84 @@
+iterator fn1: int = yield 12
+template fn2 = discard
+macro fn3 = discard
+proc fn4 = discard
+proc fn5(a, b: int, c: float, d, e: string; f: char) = discard
+
+template fn6 =
+  block: ## number literals
+    echo (1'u8, 0b1010, 0xdeadBEEF'big, -123'32, 12_345.002e-12'f128)
+    let a = 0xdeadBEEF'wrap
+    let b = -123'wrap
+
+  block: ## char literals
+    let c = '\1'
+    let c = '\e'
+    let c = '\n'
+    let c = '\x12'
+
+  block: ## string literals
+    let a = ""
+    let b = "ab\ndef"
+    let c = r"a\ndef"
+    let g = """
+a\ndef"""
+    let h = """a\ndef"""
+    let i = """a\ndef""".dedent # BUG: syntax highlight wrong
+    let j = """a\ndef"""&"asdf" # BUG: syntax highlight wrong
+    let k = """a\ndef""" & "asdf" # ok
+
+  block:
+    ## tuples
+    let a = (-123'wrap, 12'f33, )
+    let b = ()
+    let c = (1,)
+    let d = (1)
+
+  block:
+    let a = @[1]
+    let b = [1,2]
+
+proc `'fn6b`(a: string): int = discard
+proc `cast`(a: string): int = discard
+proc fn6c[T; T2](a: T): T = discard
+proc fn6d[T, T2](a: T): T = discard
+proc fn6e[T](a: T): T = discard
+
+runnableExamples: discard
+
+runnableExamples("-r:off"): discard
+
+proc fn7 =
+  runnableExamples("-r:off -d:danger"):
+    assert 1 + 1 == 2
+
+proc fn8 =
+  runnableExamples("-r:off -d:danger"):
+    assert 1 + 1 == 2
+
+proc fn9 =
+  ##[
+  hello world `foo.bar`
+  * b1
+  * b2
+  * b3
+  ]##
+  runnableExamples("-r:off -d:danger"):
+    assert 1 + 1 == 2
+
+type F10 = enum a1, a2
+type F11 = ref object of RootRef
+  x1, x2: int
+  x3: tuple[a: int]
+  x4: (int, float, float32, float64)
+
+type
+  F12 = int
+  F13 = ref F12
+
+const a = 1
+const
+  b = 2
+  c = b
+let d = "ad"
+var e = "ad"

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -295,7 +295,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **NewLisp:** [textmate/lisp.tmbundle](https://github.com/textmate/lisp.tmbundle)
 - **Nextflow:** [nextflow-io/atom-language-nextflow](https://github.com/nextflow-io/atom-language-nextflow)
 - **Nginx:** [brandonwamboldt/sublime-nginx](https://github.com/brandonwamboldt/sublime-nginx)
-- **Nim:** [timotheecour/NimLime](timotheecour/NimLime)
+- **Nim:** [timotheecour/NimLime](https://github.com/timotheecour/NimLime)
 - **Ninja:** [khyo/language-ninja](https://github.com/khyo/language-ninja)
 - **Nit:** [R4PaSs/Sublime-Nit](https://github.com/R4PaSs/Sublime-Nit)
 - **Nix:** [wmertens/sublime-nix](https://github.com/wmertens/sublime-nix)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -295,7 +295,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **NewLisp:** [textmate/lisp.tmbundle](https://github.com/textmate/lisp.tmbundle)
 - **Nextflow:** [nextflow-io/atom-language-nextflow](https://github.com/nextflow-io/atom-language-nextflow)
 - **Nginx:** [brandonwamboldt/sublime-nginx](https://github.com/brandonwamboldt/sublime-nginx)
-- **Nim:** [Varriount/NimLime](https://github.com/Varriount/NimLime)
+- **Nim:** [timotheecour/NimLime](timotheecour/NimLime)
 - **Ninja:** [khyo/language-ninja](https://github.com/khyo/language-ninja)
 - **Nit:** [R4PaSs/Sublime-Nit](https://github.com/R4PaSs/Sublime-Nit)
 - **Nix:** [wmertens/sublime-nix](https://github.com/wmertens/sublime-nix)

--- a/vendor/licenses/git_submodule/NimLime.dep.yml
+++ b/vendor/licenses/git_submodule/NimLime.dep.yml
@@ -1,7 +1,7 @@
 ---
 type: git_submodule
 name: NimLime
-version: f75325a01dd4428e12fbc38289ed6e0d12e82a9c
+version: b16e7469dd8a6a9e3e77382dfce642d424a472af
 license: mit
 licenses:
 - text: |-


### PR DESCRIPTION
update nim syntax to support the new number literals, eg:
```nim
# currently appear broken, but fixed with this PR
let a = 12'big
let b = 13'big
```

## Description
* https://github.com/Varriount/NimLime hasn't been updated in over 2 years, and a new feature in nim (number literals) renders really badly with existing grammar (causing subsequent line to render badly). This PR updates the submodule url and fixes the rendering of new number literals

## Checklist:
- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=source.nim&grammar_format=auto&grammar_url=&grammar_text=&code_source=from-text&code_url=&code=let+a+%3D+12%27big%0D%0Alet+b+%3D+13%27big
  - New: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftimotheecour%2FNimLime%2Fmaster2%2FSyntaxes%2FNim.YAML-tmLanguage&grammar_text=&code_source=from-text&code_url=&code=let+a+%3D+12%27big%0D%0Alet+b+%3D+13%27big

note that I'm also adding a new file samples/Nim/main.nim which illustrates all existing nim syntax including the new number literals which currently show up incorrectly but are being fixed via this PR

I've previously contributed to this repo for nim syntax (see https://github.com/github/linguist/pull/4295)

## links
/cc @JohnAD @Varriount 
* https://github.com/Varriount/NimLime/pull/153
* https://github.com/Varriount/NimLime/issues/154