### PR TITLE
Add imgbotconfig to JSON filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2566,6 +2566,7 @@ JSON:
   filenames:
   - ".arcconfig"
   - ".htmlhintrc"
+  - ".imgbotconfig"
   - ".tern-config"
   - ".tern-project"
   - ".watchmanconfig"

--- a/samples/JSON/filenames/.imgbotconfig
+++ b/samples/JSON/filenames/.imgbotconfig
@@ -1,0 +1,10 @@
+{
+  "schedule": "weekly",
+  "ignoredFiles": [
+    "*.svg",
+    "raw/*",
+    "public/assets/*"
+  ],
+  "minKBReduced": 200,
+  "aggressiveCompression": "false"
+}


### PR DESCRIPTION
## Description
Adds `.imgbotconfig` to the JSON filenames list.
Resolves #5359

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - [.imgbotconfig](https://github.com/search?q=filename%3Aimgbotconfig&type=code) (filename) - 447 results. It is however used only once per repository, and out of half of the search results ran using Harvester I got 178 unique users and all unique @user/repo-s.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - (manually created, CC0)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
