### PR TITLE
[Language] TeX: add extension `.mkxl`

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5761,6 +5761,7 @@ TeX:
   - ".mkii"
   - ".mkiv"
   - ".mkvi"
+  - ".mkxl"
   - ".sty"
   - ".toc"
   language_id: 369


### PR DESCRIPTION
Used by ConTeXt LMTX. See https://github.com/contextgarden/context-mirror for examples.

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Amkxl+-repo%3Acontextgarden%2Fcontext-mirror+-repo%3Amojca%2Fcontext2+-repo%3Adebian-tex%2Fcontext+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/contextgarden/context-mirror/tree/113a26a2838ace27514f6348ed0d41bf87724472/tex/context/base/mkxl
      - https://github.com/wolfgangschuster/taccount/blob/36a70e7d7ec1e62743a603c6aaf7d180d0d5657a/files/t-taccount.mkxl
      - https://github.com/stephengaito/parallelConTeXt/blob/fcd1f2dfa1db859c4a878f0d70e9fc6d417df4d4/t-pcontext/tex/context/third/pcontext/t-pcontext.mkxl
    - Sample license(s):
      - ConTeXt: `GPL-2.0`
      - taccount: `GPL-3.0-or-later`
      - Parallel ConTeXt: `MIT`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/github/linguist/5324)
<!-- Reviewable:end -->
