### PR TITLE
Add colours to many languages

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6447,6 +6447,7 @@ XCompose:
   language_id: 225167241
 XML:
   type: data
+  color: "#0060ac"
   tm_scope: text.xml
   ace_mode: xml
   codemirror_mode: xml

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4186,6 +4186,7 @@ PLSQL:
   language_id: 273
 PLpgSQL:
   type: programming
+  color: "#336790"
   ace_mode: pgsql
   codemirror_mode: sql
   codemirror_mime_type: text/x-sql
@@ -5264,6 +5265,7 @@ SQF:
   language_id: 332
 SQL:
   type: data
+  color: "#e38c00"
   tm_scope: source.sql
   ace_mode: sql
   codemirror_mode: sql
@@ -5281,6 +5283,7 @@ SQL:
   language_id: 333
 SQLPL:
   type: programming
+  color: "#e38c00"
   ace_mode: sql
   codemirror_mode: sql
   codemirror_mime_type: text/x-sql
@@ -5826,6 +5829,7 @@ TOML:
   language_id: 365
 TSQL:
   type: programming
+  color: "#e38c00"
   extensions:
   - ".sql"
   ace_mode: sql

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2208,6 +2208,7 @@ HTML:
   language_id: 146
 HTML+ECR:
   type: markup
+  color: "#2e1052"
   tm_scope: text.html.ecr
   group: HTML
   aliases:
@@ -2220,6 +2221,7 @@ HTML+ECR:
   language_id: 148
 HTML+EEX:
   type: markup
+  color: "#6e4a7e"
   tm_scope: text.html.elixir
   group: HTML
   aliases:
@@ -2234,6 +2236,7 @@ HTML+EEX:
   language_id: 149
 HTML+ERB:
   type: markup
+  color: "#701516"
   tm_scope: text.html.erb
   group: HTML
   aliases:
@@ -2250,6 +2253,7 @@ HTML+ERB:
   language_id: 150
 HTML+PHP:
   type: markup
+  color: "#4f5d95"
   tm_scope: text.html.php
   group: HTML
   extensions:
@@ -2260,6 +2264,7 @@ HTML+PHP:
   language_id: 151
 HTML+Razor:
   type: markup
+  color: "#512be4"
   tm_scope: text.html.cshtml
   group: HTML
   aliases:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1916,6 +1916,7 @@ Genshi:
   language_id: 126
 Gentoo Ebuild:
   type: programming
+  color: "#9400ff"
   group: Shell
   extensions:
   - ".ebuild"
@@ -1926,6 +1927,7 @@ Gentoo Ebuild:
   language_id: 127
 Gentoo Eclass:
   type: programming
+  color: "#9400ff"
   group: Shell
   extensions:
   - ".eclass"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1446,6 +1446,7 @@ Ecere Projects:
   language_id: 98
 EditorConfig:
   type: data
+  color: "#fff1f2"
   group: INI
   filenames:
   - ".editorconfig"
@@ -1986,6 +1987,7 @@ Gherkin:
   language_id: 76
 Git Attributes:
   type: data
+  color: "#F44D27"
   group: INI
   aliases:
   - gitattributes
@@ -1998,6 +2000,7 @@ Git Attributes:
   language_id: 956324166
 Git Config:
   type: data
+  color: "#F44D27"
   group: INI
   aliases:
   - gitconfig
@@ -2084,6 +2087,7 @@ Grace:
   language_id: 135
 Gradle:
   type: data
+  color: "#02303a"
   extensions:
   - ".gradle"
   tm_scope: source.groovy.gradle
@@ -2431,6 +2435,7 @@ IGOR Pro:
   language_id: 162
 INI:
   type: data
+  color: "#d1dbe0"
   extensions:
   - ".ini"
   - ".cfg"
@@ -2472,6 +2477,7 @@ Idris:
   language_id: 165
 Ignore List:
   type: data
+  color: "#000000"
   group: INI
   aliases:
   - ignore
@@ -2525,6 +2531,7 @@ Inform 7:
   language_id: 166
 Inno Setup:
   type: programming
+  color: "#264b99"
   extensions:
   - ".iss"
   - ".isl"
@@ -2710,6 +2717,7 @@ Java:
   language_id: 181
 Java Properties:
   type: data
+  color: "#2A6277"
   extensions:
   - ".properties"
   tm_scope: source.java-properties
@@ -2719,6 +2727,7 @@ Java Properties:
   language_id: 519377561
 Java Server Pages:
   type: programming
+  color: "#2A6277"
   group: Java
   aliases:
   - jsp
@@ -3682,6 +3691,7 @@ NL:
   language_id: 241
 NPM Config:
   type: data
+  color: "#cb3837"
   group: INI
   aliases:
   - npmrc
@@ -6903,6 +6913,7 @@ mupad:
   language_id: 416
 nanorc:
   type: data
+  color: "#2d004d"
   group: INI
   extensions:
   - ".nanorc"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -543,6 +543,7 @@ Bison:
   language_id: 31
 BitBake:
   type: programming
+  color: "#00bce4"
   tm_scope: none
   extensions:
   - ".bb"
@@ -1944,6 +1945,7 @@ Genie:
   language_id: 792408528
 Genshi:
   type: programming
+  color: "#951531"
   extensions:
   - ".kid"
   tm_scope: text.xml.genshi
@@ -3246,6 +3248,7 @@ Logos:
   language_id: 209
 Logtalk:
   type: programming
+  color: "#295b9a"
   extensions:
   - ".lgt"
   - ".logtalk"
@@ -4063,6 +4066,7 @@ Opal:
   language_id: 262
 Open Policy Agent:
   type: programming
+  color: "#7d9199"
   ace_mode: text
   extensions:
   - ".rego"
@@ -4070,6 +4074,7 @@ Open Policy Agent:
   tm_scope: source.rego
 OpenCL:
   type: programming
+  color: "#ed2e2d"
   group: C
   extensions:
   - ".cl"
@@ -4081,6 +4086,7 @@ OpenCL:
   language_id: 263
 OpenEdge ABL:
   type: programming
+  color: "#5ce600"
   aliases:
   - progress
   - openedge
@@ -4114,6 +4120,7 @@ OpenRC runscript:
   language_id: 265
 OpenSCAD:
   type: programming
+  color: "#e5cd45"
   extensions:
   - ".scad"
   tm_scope: source.scad
@@ -4256,6 +4263,7 @@ PLpgSQL:
   language_id: 274
 POV-Ray SDL:
   type: programming
+  color: "#6bac65"
   aliases:
   - pov-ray
   - povray
@@ -5072,6 +5080,7 @@ Riot:
   language_id: 878396783
 RobotFramework:
   type: programming
+  color: "#00c0b5"
   extensions:
   - ".robot"
   tm_scope: text.robot
@@ -5673,6 +5682,7 @@ Smalltalk:
   language_id: 352
 Smarty:
   type: programming
+  color: "#f0c040"
   extensions:
   - ".tpl"
   ace_mode: smarty
@@ -5767,6 +5777,7 @@ Starlark:
   language_id: 960266174
 Stata:
   type: programming
+  color: "#1a5f91"
   extensions:
   - ".do"
   - ".ado"
@@ -5870,6 +5881,7 @@ TI Program:
   tm_scope: none
 TLA:
   type: programming
+  color: "#4b0079"
   extensions:
   - ".tla"
   tm_scope: source.tla
@@ -5919,6 +5931,7 @@ TSX:
   language_id: 94901924
 TXL:
   type: programming
+  color: "#0178b8"
   extensions:
   - ".txl"
   tm_scope: source.txl
@@ -6069,6 +6082,7 @@ TextMate Properties:
   language_id: 981795023
 Textile:
   type: prose
+  color: "#ffe7ac"
   ace_mode: textile
   codemirror_mode: textile
   codemirror_mime_type: text/x-textile
@@ -6079,6 +6093,7 @@ Textile:
   language_id: 373
 Thrift:
   type: programming
+  color: "#D12127"
   tm_scope: source.thrift
   extensions:
   - ".thrift"
@@ -6149,6 +6164,7 @@ Unified Parallel C:
   language_id: 379
 Unity3D Asset:
   type: data
+  color: "#222c37"
   ace_mode: yaml
   codemirror_mode: yaml
   codemirror_mime_type: text/x-yaml
@@ -6193,6 +6209,7 @@ UnrealScript:
   language_id: 382
 UrWeb:
   type: programming
+  color: "#ccccee"
   aliases:
   - Ur/Web
   - Ur
@@ -6300,6 +6317,7 @@ Verilog:
   language_id: 387
 Vim Help File:
   type: prose
+  color: "#199f4b"
   aliases:
   - help
   - vimhelp
@@ -6310,6 +6328,7 @@ Vim Help File:
   language_id: 508563686
 Vim Snippet:
   type: markup
+  color: "#199f4b"
   aliases:
   - SnipMate
   - UltiSnip
@@ -6395,6 +6414,7 @@ Wavefront Object:
   language_id: 393
 Web Ontology Language:
   type: data
+  color: "#5b70bd"
   extensions:
   - ".owl"
   tm_scope: text.xml
@@ -6457,6 +6477,7 @@ Wikitext:
   language_id: 228
 Windows Registry Entries:
   type: data
+  color: "#52d5ff"
   extensions:
   - ".reg"
   tm_scope: source.reg
@@ -6474,6 +6495,7 @@ Wollok:
   language_id: 632745969
 World of Warcraft Addon Data:
   type: data
+  color: "#f7e43f"
   extensions:
   - ".toc"
   tm_scope: source.toc
@@ -6742,6 +6764,7 @@ XSLT:
   language_id: 404
 Xojo:
   type: programming
+  color: "#81bd41"
   extensions:
   - ".xojo_code"
   - ".xojo_menu"
@@ -6764,6 +6787,7 @@ Xonsh:
   language_id: 614078284
 Xtend:
   type: programming
+  color: "#24255d"
   extensions:
   - ".xtend"
   tm_scope: source.xtend
@@ -6887,6 +6911,7 @@ Zig:
   language_id: 646424281
 Zimpl:
   type: programming
+  color: "#d67711"
   extensions:
   - ".zimpl"
   - ".zmpl"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -778,6 +778,7 @@ CSS:
   language_id: 50
 CSV:
   type: data
+  color: "#237346"
   ace_mode: text
   tm_scope: none
   extensions:
@@ -5837,6 +5838,7 @@ TSQL:
   language_id: 918334941
 TSV:
   type: data
+  color: "#237346"
   ace_mode: text
   tm_scope: source.generic-db
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4707,6 +4707,7 @@ RAML:
   language_id: 308
 RDoc:
   type: prose
+  color: "#701516"
   ace_mode: rdoc
   wrap: true
   extensions:
@@ -4741,6 +4742,7 @@ REXX:
   language_id: 311
 RMarkdown:
   type: prose
+  color: "#198ce7"
   wrap: true
   ace_mode: markdown
   codemirror_mode: gfm
@@ -5710,6 +5712,7 @@ Stylus:
   language_id: 359
 SubRip Text:
   type: data
+  color: "#9e0101"
   extensions:
   - ".srt"
   ace_mode: text
@@ -6575,6 +6578,7 @@ XML:
   language_id: 399
 XML Property List:
   type: data
+  color: "#0060ac"
   group: XML
   extensions:
   - ".plist"
@@ -6928,6 +6932,7 @@ q:
   language_id: 970539067
 reStructuredText:
   type: prose
+  color: "#141414"
   wrap: true
   aliases:
   - rst

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5811,6 +5811,7 @@ TLA:
   language_id: 364
 TOML:
   type: data
+  color: "#9c4221"
   extensions:
   - ".toml"
   filenames:
@@ -5839,6 +5840,7 @@ TSV:
   language_id: 1035892117
 TSX:
   type: programming
+  color: "#2b7489"
   group: TypeScript
   extensions:
   - ".tsx"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2152,7 +2152,7 @@ Groovy:
   language_id: 142
 Groovy Server Pages:
   type: programming
-  color: "#76A8B8"
+  color: "#4298b8"
   group: Groovy
   aliases:
   - gsp

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -349,6 +349,7 @@ Arc:
   language_id: 20
 AsciiDoc:
   type: prose
+  color: "#e40046"
   ace_mode: asciidoc
   wrap: true
   extensions:
@@ -960,6 +961,7 @@ CoNLL-U:
   language_id: 421026389
 CodeQL:
   type: programming
+  color: "#140f46"
   extensions:
   - ".ql"
   - ".qll"
@@ -1072,6 +1074,7 @@ Cool:
   language_id: 68
 Coq:
   type: programming
+  color: "#d0b68c"
   extensions:
   - ".coq"
   - ".v"
@@ -1113,6 +1116,7 @@ Crystal:
   language_id: 72
 Csound:
   type: programming
+  color: "#1a1a1a"
   aliases:
   - csound-orc
   extensions:
@@ -1123,6 +1127,7 @@ Csound:
   language_id: 73
 Csound Document:
   type: programming
+  color: "#1a1a1a"
   aliases:
   - csound-csd
   extensions:
@@ -1132,6 +1137,7 @@ Csound Document:
   language_id: 74
 Csound Score:
   type: programming
+  color: "#1a1a1a"
   aliases:
   - csound-sco
   extensions:
@@ -1252,6 +1258,7 @@ Dafny:
   language_id: 969323346
 Darcs Patch:
   type: data
+  color: "#8eff23"
   aliases:
   - dpatch
   extensions:
@@ -1304,6 +1311,7 @@ Diff:
   language_id: 88
 DirectX 3D File:
   type: data
+  color: "#aace60"
   extensions:
   - ".x"
   ace_mode: text
@@ -1389,6 +1397,7 @@ ECL:
   language_id: 93
 ECLiPSe:
   type: programming
+  color: "#001d9d"
   group: prolog
   extensions:
   - ".ecl"
@@ -1427,6 +1436,7 @@ Eagle:
   language_id: 97
 Easybuild:
   type: data
+  color: "#069406"
   group: Python
   ace_mode: python
   codemirror_mode: python
@@ -1437,6 +1447,7 @@ Easybuild:
   language_id: 342840477
 Ecere Projects:
   type: data
+  color: "#913960"
   group: JavaScript
   extensions:
   - ".epj"
@@ -1587,6 +1598,7 @@ F*:
   language_id: 336943375
 FIGlet Font:
   type: data
+  color: "#FFDDBB"
   aliases:
   - FIGfont
   extensions:
@@ -1655,6 +1667,7 @@ Fennel:
   language_id: 239946126
 Filebench WML:
   type: programming
+  color: "#F6B900"
   extensions:
   - ".f"
   tm_scope: none
@@ -1717,6 +1730,7 @@ Fortran:
   language_id: 107
 Fortran Free Form:
   group: Fortran
+  color: "#4d41b1"
   type: programming
   extensions:
   - ".f90"
@@ -1788,6 +1802,7 @@ GAML:
   language_id: 290345951
 GAMS:
   type: programming
+  color: "#f49a22"
   extensions:
   - ".gms"
   tm_scope: none
@@ -1795,6 +1810,7 @@ GAMS:
   language_id: 118
 GAP:
   type: programming
+  color: "#0000cc"
   extensions:
   - ".g"
   - ".gap"
@@ -1806,6 +1822,7 @@ GAP:
   language_id: 119
 GCC Machine Description:
   type: programming
+  color: "#FFCFAB"
   extensions:
   - ".md"
   tm_scope: source.lisp
@@ -1831,6 +1848,7 @@ GDScript:
   language_id: 123
 GEDCOM:
   type: data
+  color: "#003058"
   ace_mode: text
   extensions:
   - ".ged"
@@ -1940,6 +1958,7 @@ Gentoo Eclass:
   language_id: 128
 Gerber Image:
   type: data
+  color: "#d20b00"
   aliases:
   - rs-274x
   extensions:
@@ -2166,6 +2185,7 @@ Groovy Server Pages:
   language_id: 143
 HAProxy:
   type: data
+  color: "#106da9"
   extensions:
   - ".cfg"
   filenames:
@@ -2571,6 +2591,7 @@ Isabelle:
   language_id: 170
 Isabelle ROOT:
   type: programming
+  color: "#FEFE00"
   group: Isabelle
   filenames:
   - ROOT
@@ -6895,6 +6916,7 @@ edn:
   language_id: 414
 fish:
   type: programming
+  color: "#4aae47"
   group: Shell
   interpreters:
   - fish

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2118,6 +2118,7 @@ GraphQL:
   language_id: 139
 Graphviz (DOT):
   type: data
+  color: "#2596be"
   tm_scope: source.dot
   extensions:
   - ".dot"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4624,6 +4624,7 @@ Python:
   language_id: 303
 Python console:
   type: programming
+  color: "#3572A5"
   group: Python
   aliases:
   - pycon
@@ -4632,6 +4633,7 @@ Python console:
   language_id: 428
 Python traceback:
   type: data
+  color: "#3572A5"
   group: Python
   extensions:
   - ".pytb"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2896,6 +2896,7 @@ KakouneScript:
   language_id: 603336474
 KiCad Layout:
   type: data
+  color: "#2f4aab"
   aliases:
   - pcbnew
   extensions:
@@ -2911,6 +2912,7 @@ KiCad Layout:
   language_id: 187
 KiCad Legacy Layout:
   type: data
+  color: "#2f4aab"
   extensions:
   - ".brd"
   tm_scope: source.pcb.board
@@ -2918,6 +2920,7 @@ KiCad Legacy Layout:
   language_id: 140848857
 KiCad Schematic:
   type: data
+  color: "#2f4aab"
   aliases:
   - eeschema schematic
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2332,6 +2332,7 @@ HTML+Razor:
   language_id: 479039817
 HTTP:
   type: data
+  color: "#005C9C"
   extensions:
   - ".http"
   tm_scope: source.httpspec

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -220,6 +220,7 @@ Ada:
   language_id: 11
 Adobe Font Metrics:
   type: data
+  color: "#fa0f00"
   tm_scope: source.afm
   extensions:
   - ".afm"
@@ -248,6 +249,7 @@ Alloy:
   language_id: 13
 Alpine Abuild:
   type: programming
+  color: "#0D597F"
   group: Shell
   aliases:
   - abuild
@@ -261,6 +263,7 @@ Alpine Abuild:
   language_id: 14
 Altium Designer:
   type: data
+  color: "#A89663"
   aliases:
   - altium
   extensions:
@@ -284,6 +287,7 @@ AngelScript:
   language_id: 389477596
 Ant Build System:
   type: data
+  color: "#A9157E"
   tm_scope: text.xml.ant
   filenames:
   - ant.xml
@@ -294,6 +298,7 @@ Ant Build System:
   language_id: 15
 ApacheConf:
   type: data
+  color: "#d12127"
   aliases:
   - aconf
   - apache
@@ -349,7 +354,7 @@ Arc:
   language_id: 20
 AsciiDoc:
   type: prose
-  color: "#e40046"
+  color: "#73a0c5"
   ace_mode: asciidoc
   wrap: true
   extensions:
@@ -405,6 +410,7 @@ Asymptote:
   language_id: 591605007
 Augeas:
   type: programming
+  color: "#9CC134"
   extensions:
   - ".aug"
   tm_scope: none
@@ -435,6 +441,7 @@ AutoIt:
   language_id: 27
 Avro IDL:
   type: data
+  color: "#0040FF"
   extensions:
   - ".avdl"
   tm_scope: source.avro
@@ -506,6 +513,7 @@ Befunge:
   language_id: 30
 BibTeX:
   type: markup
+  color: "#778899"
   group: TeX
   extensions:
   - ".bib"
@@ -550,6 +558,7 @@ Blade:
   language_id: 33
 BlitzBasic:
   type: programming
+  color: "#00FFAE"
   aliases:
   - b3d
   - blitz3d
@@ -573,6 +582,7 @@ BlitzMax:
   language_id: 35
 Bluespec:
   type: programming
+  color: "#12223c"
   extensions:
   - ".bsv"
   tm_scope: source.bsv
@@ -609,6 +619,7 @@ Brainfuck:
   language_id: 38
 Brightscript:
   type: programming
+  color: "#662D91"
   extensions:
   - ".brs"
   tm_scope: source.brightscript
@@ -711,6 +722,7 @@ CIL:
   language_id: 29176339
 CLIPS:
   type: programming
+  color: "#00A300"
   extensions:
   - ".clp"
   tm_scope: source.clips
@@ -718,6 +730,7 @@ CLIPS:
   language_id: 46
 CMake:
   type: programming
+  color: "#DA3434"
   extensions:
   - ".cmake"
   - ".cmake.in"
@@ -750,6 +763,7 @@ CODEOWNERS:
   language_id: 321684729
 COLLADA:
   type: data
+  color: "#F1A42B"
   extensions:
   - ".dae"
   tm_scope: text.xml
@@ -795,6 +809,7 @@ CUE:
   language_id: 356063509
 CWeb:
   type: programming
+  color: "#00007a"
   extensions:
   - ".w"
   tm_scope: none
@@ -802,6 +817,7 @@ CWeb:
   language_id: 657332628
 Cabal Config:
   type: data
+  color: "#483465"
   aliases:
   - Cabal
   extensions:
@@ -816,6 +832,7 @@ Cabal Config:
   language_id: 677095381
 Cap'n Proto:
   type: programming
+  color: "#c42727"
   tm_scope: source.capnp
   extensions:
   - ".capnp"
@@ -857,6 +874,7 @@ Charity:
   language_id: 56
 ChucK:
   type: programming
+  color: "#3f8000"
   extensions:
   - ".ck"
   tm_scope: source.java
@@ -941,6 +959,7 @@ Closure Templates:
   language_id: 357046146
 Cloud Firestore Security Rules:
   type: data
+  color: "#FFA000"
   ace_mode: less
   codemirror_mode: css
   codemirror_mime_type: text/css

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2287,6 +2287,7 @@ HTTP:
   language_id: 152
 HXML:
   type: data
+  color: "#f68712"
   ace_mode: text
   extensions:
   - ".hxml"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6345,6 +6345,7 @@ Wget Config:
   language_id: 668457123
 Wikitext:
   type: prose
+  color: "#fc5757"
   wrap: true
   aliases:
   - mediawiki

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5069,6 +5069,7 @@ Roff:
   language_id: 141
 Roff Manpage:
   type: markup
+  color: "#ecdebe"
   group: Roff
   extensions:
   - ".1"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4420,7 +4420,7 @@ Pony:
   language_id: 290
 PostCSS:
   type: markup
-  colour: "#dc3a0c"
+  color: "#dc3a0c"
   tm_scope: source.postcss
   group: CSS
   extensions:
@@ -5745,7 +5745,7 @@ SubRip Text:
   language_id: 360
 SugarSS:
   type: markup
-  colour: "#2fcc9f"
+  color: "#2fcc9f"
   tm_scope: source.css.postcss.sugarss
   group: CSS
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1836,6 +1836,7 @@ GEDCOM:
   language_id: 459577965
 GLSL:
   type: programming
+  color: "#5686a5"
   extensions:
   - ".glsl"
   - ".fp"
@@ -2180,6 +2181,7 @@ HCL:
   language_id: 144
 HLSL:
   type: programming
+  color: "#aace60"
   extensions:
   - ".hlsl"
   - ".cginc"
@@ -5418,6 +5420,7 @@ Self:
   language_id: 345
 ShaderLab:
   type: programming
+  color: "#222c37"
   extensions:
   - ".shader"
   ace_mode: text

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -46,6 +46,7 @@
   language_id: 0
 4D:
   type: programming
+  color: "#004289"
   extensions:
   - ".4dm"
   tm_scope: source.4dm
@@ -3439,6 +3440,7 @@ Makefile:
   language_id: 220
 Mako:
   type: programming
+  color: "#7e858d"
   extensions:
   - ".mako"
   - ".mao"
@@ -3492,6 +3494,7 @@ Mask:
   language_id: 223
 Mathematica:
   type: programming
+  color: "#dd1100"
   extensions:
   - ".mathematica"
   - ".cdf"
@@ -3605,6 +3608,7 @@ Mirah:
   language_id: 232
 Modelica:
   type: programming
+  color: "#de1d31"
   extensions:
   - ".mo"
   tm_scope: source.modelica
@@ -3614,6 +3618,7 @@ Modelica:
   language_id: 233
 Modula-2:
   type: programming
+  color: "#10253f"
   extensions:
   - ".mod"
   tm_scope: source.modula2
@@ -3658,6 +3663,7 @@ Moocode:
   language_id: 237
 MoonScript:
   type: programming
+  color: "#ff4585"
   extensions:
   - ".moon"
   interpreters:
@@ -3667,6 +3673,7 @@ MoonScript:
   language_id: 238
 Motorola 68K Assembly:
   type: programming
+  color: "#005daa"
   group: Assembly
   aliases:
   - m68k
@@ -3844,6 +3851,7 @@ Nextflow:
   language_id: 506780613
 Nginx:
   type: data
+  color: "#009639"
   extensions:
   - ".nginx"
   - ".nginxconf"
@@ -4393,6 +4401,7 @@ Pickle:
   language_id: 284
 PicoLisp:
   type: programming
+  color: "#6067af"
   extensions:
   - ".l"
   interpreters:
@@ -4798,6 +4807,7 @@ REALbasic:
   language_id: 310
 REXX:
   type: programming
+  color: "#d90e09"
   aliases:
   - arexx
   extensions:
@@ -5297,6 +5307,7 @@ SMT:
   language_id: 330
 SPARQL:
   type: data
+  color: "#0C4597"
   tm_scope: source.sparql
   ace_mode: text
   codemirror_mode: sparql
@@ -5474,6 +5485,7 @@ Scheme:
   language_id: 343
 Scilab:
   type: programming
+  color: "#ca0f21"
   extensions:
   - ".sci"
   - ".sce"
@@ -6970,6 +6982,7 @@ mcfunction:
   language_id: 462488745
 mupad:
   type: programming
+  color: "#244963"
   extensions:
   - ".mu"
   tm_scope: source.mupad

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2789,6 +2789,7 @@ JavaScript:
   language_id: 183
 JavaScript+ERB:
   type: programming
+  color: "#f1e05a"
   tm_scope: source.js
   group: JavaScript
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2613,6 +2613,7 @@ JSON:
   language_id: 174
 JSON with Comments:
   type: data
+  color: "#292929"
   group: JSON
   tm_scope: source.js
   ace_mode: javascript
@@ -2650,6 +2651,7 @@ JSON with Comments:
   language_id: 423
 JSON5:
   type: data
+  color: "#267CB9"
   extensions:
   - ".json5"
   tm_scope: source.js
@@ -2659,6 +2661,7 @@ JSON5:
   language_id: 175
 JSONLD:
   type: data
+  color: "#0c479c"
   extensions:
   - ".jsonld"
   tm_scope: source.js

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4417,6 +4417,7 @@ Pony:
   language_id: 290
 PostCSS:
   type: markup
+  colour: "#dc3a0c"
   tm_scope: source.postcss
   group: CSS
   extensions:
@@ -5739,6 +5740,7 @@ SubRip Text:
   language_id: 360
 SugarSS:
   type: markup
+  colour: "#2fcc9f"
   tm_scope: source.css.postcss.sugarss
   group: CSS
   extensions:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2081,6 +2081,7 @@ Gosu:
   language_id: 134
 Grace:
   type: programming
+  color: "#615f8b"
   extensions:
   - ".grace"
   tm_scope: source.grace
@@ -2151,6 +2152,7 @@ Groovy:
   language_id: 142
 Groovy Server Pages:
   type: programming
+  color: "#76A8B8"
   group: Groovy
   aliases:
   - gsp
@@ -2700,6 +2702,7 @@ JSONiq:
   language_id: 177
 Jasmin:
   type: programming
+  color: "#d03600"
   ace_mode: java
   extensions:
   - ".j"
@@ -2817,6 +2820,7 @@ Jinja:
   language_id: 147
 Jison:
   type: programming
+  color: "#56b3cb"
   group: Yacc
   extensions:
   - ".jison"
@@ -2825,6 +2829,7 @@ Jison:
   language_id: 284531423
 Jison Lex:
   type: programming
+  color: "#56b3cb"
   group: Lex
   extensions:
   - ".jisonlex"
@@ -3020,6 +3025,7 @@ LTspice Symbol:
   language_id: 1013566805
 LabVIEW:
   type: programming
+  color: "#fede06"
   extensions:
   - ".lvproj"
   - ".lvlib"
@@ -3138,6 +3144,7 @@ Liquid:
   language_id: 204
 Literate Agda:
   type: programming
+  color: "#315665"
   group: Agda
   extensions:
   - ".lagda"
@@ -3146,6 +3153,7 @@ Literate Agda:
   language_id: 205
 Literate CoffeeScript:
   type: programming
+  color: "#244776"
   tm_scope: source.litcoffee
   group: CoffeeScript
   ace_mode: text
@@ -3158,6 +3166,7 @@ Literate CoffeeScript:
   language_id: 206
 Literate Haskell:
   type: programming
+  color: "#5e5086"
   group: Haskell
   aliases:
   - lhaskell


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Adds colours to pretty much all languages (100+) that are without one currently.
Resolves #5003 (mostly)

## Checklist:

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.

## Colours

- 4D: `#004289` from [logo on 4d.com](https://us.4d.com/)
- Adobe Font: `#fa0f00` from Adobe logo
- Alpine Abuild: `#0D597F` from [Apine logo](https://wiki.alpinelinux.org/)
- Altium Designer: `#A89663`: from [logo](https://en.wikipedia.org/wiki/File:Altium_Designer_Logo.png)
- Ant Build: `#A9157E` from [Ant logo](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Apache-Ant-logo.svg/250px-Apache-Ant-logo.svg.png)
- ApachiConf: `#D12127`: from [Apache logo](http://httpd.apache.org/docs/2.4/configuring.html)
- Augeas: `#9CC134` from [logo](https://augeas.net/docs/language.html)
- AsciiDoc: `#73a0c5` from [branding](https://asciidoc.org/)
- Avro IDL: `#0040FF` from [avro logo](https://avro.apache.org/docs/1.9.2/idl.html)
- BitBake `#00bce4` from [developer logo](http://www.openembedded.org/wiki/Main_Page) enwp.org/BitBake
- BLitzBasic: `#00FFAE` from [logo](https://en.wikipedia.org/wiki/File:BlitzBasicLogo.gif)
- Bluespecs; `#12223c`: from [logo](https://github.com/bluespec)
- BibTeX: `#778899` from [branding](http://www.bibtex.org/)
- BrightScript `#662D91`: from [branding](https://developer.roku.com/en-gb/docs/references/brightscript/language/brightscript-language-reference.md)
- Cabal Config: `#483465` from [branding](https://www.haskell.org/cabal/)
- Capn Proto `#c42727` from [branding](https://capnproto.org/)
- Chuck: `#3f8000` from [logo](https://commons.wikimedia.org/wiki/File:ChucK_logo2.jpg)
- CLIPS: `#00a300` from [logo](http://www.clipsrules.net/AboutCLIPS.html)
- Cloud Firebase *: `#FFA000` from [branding](https://firebase.google.com/brand-guidelines)
- Collada: `#F1A42B` from [logo](https://en.wikipedia.org/wiki/File:COLLADA_logo_vect.svg)
- Coq: `#d0b68c` from [logo](https://coq.inria.fr/)
- CodeQL: `#140f46` from [branding](https://semmle.com/codeql)
- Cmake: `#DA3434` from [logo](https://commons.wikimedia.org/wiki/File:Cmake.svg)
- CSound `#1a1a1a` from [logo](https://csound.com/)
- CSound Document `#1a1a1a` from [logo](https://csound.com/)
- CSound Score: `#1a1a1a` from [logo](https://csound.com/)
- CSV: `#237346`: from MS Excel branding
- Cweb `#00007a` from [book title](https://www-cs-faculty.stanford.edu/~knuth/cweb.html)
- Darcs Patch: `#8eff23` from [logo](https://en.wikipedia.org/wiki/Darcs#/media/File:Darcs-logo.png)
- DirectX 3D: `#aace60` from [DirectX9 logo](https://en.wikipedia.org/wiki/File:Directx9.png)
- Easybuild `#069406` from [logo/branding](https://docs.easybuild.io/en/latest/)
- Ecere Project: `#913960` from eC
- Eclipse: `#001d9d` from [logo](http://eclipseclp.org)
- EditorConfig: `#fff1f2`: from [logo](https://editorconfig.org)
- FIlebench-WML: `#F6B900` from [org logo](https://github.com/filebench)
- Figlet: `#FFDDBB` from [branding](http://www.figlet.org/)
- Fish: `#4aae47` from [logo](https://fishshell.com/)
- Fortran Freeform `#4d41b1` from Fortran
- Gap: `#0000cc` from [logo](https://www.gap-system.org/)
- Gams: `#f49a22` from [logo](https://www.gams.com/)
- GCC: `#ffcfab` from [logo](https://commons.wikimedia.org/wiki/File:GNU_Compiler_Collection_logo.svg)
- Gedcom: `#003058` from [dev logo](https://en.wikipedia.org/wiki/File:SymbolofLatter-daySaintchurch.png) [[not joking](https://www.familysearch.org/developers/docs/guides/gedcom#:~:text=GEDCOM%20is%20also%20the%20name,tree%20software%20programs%20and%20websites.)]
- Genshi `#951531` from [tagline](https://genshi.edgewall.org/)
- Gentoo Ebuild: `#9400ff`: From [Gentoo branding](https://Gentoo.org)
- Gentoo Eclass: `#9400ff`: From [Gentoo branding](https://Gentoo.org)
- Gerber: `#D20B00` from [branding](https://ucamco.com/en/gerber)
- Git Attributes: `#F44D27`: from [Git logo](https://git-scm.com)
- Git Config: `#F44D27`: from [Git logo](https://git-scm.com)
- GLSL: `#5686a5`: from [OpenGL logo](https://commons.wikimedia.org/wiki/File:OpenGL_logo_(2D).svg)
- Grace: `#615f8b` from [branding](http://gracelang.org/)
- Gradle: `#02303a`: from [logo](https://Gradle.org)
- Graphviz DOT: `#2596be`: From lines in [logo](https://en.wikipedia.org/wiki/File:GraphvizLogo.png)
- Groovy Server Pages: `#4298b8`: From new Groovy #5418
- HaProxy: `#106da9` from [logo](https://www.haproxy.org/)
- HLSL: `#aace60`: from DirectX logo (HLSL uses Direct3D)
- HTML+ECR: `#2e1052`: From [ECR branding](https://crystal-lang.org/api/0.35.1/ECR.html)
- HTML+EEX: `#6e4a7e`: From [EEX branding](https://elixirschool.com/en/lessons/specifics/eex)
- HTML+ERB: `#701516`: From Ruby
- HTML+PHP: `#4f5d95`: From PHP
- HTML+Razor: `#512be4`: From .[NET logo](https://commons.wikimedia.org/wiki/File:.NET_Logo.svg)
- HTTP `#005c9c`: From [logo](https://en.m.wikipedia.org/wiki/File:HTTP_logo.svg)
- HXML: `#f68712`: From [HAXE logo](https://haxe.org)
- INI: `#d1dbe0`: from [Windows file icon](https://en.wikipedia.org/wiki/File:INI_file_icon.png)
- Ignore List: `#000000`: black as in blacklist
- Inno Setup: `#264b99`: from [branding](http://jrsoftware.org/isinfo.php)
- Isabelle root: `#FEFE00` from Isabelle
- Jasmin: `#d03600`: from fish in [logo](http://jasmin.sourceforge.net)
- JSON with Comments: `#292929`: from JSON
- JSON5: `#267CB9`: From https://json5.org
- JSONLD: `#0c479c`: From https://json-ld.org
- Java Properties: `#2A6277`: from new Java #5384
- Java Server Pages: `#2A6277`: from new Java #5384
- JavaScript+ERB: `#f1e05a`: from JS
- Jison: `#56b3cb` from [logo](https://web.archive.org/web/20180101091202/http://zaa.ch/jison)
- Jison Lex: `#56b3cb` from [Jison logo](https://web.archive.org/web/20180101091202/http://zaa.ch/jison)
- KiCad Layout: `#2f4aab`: From [KiCad logo](https://gitlab.com/kicad)
- KiCad Legacy Layout: `#2f4aab`: From [KiCad logo](https://gitlab.com/kicad)
- KiCad Schematic: `#2f4aab`: From [KiCad logo](https://gitlab.com/kicad)
- Labview `#fede06`: from [logo](https://en.wikipedia.org/wiki/File:LabVIEW_Logo.jpg)
- Literate Agda: `#315665`: from Agda
- Literate Coffeescript: `#244776` from Coffeescript
- Literate Haskell: `#5e5086` from Haskell
- Logtalk `#295b9a` from [branding](https://logtalk.org/)
- Mako `#7e858d`: from [logo](https://www.makotemplates.org/)
- Mathematica: `#dd1100` from [logo](https://www.wolfram.com/mathematica/)
- Modelica: `#de1d31` from [accent color](https://modelica.org/)
- Modula2: `#10253f` from [logo](https://www.modula2.org/)
- Moonscript `#ff4585`: from [logo](https://github.com/leafo/moonscript)
- Motorola 48k Asm: `#005daa` from [motorola logo](https://en.wikipedia.org/wiki/Motorola#/media/File:Motorola.svg)
- Mupad: `#244963` from part of [logo](https://en.wikipedia.org/wiki/File:MuPADCube.png)
- Nginx: `#009639` from [logo](https://www.nginx.com/)
- NPM Config: `#cb3837`: from [npm logo](https://commons.wikimedia.org/wiki/File:Npm-logo.svg)
- Nanorc: `#2d004d`: from [Nano logo](https://commons.wikimedia.org/wiki/File:Gnu-nano.svg)
- OpenCL: `#ed2e2d` from [prominent logo colour](https://developer.nvidia.com/opencl)
- OpenPolicyAgent: `#7d9199` from [logo](https://www.openpolicyagent.org/)
- OpenEdge `#5ce600` from [dev logo](https://en.wikipedia.org/wiki/File:OpenEdge_logo.png)
- OpenScad `#e5cd45`: From [logo](https://openscad.org/)
- PLpgSQL: `#336790`: form [logo](https://commons.wikimedia.org/wiki/File:Postgresql_elephant.svg)
- Picolisp: `#6067af` from [logo](https://picolisp.com/wiki/?home)
- PostCSS: `#dc3a0c` from [logo](https://github.com/postcss/postcss)
- Pov Ray: `#6bac65` from part of [logo](https://commons.wikimedia.org/wiki/File:Povray_logo_sphere.png)
- Python console: `#3572A5`: from Python
- Python traceback: `#3572A5`: from Python
- RDoc: `#701516`: From Ruby
- ReStructuredText: `#141414`: From [text logo](https://docutils.sourceforge.io/rst.html)
- Rexx: `#d90e09` from [logo](https://en.wikipedia.org/wiki/File:Rexx-img-lg.png)
- RMarkdown: `#198ce7`: From R
- Robot Framework: `#00c0b5` from [branding](https://robotframework.org/)
- Roff Manpage: `#ecdebe`: From Roff
- Scilab `#ca0f21`: from [logo](https://www.scilab.org/)
- SQL: `#e38c00`: from [MySQL logo](https://download.logo.wine/logo/MySQL/MySQL-Logo.wine.png)
- SQLPL: `#e38c00`: from [MySQL logo](https://download.logo.wine/logo/MySQL/MySQL-Logo.wine.png)
- ShaderLab: `#222c37`: from [Unity logo](https://commons.wikimedia.org/wiki/File:Official_unity_logo.png)
- Smarty: `#f0c040` from [logo](https://en.wikipedia.org/wiki/File:Smarty-logo.png)
- SparQL: `#0c4597` from [apparent logo](https://www.google.com/search?q=SPARQL+logo&tbm=isch)
- Stata: `#1a5f91` from [logo](https://www.stata.com/why-use-stata/)
- SubRip Text: `#9e0101`: From [branding](http://zuggy.wz.cz)
- SugarSS: `#2fcc9f`: from [logo](https://github.com/postcss/sugarss)
- Textile: `#ffe7ac`: form [logo](https://textile-lang.com/)
- TOML: `#9c4221`: From [logo](https://TOML.io)
- Thrift: `#D12127`: from [Apache logo](http://httpd.apache.org/docs/2.4/configuring.html)
- TSQL: `#e38c00` from [MySQL logo](https://download.logo.wine/logo/MySQL/MySQL-Logo.wine.png)
- TSV: `#237346`: from MS Excel branding
- TSX: `#2b7489`: From TypeScript
- TXL `#0178b8`: From [logo](https://www.txl.ca/)
- TLA: `#4b0079` from [logo](https://en.wikipedia.org/wiki/File:TLA%2B_logo_splash_image.png)
- Unity Asset: `#222c37`: from [Unity logo](https://commons.wikimedia.org/wiki/File:Official_unity_logo.png)
- UrWeb: `#ccccee` from [branding](http://www.impredicative.com/ur/)
- Vim Help: `#199f4b` from Vim
- Vim snippit: `#199f4b` from Vim
- Web Ontology: `#5b70bd` from [apparent logo](https://www.google.com/search?q=web+ontology+Language+logo&tbm=isch)
- WIndows Registry: `#52d5ff` from [editor logo](https://en.wikipedia.org/wiki/File:Registry_Editor_icon.png)
- WoW Addon: `#f7e43f` form [logo text](https://upload.wikimedia.org/wikipedia/en/thumb/9/91/WoW_Box_Art1.jpg/220px-WoW_Box_Art1.jpg)
- Wikitext: `#fc5757`: From [MediaWiki logo](https://commons.wikimedia.org/wiki/File:MediaWiki-2020-logo.svg)
- XML: `#0060ac`: From [logo](https://w3.org/Icons/XML/xml.svg)
- XML Property List: `#0060ac`: From XML
- Xojo: `#81bd41` from [logo](https://www.xojo.com/)
- Xtend `#24255d`: From [logo](https://commons.wikimedia.org/wiki/File:Xtend-logo-c.png)
- Zimpl: `#d67711` from [branding](https://zimpl.zib.de/)
