### PR TITLE
Add PEG.js language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,9 +76,6 @@
 [submodule "vendor/grammars/ObjectScript.tmBundle"]
 	path = vendor/grammars/ObjectScript.tmBundle
 	url = https://github.com/intersystems-community/ObjectScript.tmBundle
-[submodule "vendor/grammars/PEGjs.tmbundle"]
-	path = vendor/grammars/PEGjs.tmbundle
-	url = https://github.com/alexstrat/PEGjs.tmbundle
 [submodule "vendor/grammars/PHP-Twig.tmbundle"]
 	path = vendor/grammars/PHP-Twig.tmbundle
 	url = https://github.com/Anomareh/PHP-Twig.tmbundle

--- a/.gitmodules
+++ b/.gitmodules
@@ -76,6 +76,9 @@
 [submodule "vendor/grammars/ObjectScript.tmBundle"]
 	path = vendor/grammars/ObjectScript.tmBundle
 	url = https://github.com/intersystems-community/ObjectScript.tmBundle
+[submodule "vendor/grammars/PEGjs.tmbundle"]
+	path = vendor/grammars/PEGjs.tmbundle
+	url = https://github.com/alexstrat/PEGjs.tmbundle
 [submodule "vendor/grammars/PHP-Twig.tmbundle"]
 	path = vendor/grammars/PHP-Twig.tmbundle
 	url = https://github.com/Anomareh/PHP-Twig.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -68,6 +68,8 @@ vendor/grammars/ObjectScript.tmBundle:
 - source.objectscript_class
 - source.objectscript_csp
 - source.objectscript_macros
+vendor/grammars/PEGjs.tmbundle:
+- source.pegjs
 vendor/grammars/PHP-Twig.tmbundle:
 - text.html.twig
 vendor/grammars/PogoScript.tmbundle:

--- a/grammars.yml
+++ b/grammars.yml
@@ -69,8 +69,6 @@ vendor/grammars/ObjectScript.tmBundle:
 - source.objectscript_class
 - source.objectscript_csp
 - source.objectscript_macros
-vendor/grammars/PEGjs.tmbundle:
-- source.pegjs
 vendor/grammars/PHP-Twig.tmbundle:
 - text.html.twig
 vendor/grammars/PogoScript.tmbundle:
@@ -516,6 +514,7 @@ vendor/grammars/language-grammars:
 - source.lbnf
 - source.lex
 - source.lex.regexp
+- source.pegjs
 - source.yacc
 vendor/grammars/language-graphql:
 - source.graphql

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4192,6 +4192,16 @@ Pawn:
   tm_scope: source.pawn
   ace_mode: text
   language_id: 271
+PEG.js:
+  type: programming
+  color: "#234d6b"
+  extensions:
+  - ".pegjs"
+  tm_scope: source.pegjs
+  ace_mode: javascript
+  codemirror_mode: javascript
+  codemirror_mime_type: text/javascript
+  language_id: 81442128
 Pep8:
   type: programming
   color: "#C76F5B"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4039,6 +4039,16 @@ P4:
   tm_scope: source.p4
   ace_mode: text
   language_id: 348895984
+PEG.js:
+  type: programming
+  color: "#234d6b"
+  extensions:
+  - ".pegjs"
+  tm_scope: source.pegjs
+  ace_mode: javascript
+  codemirror_mode: javascript
+  codemirror_mime_type: text/javascript
+  language_id: 81442128
 PHP:
   type: programming
   tm_scope: text.html.php
@@ -4192,16 +4202,6 @@ Pawn:
   tm_scope: source.pawn
   ace_mode: text
   language_id: 271
-PEG.js:
-  type: programming
-  color: "#234d6b"
-  extensions:
-  - ".pegjs"
-  tm_scope: source.pegjs
-  ace_mode: javascript
-  codemirror_mode: javascript
-  codemirror_mime_type: text/javascript
-  language_id: 81442128
 Pep8:
   type: programming
   color: "#C76F5B"

--- a/samples/PEG.js/rfc5988.pegjs
+++ b/samples/PEG.js/rfc5988.pegjs
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 the original author or authors
+ * @license MIT, see LICENSE.txt for details
+ * https://github.com/cujojs/rest/blob/master/parsers/rfc5988.pegjs
+ *
+ * @author Scott Andrews
+ */
+
+start =
+  start:(i:LinkValue OptionalSP ',' OptionalSP {return i;})* last:LinkValue
+  { return start.concat([last]) }
+
+LinkValue =
+  '<' href:URIReference '>' OptionalSP params:LinkParams*
+  {
+    var link = {};
+    params.forEach(function (param) {
+      link[param[0]] = param[1];
+    });
+    link.href = href;
+    return link;
+  }
+
+LinkParams = 
+  ';' OptionalSP param:LinkParam OptionalSP
+  { return param }
+
+URIReference =
+  // TODO see http://tools.ietf.org/html/rfc3987#section-3.1
+  url:[^>]+
+  { return url.join('') }
+
+LinkParam = 
+  name:LinkParamName value:LinkParamValue?
+  { return [name, value] }
+
+LinkParamName =
+  name:[a-z]+
+  { return name.join('') }
+
+LinkParamValue =
+  "=" str:(PToken / QuotedString)
+  { return str }
+
+PToken =
+  token:PTokenChar+
+  { return token.join('') }
+
+PTokenChar = '!' / '#' / '$' / '%' / '&' / "'" / '('
+           / ')' / '*' / '+' / '-' / '.' / '|' / Digit
+           / ':' / '<' / '=' / '>' / '?' / '@' / Alpha
+           / '[' / ']' / '^' / '_' / '`' / '{' / [//]
+           / '}' / '~'
+
+OptionalSP =
+  SP*
+
+QuotedString =
+  DQ str:QuotedStringInternal DQ
+  { return str }
+
+QuotedStringInternal =
+  str:(QDText / QuotedPair )*
+  { return str.join('') }
+
+Char        = [\x00-\x7F]
+UpAlpha     = [A-Z]
+LoAlpha     = [a-z]
+Alpha       = UpAlpha / LoAlpha
+Digit       = [0-9]
+SP          = [\x20]
+DQ          = [\x22]
+QDText      = [^"]
+QuotedPair  = [\\] Char

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -329,7 +329,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Ox:** [andreashetland/sublime-text-ox](https://github.com/andreashetland/sublime-text-ox)
 - **Oz:** [eregon/oz-tmbundle](https://github.com/eregon/oz-tmbundle)
 - **P4:** [TakeshiTseng/atom-language-p4](https://github.com/TakeshiTseng/atom-language-p4)
-- **PEG.js:** [alexstrat/PEGjs.tmbundle](https://github.com/alexstrat/PEGjs.tmbundle)
+- **PEG.js:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
 - **PHP:** [textmate/php.tmbundle](https://github.com/textmate/php.tmbundle)
 - **PLpgSQL:** [textmate/sql.tmbundle](https://github.com/textmate/sql.tmbundle)
 - **POV-Ray SDL:** [c-lipka/language-povray](https://github.com/c-lipka/language-povray)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -328,6 +328,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Ox:** [andreashetland/sublime-text-ox](https://github.com/andreashetland/sublime-text-ox)
 - **Oz:** [eregon/oz-tmbundle](https://github.com/eregon/oz-tmbundle)
 - **P4:** [TakeshiTseng/atom-language-p4](https://github.com/TakeshiTseng/atom-language-p4)
+- **PEG.js:** [alexstrat/PEGjs.tmbundle](https://github.com/alexstrat/PEGjs.tmbundle)
 - **PHP:** [textmate/php.tmbundle](https://github.com/textmate/php.tmbundle)
 - **PLpgSQL:** [textmate/sql.tmbundle](https://github.com/textmate/sql.tmbundle)
 - **POV-Ray SDL:** [c-lipka/language-povray](https://github.com/c-lipka/language-povray)

--- a/vendor/licenses/git_submodule/language-grammars.dep.yml
+++ b/vendor/licenses/git_submodule/language-grammars.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: language-grammars
-version: 4fc0dfab1453492a3ebd6560c9107448812ec86c
+version: cbeecb8a856f1536174a1f4370bc00285576bf40
 type: git_submodule
 homepage: https://github.com/Alhadis/language-grammars
 license: isc


### PR DESCRIPTION
## Description
Adds the [PEG.js](https://pegjs.org/) language, file extension `.pegjs`.
Resolves #5373

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension: [.pegjs](https://github.com/search?q=extension%3Apegjs&type=code) - 100K+
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source: [repo](https://github.com/cujojs/rest/blob/master/parsers/rfc5988.pegjs), MIT
  - [x] I have included a syntax highlighting grammar: [repo](https://github.com/alexstrat/PEGjs.tmbundle), [lightshow][lightshow]
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

 [lightshow]: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Falexstrat%2FPEGjs.tmbundle%2Fmaster%2FSyntaxes%2FPEGjs.tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Faybarsgocerler%2Fecommerce-app%2F071633a95734219f01cddd77512915b10c9233c7%2Fnode_modules%2Fxcode%2Flib%2Fparser%2Fpbxproj.pegjs&code=