### PR TITLE
Adding FIDL to github linguist

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1565,6 +1565,14 @@ F*:
   tm_scope: source.fstar
   ace_mode: text
   language_id: 336943375
+FIDL:
+  type: programming
+  color: "#d63964"
+  extensions:
+  - ".fidl"
+  ace_mode: text
+  tm_scope: none
+  language_id: 432
 FIGlet Font:
   type: data
   aliases:


### PR DESCRIPTION
The Fuchsia Interface Definition Language (FIDL) is the core language
describing API and ABI in the Fuchsia OS.

References:

* https://fuchsia.dev/fuchsia-src/concepts/fidl/overview
* https://fuchsia.dev/

<!--- Briefly describe your changes in the field above. -->

## Description

See PR description. I'm hoping this PR gets things started, and others can contribute grammar / samples / etc. Let me know if more is needed.

## Checklist:
- [ x] **I am associating a language with a new file extension.**
  - [x ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Afidl+protocol+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.