### PR TITLE
Add file_version_info.txt to list of Python filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4684,6 +4684,7 @@ Python:
   - SConscript
   - SConstruct
   - Snakefile
+  - file_version_info.txt
   - wscript
   interpreters:
   - python

--- a/samples/Python/filenames/file_version_info.txt
+++ b/samples/Python/filenames/file_version_info.txt
@@ -1,0 +1,43 @@
+# UTF-8
+#
+# For more details about fixed file info 'ffi' see:
+# http://msdn.microsoft.com/en-us/library/ms646997.aspx
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
+    # Set not needed items to zero 0.
+    filevers=(1, 0, 0, 0),
+    prodvers=(1, 0, 0, 0),
+    # Contains a bitmask that specifies the valid bits 'flags'r
+    mask=0x0,
+    # Contains a bitmask that specifies the Boolean attributes of the file.
+    flags=0x0,
+    # The operating system for which this file was designed.
+    # 0x4 - NT and there is no need to change it.
+    OS=0x4,
+    # The general type of file.
+    # 0x1 - the file is an application.
+    fileType=0x1,
+    # The function of the file.
+    # 0x0 - the function is not defined for this fileType
+    subtype=0x0,
+    # Creation date and time stamp.
+    date=(0, 0)
+    ),
+  kids=[
+    StringFileInfo(
+      [
+      StringTable(
+        u'040904E4',
+        [StringStruct(u'CompanyName', u'TEST'),
+        StringStruct(u'ProductName', u'test file'),
+        StringStruct(u'ProductVersion', u'1,0,0,0'),
+        StringStruct(u'InternalName', u'test'),
+        StringStruct(u'OriginalFilename', u'test.exe'),
+        StringStruct(u'FileVersion', u'1.0'),
+        StringStruct(u'FileDescription', u'Test'),
+        StringStruct(u'LegalCopyright', u'Copyright © 2021 TEST')])
+      ]),
+    VarFileInfo([VarStruct(u'Translation', [1033, 1252])])
+  ]
+)

--- a/samples/Python/filenames/file_version_info.txt
+++ b/samples/Python/filenames/file_version_info.txt
@@ -6,10 +6,10 @@ VSVersionInfo(
   ffi=FixedFileInfo(
     # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
     # Set not needed items to zero 0.
-    filevers=(1, 0, 0, 0),
-    prodvers=(1, 0, 0, 0),
+    filevers=(0, 0, 1, 0),
+    prodvers=(0, 0, 1, 0),
     # Contains a bitmask that specifies the valid bits 'flags'r
-    mask=0x0,
+    mask=0x3f,
     # Contains a bitmask that specifies the Boolean attributes of the file.
     flags=0x0,
     # The operating system for which this file was designed.
@@ -25,19 +25,22 @@ VSVersionInfo(
     date=(0, 0)
     ),
   kids=[
+    VarFileInfo([VarStruct(u'Translation', [0, 1200])]), 
     StringFileInfo(
       [
       StringTable(
-        u'040904E4',
-        [StringStruct(u'CompanyName', u'TEST'),
-        StringStruct(u'ProductName', u'test file'),
-        StringStruct(u'ProductVersion', u'1,0,0,0'),
-        StringStruct(u'InternalName', u'test'),
-        StringStruct(u'OriginalFilename', u'test.exe'),
-        StringStruct(u'FileVersion', u'1.0'),
-        StringStruct(u'FileDescription', u'Test'),
-        StringStruct(u'LegalCopyright', u'Copyright © 2021 TEST')])
-      ]),
-    VarFileInfo([VarStruct(u'Translation', [1033, 1252])])
+        u'000004b0',
+        [StringStruct(u'Comments', u''),
+        StringStruct(u'CompanyName', u'Ömer Furkan İşleyen'),
+        StringStruct(u'FileDescription', u'PyFlappy'),
+        StringStruct(u'FileVersion', u'0.0.1.0'),
+        StringStruct(u'InternalName', u'PyFlappy.exe'),
+        StringStruct(u'LegalCopyright', u'Ömer Furkan İşleyen'),
+        StringStruct(u'LegalTrademarks', u''),
+        StringStruct(u'OriginalFilename', u'PyFlappy.exe'),
+        StringStruct(u'ProductName', u'PyFlappy'),
+        StringStruct(u'ProductVersion', u'0.0.1.0'),
+        StringStruct(u'Assembly Version', u'0.0.1.0')])
+      ])
   ]
 )


### PR DESCRIPTION
I ~moved `.gclient` from `filenames` to `extensions` and~ added `file_version_info.txt` to filenames in Python.

## Description

### ~`.gclient`~

~It seems that `.gclient` is more often used as an extension than a file name.~
~See: <https://github.com/search?q=extension%3Agclient&type=Code> (200 hits)~

### `file_version_info.txt`

`file_version_info.txt` is a filename that is often used to add version information to exe programs created by [Pyinstaller](https://github.com/pyinstaller/pyinstaller).
It is the default name of the file to which the version information is extracted from an existing exe program and written, like `pyi-grab_version <exe file>`.

## Checklist:

- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - ~`.gclient`: <https://github.com/search?q=extension%3Agclient&type=Code> (200 hits)~
      - `file_version_info.txt`: <https://github.com/search?p=1&q=filename%3A%22file_version_info.txt%22&type=Code> (319 hits)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - ~[test.gclient](https://github.com/eggplants/linguist/blob/fix_python_ext/samples/Python/test.gclient)~
      - [OmerFI/PyFlappy/file_version_info.txt](https://github.com/OmerFI/PyFlappy/blob/main/file_version_info.txt)
    - Sample license(s):
      - [MIT License](https://github.com/OmerFI/PyFlappy/blob/main/LICENSE)
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.