### PR TITLE
Improve github-linguist to handle full paths to individual files

### DIFF
--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -53,11 +53,10 @@ elsif File.file?(path)
   begin
     # Check if this file is inside a git repository so we have things like
     # `.gitattributes` applied.
-    file_full_path = Pathname.new File.join(Dir.pwd, path)
+    file_full_path = File.realpath(path)
     rugged = Rugged::Repository.discover(file_full_path)
-    file_rel_path = file_full_path.relative_path_from(rugged.workdir).to_s
+    file_rel_path = file_full_path.sub(rugged.workdir, '')
     oid = -> { rugged.head.target.tree.walk_blobs { |r, b| return b[:oid] if r + b[:name] == file_rel_path } }
-
     blob = Linguist::LazyBlob.new(rugged, oid.call, file_rel_path)
   rescue Rugged::RepositoryError
     blob = Linguist::FileBlob.new(path, Dir.pwd)


### PR DESCRIPTION
I discovered today that running the updated `github-linguist` doesn't correctly handle being passed full paths:

```console
$ bundle exec bin/github-linguist ~/tmp/trash/overmind/dialer.go
bundler: failed to load command: bin/github-linguist (bin/github-linguist)
Traceback (most recent call last):
	16: from /Users/lildude/.asdf/installs/ruby/2.7.2/bin/bundle:23:in `<main>'
	15: from /Users/lildude/.asdf/installs/ruby/2.7.2/bin/bundle:23:in `load'
	14: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/exe/bundle:37:in `<top (required)>'
	13: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	12: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/exe/bundle:49:in `block in <top (required)>'
	11: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/cli.rb:24:in `start'
	10: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	 9: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/cli.rb:30:in `dispatch'
	 8: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	 7: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	 6: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	 5: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/cli.rb:494:in `exec'
	 4: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/cli/exec.rb:28:in `run'
	 3: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/cli/exec.rb:63:in `kernel_load'
	 2: from /Users/lildude/.asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.17/lib/bundler/cli/exec.rb:63:in `load'
	 1: from bin/github-linguist:57:in `<top (required)>'
bin/github-linguist:57:in `discover': failed to resolve path '/Users/lildude/github/linguist/Users/lildude/tmp/trash/overmind/dialer.go': No such file or directory (Rugged::OSError)
$
```

Note the double `/Users/lildude/github/linguist/` in the path in the last line of the error.

Determining the full path is assuming the path provided is relative to the current location, which isn't the case when using `bundle exec`. The same would apply with normal `github-linguist` when a new release is made.

This PR corrects that behaviour:

```console
$ # Relative to the repo in the current directory
$ bundle exec bin/github-linguist ./Gemfile
./Gemfile: 6 lines (5 sloc)
  type:      Text
  mime type: text/plain
  language:  Ruby

$ # Absolute path to a file in repo in a directory
$ bundle exec bin/github-linguist /Users/lildude/Downloads/trash/overmind/dialer.go
/Users/lildude/tmp/trash/overmind/dialer.go: 12 lines (9 sloc)
  type:      Text
  mime type: text/plain
  language:  Go

$ # Absolute path to a file in repo in a symlinked directory
$ bundle exec bin/github-linguist /Users/lildude/tmp/trash/overmind/dialer.go
/Users/lildude/Downloads/trash/overmind/dialer.go: 12 lines (9 sloc)
  type:      Text
  mime type: text/plain
  language:  Go

$ # Absolute path using tilde
$ bundle exec bin/github-linguist ~/Downloads/trash/overmind/dialer.go
/Users/lildude/Downloads/trash/overmind/dialer.go: 12 lines (9 sloc)
  type:      Text
  mime type: text/plain
  language:  Go
```

Ref https://github.com/github/linguist/pull/5382#issuecomment-882348560
/cc @mithro 

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
  N/A - there are no tests for the cmd.