### PR TITLE
Add JAR Manifest file

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3454,6 +3454,14 @@ Mako:
   tm_scope: text.html.mako
   ace_mode: text
   language_id: 221
+Manifest:
+  type: data
+  color: "#b07219"
+  filenames:
+  - manifest.mf
+  tm_scope: source.yaml
+  ace_mode: text
+  language_id: 447261135
 Markdown:
   type: prose
   color: "#083fa1"

--- a/samples/Manifest/filenames/MANIFEST.MF
+++ b/samples/Manifest/filenames/MANIFEST.MF
@@ -1,0 +1,81 @@
+Manifest-Version: 1.0
+
+Name: CheckCerts.class
+Digest-Algorithms: SHA
+SHA-Digest: xLygljhRro6990piIVEilVI8szQ=
+
+Name: ContentInfoTest.class
+Digest-Algorithms: SHA
+SHA-Digest: TSVdEMQW2gdFi6qeba+UixdHSdo=
+
+Name: JarVerify.class
+Digest-Algorithms: SHA
+SHA-Digest: Wg+PiDzunNGH4KrWAp00/okp39s=
+
+Name: JarVerify2.class
+Digest-Algorithms: SHA
+SHA-Digest: 5uYBQxwGWgYmNBwhnWRbymeXmWM=
+
+Name: PKCS7Read.class
+Digest-Algorithms: SHA
+SHA-Digest: JPIxttHBfRpQaFyiQJ2Wfkvj/ls=
+
+Name: PKCS7Test.class
+Digest-Algorithms: SHA
+SHA-Digest: R64SXXgZrOvGiO/eMsfG/T1Vn30=
+
+Name: PKCS7Test10.class
+Digest-Algorithms: SHA
+SHA-Digest: 2R0yxuxRHTPqdAzJJcrvqkpbQgo=
+
+Name: PKCS7Test11.class
+Digest-Algorithms: SHA
+SHA-Digest: /0HcwnpQi0hwJsJtvt5peWFGvtc=
+
+Name: PKCS7Test12.class
+Digest-Algorithms: SHA
+SHA-Digest: s5CcqimfRqR9CW25tFBY0JK3RVU=
+
+Name: PKCS7Test2.class
+Digest-Algorithms: SHA
+SHA-Digest: 71VkFEMUle5sjXNFbSW31F1ZJ58=
+
+Name: PKCS7Test3.class
+Digest-Algorithms: SHA
+SHA-Digest: mU/D5C6SgPRmwoLQzwF5VnN3aqM=
+
+Name: PKCS7Test4.class
+Digest-Algorithms: SHA
+SHA-Digest: ss9NFvxF8emaEjdKdvtzWXfs0/E=
+
+Name: PKCS7Test5.class
+Digest-Algorithms: SHA
+SHA-Digest: DHvQ20UAXoYgfCPAOeCOrglsJwU=
+
+Name: PKCS7Test6.class
+Digest-Algorithms: SHA
+SHA-Digest: aiCb8chroH7XDaNfAz6wr57lXsA=
+
+Name: PKCS7Test7.class
+Digest-Algorithms: SHA
+SHA-Digest: UoieXLC68alFgfD/Q1NW9/r2kaY=
+
+Name: PKCS7Test8.class
+Digest-Algorithms: SHA
+SHA-Digest: eMW7mq5b/KVB1M5L76wcV1+uFQs=
+
+Name: PKCS7Test9.class
+Digest-Algorithms: SHA
+SHA-Digest: EEWCZG1creWjqVZVIEgr0on3y6A=
+
+Name: SignerInfoTest.class
+Digest-Algorithms: SHA
+SHA-Digest: l6SNfpnFipGg8gy4XqY3HhA0RrY=
+
+Name: SignerInfoTest2.class
+Digest-Algorithms: SHA
+SHA-Digest: 5jbzlkZqXKNmmmE+pcjQka8D6WE=
+
+Name: SimpleSigner.class
+Digest-Algorithms: SHA
+SHA-Digest: l9ODQHY4wxhIvLw4/B0qe9NjwxQ=

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -273,6 +273,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Macaulay2:** [Macaulay2/language-macaulay2](https://github.com/Macaulay2/language-macaulay2)
 - **Makefile:** [textmate/make.tmbundle](https://github.com/textmate/make.tmbundle)
 - **Mako:** [marconi/mako-tmbundle](https://github.com/marconi/mako-tmbundle)
+- **Manifest:** [atom/language-yaml](https://github.com/atom/language-yaml)
 - **Markdown:** [atom/language-gfm](https://github.com/atom/language-gfm)
 - **Marko:** [marko-js/marko-tmbundle](https://github.com/marko-js/marko-tmbundle)
 - **Mask:** [tenbits/sublime-mask](https://github.com/tenbits/sublime-mask)


### PR DESCRIPTION
- Resolve #5503<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Adds support for JAR [`MANIFEST.MF`](https://docs.oracle.com/javase/tutorial/deployment/jar/manifestindex.html) files.

## Checklist

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  [`manifest.mf`](https://github.com/search?q=filename%3Amanifest.mf&type=code): 1.7M
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [MANIFEST.MF](https://github.com/rim99/OpenJDK8u-jdk/blob/ff08e65bf0706bdeaf682b8e1b2b304141855c38/test/sun/security/pkcs/pkcs7/jarsigner/META-INF/MANIFEST.MF): [GPL-2](https://github.com/rim99/OpenJDK8u-jdk/blob/master/LICENSE) (but autogenerated)
  - [x] I have included a syntax highlighting grammar:
    - Uses YAML's one. Lightshow doesn't like it but Manifest is valid YAML syntax so there shouldnt be an issue. [Gist works though](https://gist.github.com/Nixinova/ce4d3dda4c4b6b42384ef3815207e743).
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
