### PR TITLE
Add typical Gitpod custom Dockerfile name

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -380,3 +380,6 @@
 
 # Jenkins Pipeline
 - (^|/)Jenkinsfile$
+
+# Gitpod
+- (^|/)\.gitpod\.Dockerfile$


### PR DESCRIPTION
This adds [custom Gitpod Dockerfile](https://www.gitpod.io/docs/config-docker#configure-a-custom-dockerfile) to the list of vendor files. It is used to setup a development environment and is similar to Vagrantfile in this respect, which already has its own entry in `vendor.yml`. I think it is fair to add an entry for `.gitpod.Dockerfile` too and stop reflecting it in repository's language statistics. Otherwise it may give a false impression that project provides Docker images.