### PR TITLE
Improve the Kotlin language color + match modern branding

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2875,7 +2875,7 @@ Kit:
   language_id: 188
 Kotlin:
   type: programming
-  color: "#F18E33"
+  color: "#664ACC"
   extensions:
   - ".kt"
   - ".ktm"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2875,7 +2875,7 @@ Kit:
   language_id: 188
 Kotlin:
   type: programming
-  color: "#664ACC"
+  color: "#A97BFF"
   extensions:
   - ".kt"
   - ".ktm"


### PR DESCRIPTION
The previous color no longer matches the kotlin branding colors and hasn't aged well. This matches the newer branding

Before: `#f18e33`
After: `#A97BFF`

![image](https://user-images.githubusercontent.com/1361086/119437625-8a170400-bcec-11eb-9df3-e3e3443b3e90.png)

## Checklist:

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - I don't know necessarily where to create a wider discussion but happy to post somewhere you recommend!
    - [Added by @lildude]: Discussion started at https://discuss.kotlinlang.org/t/proposed-color-change-for-kotlins-language-on-github/21931
    - https://twitter.com/kotlin