### PR TITLE
Set tm_scope for ECL language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1411,7 +1411,7 @@ ECL:
   extensions:
   - ".ecl"
   - ".eclxml"
-  tm_scope: none
+  tm_scope: source.ecl
   ace_mode: text
   codemirror_mode: ecl
   codemirror_mime_type: text/x-ecl

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -121,6 +121,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Dylan:** [textmate/dylan.tmbundle](https://github.com/textmate/dylan.tmbundle)
 - **E-mail:** [mariozaizar/language-eml](https://github.com/mariozaizar/language-eml)
 - **EBNF:** [Alhadis/language-grammars](https://github.com/Alhadis/language-grammars)
+- **ECL:** [hpcc-systems/ecl-tmLanguage](https://github.com/hpcc-systems/ecl-tmLanguage)
 - **ECLiPSe:** [alnkpa/sublimeprolog](https://github.com/alnkpa/sublimeprolog)
 - **EJS:** [gregory-m/ejs-tmbundle](https://github.com/gregory-m/ejs-tmbundle)
 - **EQ:** [dotnet/csharp-tmLanguage](https://github.com/dotnet/csharp-tmLanguage)


### PR DESCRIPTION
## Description

I completely missed that the PR that added the ECL grammar (https://github.com/github/linguist/pull/5424) didn't include an update to the `tm_scope` needed to identify which grammar to use so it continued to use `none` which means no syntax highlighting.

This PR sets the scope to `source.ecl` and also updates the `vendor/README.md` with the missing line that was also missed because the `tm_scope` wasn't updated at the time.

/cc @GordonSmith 


## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [N/A] I have added or updated the tests for the new or changed functionality.
