### PR TITLE
Change Vue's language color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6170,7 +6170,7 @@ Volt:
   language_id: 390
 Vue:
   type: markup
-  color: "#2c3e50"
+  color: "#41b883"
   extensions:
   - ".vue"
   tm_scope: text.html.vue


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

<!--- If necessary, go into depth about what this pull request is doing. -->

The green color was [originally preferred](https://github.com/github/linguist/pull/2513#issuecomment-123485637) but opted for the current color due to the green color was too close to the color of other languages, since this restriction is [no longer applied](https://github.com/github/linguist/pull/4978), it's time to switch back. 

This PR should close https://github.com/github/linguist/issues/5338 and https://github.com/vuejs/vue-next/issues/3674.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained an agreement from the wider language community on this color change.
    - https://github.com/vuejs/vue-next/issues/3674
    - [Vue author's agreement](https://github.com/github/linguist/issues/5338#issuecomment-827678510)
