### PR TITLE
Add colours for Awk and regular expression source

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -431,6 +431,7 @@ Avro IDL:
   language_id: 785497837
 Awk:
   type: programming
+  color: "#c30e9b"
   extensions:
   - ".awk"
   - ".auk"
@@ -4881,6 +4882,7 @@ Redirect Rules:
   language_id: 1020148948
 Regular Expression:
   type: data
+  color: "#009a00"
   extensions:
   - ".regexp"
   - ".regex"


### PR DESCRIPTION
This PR adds a language colour for Awk, taken from the covers of [_"Effective Awk Programming"_](https://www.amazon.com.au/Effective-awk-Programming-Universal-Processing-ebook/dp/B00U8232XM) and [_"sed & awk"_](https://www.oreilly.com/library/view/sed-awk/1565922255/):

<img src="https://user-images.githubusercontent.com/2346707/119960434-4cfe8a80-bfe8-11eb-9508-c35e152e726f.png" alt="Figure 1" width="700" />

Regular expression colour taken from the default colour palette of many vintage code editors (which incidentally happens to be the one I'm most used  to seeing). It's as suitable a colour as any. 😜

_(Template removed because it doesn't apply)._