### PR TITLE
Add .gobook as an extension to Markdown

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3347,6 +3347,7 @@ Markdown:
   - ".ronn"
   - ".scd"
   - ".workbook"
+  - ".gobook"
   filenames:
   - contents.lr
   tm_scope: source.gfm


### PR DESCRIPTION
I've developed an extension for VS Code that has a file extension of .gobook, it works like a Jupyter notebook running Go code in a REPL, except the source code is fully markdown compliant. This would allow code committed to GitHub as a .gobook extension to be rendered correctly.

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://marketplace.visualstudio.com/items?itemName=gobookdev.gobook
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.