### PR TITLE
Add `.markdownlintignore` to Ignore List filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2527,7 +2527,6 @@ Ignore List:
   group: INI
   aliases:
   - ignore
-  - gitignore
   - git ignore
   extensions:
   - ".gitignore"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2528,7 +2528,7 @@ Ignore List:
   aliases:
   - ignore
   - gitignore
-  - git-ignore
+  - git ignore
   extensions:
   - ".gitignore"
   filenames:
@@ -2541,6 +2541,7 @@ Ignore List:
   - ".eleventyignore"
   - ".eslintignore"
   - ".gitignore"
+  - ".markdownlintignore"
   - ".nodemonignore"
   - ".npmignore"
   - ".prettierignore"

--- a/samples/Ignore List/filenames/.markdownlintignore
+++ b/samples/Ignore List/filenames/.markdownlintignore
@@ -1,0 +1,12 @@
+# dependencies
+node_modules/
+
+# testing
+coverage/
+.vscode-test/
+__output__/
+
+# production
+dist/
+out/
+build/


### PR DESCRIPTION
- Resolve #5113

## Description

Adds `.markdownlint` to the list of Ignore-List filenames.

Also replaces alias `git-ignore` with `git ignore` as spaces automatically alias to hyphens.

## Checklist
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results: [902 files](https://github.com/search?q=filename%3A.markdownlintignore&type=code), used once per repo, [816 in root](https://github.com/search?q=filename%3A.markdownlintignore+path%3A%2F&type=code)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample: [source](https://github.com/litezk/vscode-extension/blob/ffb0aa34391b46676c0029de823a456cee4b3e26/.markdownlintignore), [MIT](https://github.com/litezk/vscode-extension/blob/main/LICENSE.md)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
