### PR TITLE
Fix incorrect capitalisation in `.properties` heuristic

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -445,7 +445,7 @@ disambiguations:
     - pattern: '^[#!]'
   - language: INI
     named_pattern: key_equals_value
-  - language: Java properties
+  - language: Java Properties
     pattern: '^[^#!][^:]*:'
 - extensions: ['.q']
   rules:


### PR DESCRIPTION
```diff
- - language: Java properties
+ - language: Java Properties
```

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
The word "properties" in "Java Properties" was not capitalised in one instance, which leads to a mismatch between the heuristic result and language name.

For me this led to my [Linguist port](https://github.com/Nixinova/Linguist) throwing as it couldn't find an associated language for this heuristic (the port fetches this repo's yml files).

