### PR TITLE
Lock docker version and require set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2-alpine
+FROM ruby:2-alpine3.13
 
 RUN apk --update add --virtual build_deps \
     build-base \

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,7 +3,7 @@ require "minitest/autorun"
 require "mocha/minitest"
 require "linguist"
 require "linguist/blob"
-require 'licensee'
+require "licensee"
 require "set"
 
 def fixtures_path

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,6 +4,7 @@ require "mocha/minitest"
 require "linguist"
 require "linguist/blob"
 require 'licensee'
+require "set"
 
 def fixtures_path
   File.expand_path("../fixtures", __FILE__)


### PR DESCRIPTION
I noticed yesterday that our tests have started failing:

```
  1) Error:
TestClassifier#test_classify_ambiguous_languages:
NameError: uninitialized constant TestClassifier::Set
    /home/runner/work/linguist/linguist/test/test_classifier.rb:53:in `test_classify_ambiguous_languages'
```

This is caused by a missing `require "set"` that is needed for the use of `Set()` in the test. I'm not sure why this is suddenly an issue now without any changes. I can only think we were inadvertently getting this elsewhere.

The docker build is also failing with:

```
[...]
(6/7) Installing libressl3.3-libtls (3.3.3-r0)
ERROR: libressl3.3-libtls-3.3.3-r0: trying to overwrite usr/lib/libtls.so.20 owned by libretls-3.3.3-r0.
ERROR: libressl3.3-libtls-3.3.3-r0: trying to overwrite usr/lib/libtls.so.20.0.3 owned by libretls-3.3.3-r0.
(7/7) Installing libressl-dev (3.3.3-r0)
Executing busybox-1.33.1-r2.trigger
1 error; 333 MiB in 74 packages
The command '/bin/sh -c apk --update add --virtual build_deps     build-base     libc-dev     linux-headers     cmake     && apk --no-cache add icu-dev libressl-dev     && gem install github-linguist     && apk del build_deps build-base libc-dev linux-headers cmake' returned a non-zero code: 1
Error: Process completed with exit code 1.
```

This being tracked upstream in https://gitlab.alpinelinux.org/alpine/aports/-/issues/12763 and the workaround is to lock to an earlier version of Alpine, which I'm doing by locking us to 3.13.