### PR TITLE
Add filesize metrics to `github-linguist` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ $ github-linguist
 0.31%   1212       Dockerfile
 ```
 
-##### Additional options - Breakdown
+#### Additional options
+
+##### `--breakdown`
 The `--breakdown` or `-b` flag will additionally show the breakdown of files by language.
 
 You can try running `github-linguist` on the root directory in this repository itself:
@@ -117,7 +119,7 @@ lib/linguist.rb
 …
 ```
 
-##### Additional options - JSON
+##### `--json`
 The `--json` or `-j` flag output the data into JSON format.
 
 ```console

--- a/README.md
+++ b/README.md
@@ -73,23 +73,38 @@ project.languages      #=> { "Ruby" => 119387 }
 #### Git Repository
 
 A repository's languages stats can also be assessed from the command line using the `github-linguist` executable.
-Without any options, `github-linguist` will output the breakdown that correlates to what is shown in the language stats bar.
-The `--breakdown` flag will additionally show the breakdown of files by language.
+Without any options, `github-linguist` will output the language breakdown by percentage and file size.
 
 ```bash
-cd /path-to-repository/
+cd /path-to-repository
 github-linguist
 ```
 
 You can try running `github-linguist` on the root directory in this repository itself:
 
 ```console
+$ github-linguist
+66.84%  264519     Ruby
+24.68%  97685      C
+6.57%   25999      Go
+1.29%   5098       Lex
+0.32%   1257       Shell
+0.31%   1212       Dockerfile
+```
+
+##### Additional options - Breakdown
+The `--breakdown` or `-b` flag will additionally show the breakdown of files by language.
+
+You can try running `github-linguist` on the root directory in this repository itself:
+
+```console
 $ github-linguist --breakdown
-68.57%  Ruby
-22.90%  C
-6.93%   Go
-1.21%   Lex
-0.39%   Shell
+66.84%  264519     Ruby
+24.68%  97685      C
+6.57%   25999      Go
+1.29%   5098       Lex
+0.32%   1257       Shell
+0.31%   1212       Dockerfile
 
 Ruby:
 Gemfile
@@ -100,6 +115,21 @@ ext/linguist/extconf.rb
 github-linguist.gemspec
 lib/linguist.rb
 …
+```
+
+##### Additional options - JSON
+The `--json` or `-j` flag output the data into JSON format.
+
+```console
+$ github-linguist --json
+{"Dockerfile":{"size":1212,"percentage":"0.31"},"Ruby":{"size":264519,"percentage":"66.84"},"C":{"size":97685,"percentage":"24.68"},"Lex":{"size":5098,"percentage":"1.29"},"Shell":{"size":1257,"percentage":"0.32"},"Go":{"size":25999,"percentage":"6.57"}}
+```
+
+This option can be used in conjunction with `--breakdown` to get a full list of files along with the size and percentage data.
+```console
+$ github-linguist --breakdown --json
+{"Dockerfile":{"size":1212,"percentage":"0.31","files":["Dockerfile","tools/grammars/Dockerfile"]},"Ruby":{"size":264519,"percentage":"66.84","files":["Gemfile","Rakefile","bin/git-linguist","bin/github-linguist","ext/linguist/extconf.rb","github-linguist.gemspec","lib/linguist.rb",...]}}
+
 ```
 
 #### Single file
@@ -123,17 +153,19 @@ If you have Docker installed you can build an image and run Linguist within a co
 ```console
 $ docker build -t linguist .
 $ docker run --rm -v $(pwd):$(pwd) -w $(pwd) -t linguist
-68.57%  Ruby
-22.90%  C
-6.93%   Go
-1.21%   Lex
-0.39%   Shell
+66.84%  264519     Ruby
+24.68%  97685      C
+6.57%   25999      Go
+1.29%   5098       Lex
+0.32%   1257       Shell
+0.31%   1212       Dockerfile
 $ docker run --rm -v $(pwd):$(pwd) -w $(pwd) -t linguist github-linguist --breakdown
-68.57%  Ruby
-22.90%  C
-6.93%   Go
-1.21%   Lex
-0.39%   Shell
+66.84%  264519     Ruby
+24.68%  97685      C
+6.57%   25999      Go
+1.29%   5098       Lex
+0.32%   1257       Shell
+0.31%   1212       Dockerfile
 
 Ruby:
 Gemfile

--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -122,6 +122,17 @@ def git_linguist(args)
     wrapper.linguist do |linguist|
       puts JSON.dump(linguist.languages)
     end
+  when "detailed-stats"
+    wrapper.linguist do |linguist|
+      repo_size = linguist.size
+      languages = {}
+      linguist.languages.each do |language, size|
+        percentage = sprintf '%.2f' % ((size / repo_size.to_f) * 100)
+        languages.merge!({"#{language}": { percentage: "#{percentage}%", size: size } })
+      end
+
+      puts JSON.dump(languages)
+    end
   when "breakdown"
     wrapper.linguist do |linguist|
       puts JSON.dump(linguist.breakdown_by_file)

--- a/bin/git-linguist
+++ b/bin/git-linguist
@@ -122,17 +122,6 @@ def git_linguist(args)
     wrapper.linguist do |linguist|
       puts JSON.dump(linguist.languages)
     end
-  when "detailed-stats"
-    wrapper.linguist do |linguist|
-      repo_size = linguist.size
-      languages = {}
-      linguist.languages.each do |language, size|
-        percentage = sprintf '%.2f' % ((size / repo_size.to_f) * 100)
-        languages.merge!({"#{language}": { percentage: "#{percentage}%", size: size } })
-      end
-
-      puts JSON.dump(languages)
-    end
   when "breakdown"
     wrapper.linguist do |linguist|
       puts JSON.dump(linguist.breakdown_by_file)

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -13,8 +13,8 @@ Linguist v#{Linguist::VERSION}
 Detect language type and determine language breakdown for a given Git repository.
 
 Usage: linguist <path>
-      linguist <path> [--breakdown] [--json]
-      linguist [--breakdown] [--json]
+       linguist <path> [--breakdown] [--json]
+       linguist [--breakdown] [--json]
 HELP
 
 def github_linguist(args)

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -47,25 +47,39 @@ def github_linguist(args)
     rugged = Rugged::Repository.new(path)
     repo = Linguist::Repository.new(rugged, rugged.head.target_id)
 
-    if !json_breakdown
-      repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
-        percentage = ((size / repo.size.to_f) * 100)
-        percentage = sprintf '%.2f' % percentage
-        puts "%-7s %s" % ["#{percentage}%", language]
-      end
+    full_results = {}
+    repo.languages.each do |language, size|
+      percentage = ((size / repo.size.to_f) * 100)
+      percentage = sprintf '%.2f' % percentage
+      full_results.merge!({"#{language}": { percentage: percentage } })
     end
-    if breakdown
-      puts
-      file_breakdown = repo.breakdown_by_file
-      file_breakdown.each do |lang, files|
-        puts "#{lang}:"
-        files.each do |file|
-          puts file
-        end
-        puts
+
+    if !json_breakdown
+      full_results.sort_by { |_, v| v[:percentage] }.reverse.each do |language, details|
+        puts "%-7s %s" % ["#{details[:percentage]}%", language]
       end
-    elsif json_breakdown
-      puts JSON.dump(repo.breakdown_by_file)
+      if breakdown
+        puts
+        file_breakdown = repo.breakdown_by_file
+        file_breakdown.each do |lang, files|
+          puts "#{lang}:"
+          files.each do |file|
+            puts file
+          end
+          puts
+        end
+      end
+    else
+      if !breakdown
+        puts JSON.dump(full_results)
+      else
+        combined_results = full_results.merge({})
+
+        repo.breakdown_by_file.each do |language, files|
+          combined_results[language.to_sym].update({"files": files})
+        end
+        puts JSON.dump(combined_results)
+      end
     end
   elsif File.file?(path)
 

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -25,9 +25,9 @@ def github_linguist(args)
   parser = OptionParser.new do |opts|
     opts.banner = HELP_TEXT
 
-    opts.on("-b", "--breakdown", "Breakdown stuff") { breakdown = true }
-    opts.on("-j", "--json", "Output results in JSON format") { json_output = true }
-    opts.on("-h", "--help", "Prints this help") do
+    opts.on("-b", "--breakdown", "Analyze entire repository and display detailed usage statistics") { breakdown = true }
+    opts.on("-j", "--json", "Output results as JSON") { json_output = true }
+    opts.on("-h", "--help", "Display a short usage summary, then exit") do
       puts opts
       exit
     end

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -19,14 +19,14 @@ HELP
 
 def github_linguist(args)
   breakdown = false
-  json_breakdown = false
+  json_output = false
   path = Dir.pwd
 
   parser = OptionParser.new do |opts|
     opts.banner = HELP_TEXT
 
     opts.on("-b", "--breakdown", "Breakdown stuff") { breakdown = true }
-    opts.on("-j", "--json", "Output results in JSON format") { json_breakdown = true }
+    opts.on("-j", "--json", "Output results in JSON format") { json_output = true }
     opts.on("-h", "--help", "Prints this help") do
       puts opts
       exit
@@ -54,7 +54,7 @@ def github_linguist(args)
       full_results.merge!({"#{language}": { size: size, percentage: percentage } })
     end
 
-    if !json_breakdown
+    if !json_output
       full_results.sort_by { |_, v| v[:size] }.reverse.each do |language, details|
         puts "%-7s %-10s %s" % ["#{details[:percentage]}%", details[:size], language]
       end
@@ -103,7 +103,7 @@ def github_linguist(args)
       'Binary'
     end
 
-    if json_breakdown
+    if json_output
       puts JSON.generate( { path =>  {
                                         :lines => blob.loc,
                                         :sloc => blob.sloc,

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -51,12 +51,12 @@ def github_linguist(args)
     repo.languages.each do |language, size|
       percentage = ((size / repo.size.to_f) * 100)
       percentage = sprintf '%.2f' % percentage
-      full_results.merge!({"#{language}": { percentage: percentage } })
+      full_results.merge!({"#{language}": { size: size, percentage: percentage } })
     end
 
     if !json_breakdown
-      full_results.sort_by { |_, v| v[:percentage] }.reverse.each do |language, details|
-        puts "%-7s %s" % ["#{details[:percentage]}%", language]
+      full_results.sort_by { |_, v| v[:size] }.reverse.each do |language, details|
+        puts "%-7s %-10s %s" % ["#{details[:percentage]}%", details[:size], language]
       end
       if breakdown
         puts

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -134,14 +134,7 @@ def github_linguist(args)
       end
     end
   else
-    abort <<-HELP
-    Linguist v#{Linguist::VERSION}
-    Detect language type for a file, or, given a repository, determine language breakdown.
-
-    Usage: linguist <path>
-          linguist <path> [--breakdown] [--json]
-          linguist [--breakdown] [--json]
-    HELP
+    abort HELP_TEXT
   end
 end
 

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -8,22 +8,40 @@ require 'json'
 require 'optparse'
 require 'pathname'
 
-def github_linguist(args)
-  path = args[0] || Dir.pwd
+HELP_TEXT = <<~HELP
+Linguist v#{Linguist::VERSION}
+Detect language type and determine language breakdown for a given Git repository.
 
-  # special case if not given a directory
-  # but still given the --breakdown or --json options/
-  if path == "--breakdown"
-    path = Dir.pwd
-    breakdown = true
-  elsif path == "--json"
-    path = Dir.pwd
-    json_breakdown = true
+Usage: linguist <path>
+      linguist <path> [--breakdown] [--json]
+      linguist [--breakdown] [--json]
+HELP
+
+def github_linguist(args)
+  breakdown = false
+  json_breakdown = false
+  path = Dir.pwd
+
+  parser = OptionParser.new do |opts|
+    opts.banner = HELP_TEXT
+
+    opts.on("-b", "--breakdown", "Breakdown stuff") { breakdown = true }
+    opts.on("-j", "--json", "Output results in JSON format") { json_breakdown = true }
+    opts.on("-h", "--help", "Prints this help") do
+      puts opts
+      exit
+    end
   end
 
-  args.shift
-  breakdown = true if args[0] == "--breakdown"
-  json_breakdown = true if args[0] == "--json"
+  parser.parse!(args)
+
+  if !args.empty?
+    if File.directory?(args[0]) || File.file?(args[0])
+      path = args[0]
+    else
+      abort HELP_TEXT
+    end
+  end
 
   if File.directory?(path)
     rugged = Rugged::Repository.new(path)

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -8,105 +8,109 @@ require 'json'
 require 'optparse'
 require 'pathname'
 
-path = ARGV[0] || Dir.pwd
+def github_linguist(args)
+  path = args[0] || Dir.pwd
 
-# special case if not given a directory
-# but still given the --breakdown or --json options/
-if path == "--breakdown"
-  path = Dir.pwd
-  breakdown = true
-elsif path == "--json"
-  path = Dir.pwd
-  json_breakdown = true
-end
-
-ARGV.shift
-breakdown = true if ARGV[0] == "--breakdown"
-json_breakdown = true if ARGV[0] == "--json"
-
-if File.directory?(path)
-  rugged = Rugged::Repository.new(path)
-  repo = Linguist::Repository.new(rugged, rugged.head.target_id)
-
-  if !json_breakdown
-    repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
-      percentage = ((size / repo.size.to_f) * 100)
-      percentage = sprintf '%.2f' % percentage
-      puts "%-7s %s" % ["#{percentage}%", language]
-    end
+  # special case if not given a directory
+  # but still given the --breakdown or --json options/
+  if path == "--breakdown"
+    path = Dir.pwd
+    breakdown = true
+  elsif path == "--json"
+    path = Dir.pwd
+    json_breakdown = true
   end
-  if breakdown
-    puts
-    file_breakdown = repo.breakdown_by_file
-    file_breakdown.each do |lang, files|
-      puts "#{lang}:"
-      files.each do |file|
-        puts file
+
+  args.shift
+  breakdown = true if args[0] == "--breakdown"
+  json_breakdown = true if args[0] == "--json"
+
+  if File.directory?(path)
+    rugged = Rugged::Repository.new(path)
+    repo = Linguist::Repository.new(rugged, rugged.head.target_id)
+
+    if !json_breakdown
+      repo.languages.sort_by { |_, size| size }.reverse.each do |language, size|
+        percentage = ((size / repo.size.to_f) * 100)
+        percentage = sprintf '%.2f' % percentage
+        puts "%-7s %s" % ["#{percentage}%", language]
       end
+    end
+    if breakdown
       puts
+      file_breakdown = repo.breakdown_by_file
+      file_breakdown.each do |lang, files|
+        puts "#{lang}:"
+        files.each do |file|
+          puts file
+        end
+        puts
+      end
+    elsif json_breakdown
+      puts JSON.dump(repo.breakdown_by_file)
     end
-  elsif json_breakdown
-    puts JSON.dump(repo.breakdown_by_file)
-  end
-elsif File.file?(path)
+  elsif File.file?(path)
 
-  begin
-    # Check if this file is inside a git repository so we have things like
-    # `.gitattributes` applied.
-    file_full_path = File.realpath(path)
-    rugged = Rugged::Repository.discover(file_full_path)
-    file_rel_path = file_full_path.sub(rugged.workdir, '')
-    oid = -> { rugged.head.target.tree.walk_blobs { |r, b| return b[:oid] if r + b[:name] == file_rel_path } }
-    blob = Linguist::LazyBlob.new(rugged, oid.call, file_rel_path)
-  rescue Rugged::RepositoryError
-    blob = Linguist::FileBlob.new(path, Dir.pwd)
-  end
+    begin
+      # Check if this file is inside a git repository so we have things like
+      # `.gitattributes` applied.
+      file_full_path = File.realpath(path)
+      rugged = Rugged::Repository.discover(file_full_path)
+      file_rel_path = file_full_path.sub(rugged.workdir, '')
+      oid = -> { rugged.head.target.tree.walk_blobs { |r, b| return b[:oid] if r + b[:name] == file_rel_path } }
+      blob = Linguist::LazyBlob.new(rugged, oid.call, file_rel_path)
+    rescue Rugged::RepositoryError
+      blob = Linguist::FileBlob.new(path, Dir.pwd)
+    end
 
-  type = if blob.text?
-    'Text'
-  elsif blob.image?
-    'Image'
+    type = if blob.text?
+      'Text'
+    elsif blob.image?
+      'Image'
+    else
+      'Binary'
+    end
+
+    if json_breakdown
+      puts JSON.generate( { path =>  {
+                                        :lines => blob.loc,
+                                        :sloc => blob.sloc,
+                                        :type => type,
+                                        :mime_type => blob.mime_type,
+                                        :language => blob.language,
+                                        :large => blob.large?,
+                                        :generated => blob.generated?,
+                                        :vendored => blob.vendored?,
+                                      }
+                          } )
+    else
+      puts "#{path}: #{blob.loc} lines (#{blob.sloc} sloc)"
+      puts "  type:      #{type}"
+      puts "  mime type: #{blob.mime_type}"
+      puts "  language:  #{blob.language}"
+
+      if blob.large?
+        puts "  blob is too large to be shown"
+      end
+
+      if blob.generated?
+        puts "  appears to be generated source code"
+      end
+
+      if blob.vendored?
+        puts "  appears to be a vendored file"
+      end
+    end
   else
-    'Binary'
+    abort <<-HELP
+    Linguist v#{Linguist::VERSION}
+    Detect language type for a file, or, given a repository, determine language breakdown.
+
+    Usage: linguist <path>
+          linguist <path> [--breakdown] [--json]
+          linguist [--breakdown] [--json]
+    HELP
   end
-
-  if json_breakdown
-    puts JSON.generate( { path =>  {
-                                      :lines => blob.loc,
-                                      :sloc => blob.sloc,
-                                      :type => type,
-                                      :mime_type => blob.mime_type,
-                                      :language => blob.language,
-                                      :large => blob.large?,
-                                      :generated => blob.generated?,
-                                      :vendored => blob.vendored?,
-                                    }
-                        } )
-  else
-    puts "#{path}: #{blob.loc} lines (#{blob.sloc} sloc)"
-    puts "  type:      #{type}"
-    puts "  mime type: #{blob.mime_type}"
-    puts "  language:  #{blob.language}"
-
-    if blob.large?
-      puts "  blob is too large to be shown"
-    end
-
-    if blob.generated?
-      puts "  appears to be generated source code"
-    end
-
-    if blob.vendored?
-      puts "  appears to be a vendored file"
-    end
-  end
-else
-  abort <<-HELP
-  Linguist v#{Linguist::VERSION}
-  Detect language type for a file, or, given a repository, determine language breakdown.
-
-  Usage: linguist <path>
-         linguist <path> [--breakdown] [--json]
-         linguist [--breakdown] [--json]
-  HELP
 end
+
+github_linguist(ARGV)


### PR DESCRIPTION
## Description
### Adding Size of Language
When generating Linguist statistics there was some missing information that could be useful to the developer, specifically the size of files for a given language. This PR adds in that data to the output of the tool.

### Command Line Options
Additionally, while adding this functionality in, it was found that the two options currently available, `--breakdown` and `--json` delivered differing information when chosen. Currently, the tool will allow a user to pick one of these two options to get some information around the repository.

The `--breakdown` option allowed the user to get a list of languages with the percentage of the repository it comprised of as well as a list of files broken out by language in that repository (everything this script currently supplies to the user). 

The `--json` option, however, only allowed the user to get a JSON representation of the list of files that were broken out by language in that repository in a JSON format. There was not a way to see the percentage of the repository that language consisted of or the total file size of each language.

This PR also cleans up these options to do the following:

* If no options are supplied, the listing of languages, their percentage of the total repository, and the total file size of the language-specific files is output in a CLI-Output friendly format
* If only the `--json` option is given, the listing of languages, their percentage of the total repository, and the total file size of the language-specific files is output in JSON format
* If only the `--breakdown` option is given, the listing of languages, their percentage of the total repository, the total file size of the language-specific files, and a listing of every file organized by language is output in a CLI-Output friendly format
* If both `--breakdown` and `--json` options are given, the listing of languages, their percentage of the total repository, the total file size of the language-specific files, and a listing of every file organized by language is output in JSON format

### Usage
`bin/github-linguist --breakdown --json`

### Results
The result example below is of the `github-linguist` repository itself.

JSON Fromat response
```console
$ github-linguist --json
```

```json
{"Dockerfile":{"size":1212,"percentage":"0.31"},"Ruby":{"size":264519,"percentage":"66.84"},"C":{"size":97685,"percentage":"24.68"},"Lex":{"size":5098,"percentage":"1.29"},"Shell":{"size":1257,"percentage":"0.32"},"Go":{"size":25999,"percentage":"6.57"}}
```

JSON Format response with the file breakdown
```console
$ github-linguist --json --breakdown
```

```json
{"Dockerfile":{"size":1212,"percentage":"0.31","files":["Dockerfile","tools/grammars/Dockerfile"]},"Ruby":{"size":264519,"percentage":"66.84","files":["Gemfile","Rakefile","bin/git-linguist","bin/github-linguist","ext/linguist/extconf.rb","github-linguist.gemspec","lib/linguist.rb","lib/linguist/blob.rb","lib/linguist/blob_helper.rb","lib/linguist/classifier.rb","lib/linguist/file_blob.rb","lib/linguist/generated.rb","lib/linguist/grammars.rb","lib/linguist/heuristics.rb","lib/linguist/language.rb","lib/linguist/lazy_blob.rb","lib/linguist/repository.rb","lib/linguist/samples.rb","lib/linguist/sha256.rb","lib/linguist/shebang.rb","lib/linguist/strategy/extension.rb","lib/linguist/strategy/filename.rb","lib/linguist/strategy/manpage.rb","lib/linguist/strategy/modeline.rb","lib/linguist/strategy/xml.rb","lib/linguist/tokenizer.rb","lib/linguist/version.rb","script/add-grammar","script/cross-validation","script/fast-submodule-update","script/list-grammars","script/sort-submodules","script/update-ids","test/helper.rb","test/test_blob.rb","test/test_classifier.rb","test/test_file_blob.rb","test/test_generated.rb","test/test_grammars.rb","test/test_heuristics.rb","test/test_instrumentation.rb","test/test_language.rb","test/test_pedantic.rb","test/test_repository.rb","test/test_samples.rb","test/test_sha256.rb","test/test_strategies.rb","test/test_tokenizer.rb"]},"C":{"size":97685,"percentage":"24.68","files":["ext/linguist/lex.linguist_yy.c","ext/linguist/lex.linguist_yy.h","ext/linguist/linguist.c"]},"Lex":{"size":5098,"percentage":"1.29","files":["ext/linguist/tokenizer.l"]},"Shell":{"size":1257,"percentage":"0.32","files":["script/bootstrap","script/build-grammars-tarball","script/cibuild","script/grammar-compiler","tools/grammars/docker/build"]},"Go":{"size":25999,"percentage":"6.57","files":["tools/grammars/cmd/grammar-compiler/main.go","tools/grammars/compiler/converter.go","tools/grammars/compiler/cson.go","tools/grammars/compiler/data.go","tools/grammars/compiler/errors.go","tools/grammars/compiler/loader.go","tools/grammars/compiler/loader_fs.go","tools/grammars/compiler/loader_url.go","tools/grammars/compiler/pcre.go","tools/grammars/compiler/pcre_test.go","tools/grammars/compiler/proto.go","tools/grammars/compiler/walker.go","tools/grammars/pcre/pcre.go"]}}```
```

CLI-Output Friendly response
```console
$ github-linguist --breakdown
66.84%  264519     Ruby
24.68%  97685      C
6.57%   25999      Go
1.29%   5098       Lex
0.32%   1257       Shell
0.31%   1212       Dockerfile
```

CLI-Output Friendly response with the breakdown
```console
$ github-linguist --breakdown
66.84%  264519     Ruby
24.68%  97685      C
6.57%   25999      Go
1.29%   5098       Lex
0.32%   1257       Shell
0.31%   1212       Dockerfile

Dockerfile:
Dockerfile
tools/grammars/Dockerfile

Ruby:
Gemfile
Rakefile
bin/git-linguist
bin/github-linguist
ext/linguist/extconf.rb
github-linguist.gemspec
lib/linguist.rb
...
```

## Checklist:
- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality. 
  (`bin/git-linguist` does not have tests associated)
  - [x] I have added or updated the README file with a description for how to use the tool after functionality changes.
