### PR TITLE
Add rs alias for Rust

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5055,6 +5055,8 @@ Ruby:
   language_id: 326
 Rust:
   type: programming
+  aliases:
+  - rs
   color: "#dea584"
   extensions:
   - ".rs"


### PR DESCRIPTION
This adds an `rs` alias for Rust.

## Description
This hopefully enables Rust code highlighting for code blocks using ```rs.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [X] I have added or updated the tests for the new or changed functionality. _(I haven't found any tests that need updates.)_