### PR TITLE
nim: update grammar url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,8 +69,7 @@
 	url = https://github.com/github-linguist/NSIS
 [submodule "vendor/grammars/NimLime"]
 	path = vendor/grammars/NimLime
-  url = https://github.com/nim-lang/NimLime
-	branch = master
+	url = https://github.com/nim-lang/NimLime
 [submodule "vendor/grammars/Nova.tmLanguage"]
 	path = vendor/grammars/Nova.tmLanguage
 	url = https://github.com/Nixinova/Nova.tmLanguage

--- a/.gitmodules
+++ b/.gitmodules
@@ -69,8 +69,8 @@
 	url = https://github.com/github-linguist/NSIS
 [submodule "vendor/grammars/NimLime"]
 	path = vendor/grammars/NimLime
-	url = https://github.com/timotheecour/NimLime
-	branch = master2
+  url = https://github.com/nim-lang/NimLime
+	branch = master
 [submodule "vendor/grammars/Nova.tmLanguage"]
 	path = vendor/grammars/Nova.tmLanguage
 	url = https://github.com/Nixinova/Nova.tmLanguage

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -301,7 +301,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **NewLisp:** [textmate/lisp.tmbundle](https://github.com/textmate/lisp.tmbundle)
 - **Nextflow:** [nextflow-io/atom-language-nextflow](https://github.com/nextflow-io/atom-language-nextflow)
 - **Nginx:** [brandonwamboldt/sublime-nginx](https://github.com/brandonwamboldt/sublime-nginx)
-- **Nim:** [timotheecour/NimLime](https://github.com/timotheecour/NimLime)
+- **Nim:** [nim-lang/NimLime](https://github.com/nim-lang/NimLime)
 - **Ninja:** [khyo/language-ninja](https://github.com/khyo/language-ninja)
 - **Nit:** [R4PaSs/Sublime-Nit](https://github.com/R4PaSs/Sublime-Nit)
 - **Nix:** [wmertens/sublime-nix](https://github.com/wmertens/sublime-nix)


### PR DESCRIPTION
update grammar url following https://github.com/nim-lang/RFCs/issues/365 (https://github.com/github/linguist/pull/5306 was a necessary intermediate step)

## Checklist:
- [x] **I am changing the source of a syntax highlighting grammar**
there should be no change for now
