### PR TITLE
Add .nest extension under Rebol language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4774,6 +4774,7 @@ Rebol:
   - ".r2"
   - ".r3"
   - ".rebol"
+  - ".nest"
   ace_mode: text
   tm_scope: source.rebol
   language_id: 319


### PR DESCRIPTION
## Description

Registering new `.nest` file extension under Rebol language.
Example of the file use is for example here: https://github.com/Oldes/Rebol3/blob/master/make/rebol3.nest
It's a build configuration dialect.
