### PR TITLE
Add color for LilyPond

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3013,6 +3013,7 @@ Lex:
   language_id: 199
 LilyPond:
   type: programming
+  color: "#9ccc7c"
   extensions:
   - ".ly"
   - ".ily"


### PR DESCRIPTION
This pull request adds a color for LilyPond. This color (`#9ccc7c`) is from the CSS of the LilyPond website (https://lilypond.org):

https://github.com/lilypond/lilypond/blob/0de9d9ae80957e9961d1d79193cdf71d56d94726/Documentation/css/lilypond-website.css#L526