### PR TITLE
added .aplf, .aplc, .apln and .aplo as APL extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -136,6 +136,10 @@ APL:
   color: "#5A8164"
   extensions:
   - ".apl"
+  - ".aplc"
+  - ".aplf"
+  - ".apln"
+  - ".aplo"
   - ".dyalog"
   interpreters:
   - apl

--- a/samples/APL/EstablishVariablesFromFiles.aplf
+++ b/samples/APL/EstablishVariablesFromFiles.aplf
@@ -1,0 +1,14 @@
+ {r}←ref EstablishVariablesFromFiles filenames;filename;data;name;dmx
+ r←0
+ :For filename :In filenames
+     data←⊃⎕NGET filename 1
+     data←⎕SE.Dyalog.Array.Deserialise data
+     name←StripCaseCodePart 2⊃⎕NPARTS filename
+     :Trap 0
+         name ref.{⍎⍺,'←⍵'}data
+     :Else
+         dmx←⎕DMX
+         ⎕←'*** Establishing variable <',name,'> failed with a ',dmx.EM,'; RC=',⍕dmx.EN
+     :EndTrap
+ :EndFor
+⍝Done

--- a/samples/APL/GetElementById-1409.aplf
+++ b/samples/APL/GetElementById-1409.aplf
@@ -1,0 +1,12 @@
+ GetElementById←{
+     done←0
+     r←⍺{done:''
+         0=80|⎕DR ⍺:''
+         e←0≠⍺.⎕NC'id'
+         n←⍺{⍵:⍺.id ⋄ ''}e
+         n≡⍵:⍺⊣done∨←1
+         ∊⍺.Content ∇¨⊂⍵
+     }⍵
+     done:↑∊r
+     0
+ }

--- a/samples/APL/HtmlFormBuilder.aplc
+++ b/samples/APL/HtmlFormBuilder.aplc
@@ -1,0 +1,285 @@
+:Class HtmlFormBuilder 
+:Include ##.Utils
+ ⎕IO←0
+
+    :field private TITLE←''
+    :field private HEAD←'<meta charset="UTF-8">'
+    :field private STYLE←''
+    :field private HEADING←''
+    :field private BODY←''  
+    :field private SCRIPT←''  
+    :field private BTN_CAPTION←'OK'
+    :field private divCounter←¯1
+    :field private groupCounter←¯1 
+    :field private closeDiv←'</div>' 
+    :field public isForm←1 ⍝ Default yes    
+    :field private BR←'<BR>' ⍝ Line break 
+    :field public PAGE_CLASS←'page_class'
+
+    ∇ make    
+      :Access public  
+      :Implements constructor 
+      STYLE,←resetSpacing ''
+    ∇  
+
+    ∇ make2 fieldValues;fnames;quote
+    ⍝ ⍵ ←→ (1 item boolean indicating isForm or not) |
+    ⍝   (List of field values to copy into this instance)
+      :Access public  
+      :Implements constructor
+      STYLE,←resetSpacing '' 
+      :If 1=≢fieldValues
+        isForm←fieldValues
+      :Else
+      ⍝ Assign fields in this object with the passed in values
+        fnames←getFieldNames ''
+        quote←(' ','''')[isChar¨fieldValues] ⍝ Single quote if char, else blank 
+        ⍎⍕ fnames,'←',quote,¨(pairQuotes¨fieldValues),¨quote    
+      :EndIf
+    ∇    
+    
+    ∇ r←clone;fieldValues
+    :Access public
+      ⍝ Make a deep copy of this object
+      fieldValues←⍎¨getFieldNames ''
+      r←##.⎕NEW HtmlFormBuilder fieldValues
+    ∇                 
+
+    ∇ {r}←setTitle title
+      :Access public                
+      TITLE←'title' wrapTag ⍕title
+      r←0
+    ∇
+     
+    ∇ {r}←setBtnCaption caption
+      :Access public          
+      BTN_CAPTION←(isEmpty caption)⊃caption BTN_CAPTION              
+      r←0
+    ∇     
+   
+    ∇ {r}←setPageClass class
+      :Access public          
+      PAGE_CLASS←⍕class            
+      r←0
+    ∇ 
+    
+    ∇ {r}←addHead head
+      :Access public                
+      HEAD,←⍕head
+      r←0
+    ∇   
+
+    ∇ {r}←addStyle style
+      :Access public   
+      STYLE,←⍕style
+      r←0
+    ∇  
+    
+    ∇ {r}←addBody body
+      :Access public                
+      BODY,←⍕body
+      r←0
+    ∇        
+    
+    ∇ {r}←addParagraph p
+      :Access public
+      BODY,←'p' wrapTag ⍕p
+      r←0
+    ∇
+
+    ∇ {r}←addJavaScript script
+      :Access public
+      SCRIPT,←⍕script
+      r←0
+    ∇
+
+    ∇ r←getHTML;tempH;tempB;formStart;formEnd;tempS;pageDiv;doc
+      :Access public
+      ⍝ We do not overwrite the fields so that we can continue to add to the page after this call  
+      tempH←HEAD,TITLE,'style' wrapTag STYLE
+      tempH←'head' wrapTag tempH 
+      pageDiv←'<div class="',PAGE_CLASS,'">'
+      formStart formEnd ← ⊂''      
+      :If isForm   
+        formStart←pageDiv,'<form method="post" action="cb" id="mainForm">'
+        formEnd←'<input type="submit" id="btn" value="',BTN_CAPTION,'"></form>'
+      :EndIf
+      tempS←'script' wrapTag SCRIPT
+      tempB←'body' wrapTag (pageDiv,HEADING,formStart,BODY,formEnd,closeDiv,tempS)  
+      doc←'<!DOCTYPE html>'
+      r←⍕ escapeUnicode doc,('html' wrapTag (tempH,tempB))
+    ∇    
+   
+    ∇ {r}←{t} addHeading msg;header;h;m
+      :Access public    
+      :If msg≢''
+        m←⍕msg
+        h←{(2=⎕NC't'):t ⋄ ⍵}'h3'  
+        header← h wrapTag m     
+        HEADING←'header' wrapTag header,HEADING
+        ⍝ Keep the inputted header at the top   
+      :EndIf
+      r←0
+    ∇   
+    
+    ∇ {r}←addRadioInput args;s1;s2;s3;labels;values;gname 
+      :Access public  
+      values labels ← args  
+      BODY,←openNewDiv
+      gname←createNewGroup  
+      s1←'<input type="radio" name="'
+      s1,←gname,'" value="'
+      s2 s3←'">' '<br>'
+      BODY,← s1 s2 s3 link values labels
+      BODY,←closeDiv
+      r←0
+    ∇  
+
+    ∇ {r}←{m}addSelectInput args;gname;s1;s2;s3;labels;values   
+      :Access public    
+      labels←args
+      values←⍳≢labels  
+      :If 0=⎕NC 'm' ⋄ m←''⋄ :EndIf
+      BODY,←openNewDiv 
+      gname←createNewGroup
+      BODY,←'<select ',m,' class="s2" style="width:100%" name="',gname
+      BODY,←'" form="mainForm">'   
+      s1 s2 s3 ←'<option value ="' '">' '</option>'     
+      BODY,← s1 s2 s3 link values labels  
+      BODY,←'</select>'
+      BODY,←closeDiv
+      r←0
+    ∇   
+    
+    ∇ {r}←addCheckboxInput args;s1;s2;s3;gname;labels;values
+      :Access public       
+      labels←args
+      values←⍳≢labels
+      BODY,←openNewDiv 
+      gname←createNewGroup  
+      s1←'<input type ="checkbox" name="',gname,'" value="'
+      s2 s3←'">' '<br>'
+      BODY,← s1 s2 s3 link values labels
+      BODY,←closeDiv
+      r←0
+    ∇  
+
+    ∇ {r}←type addNotification msg;types;colors;msgBr
+      ⍝ Based off W3's notification examples  
+      ⍝ Matrix input will add line breaks to rows 
+      :Access public
+      types←'Danger' 'Success' 'Info' 'Warning'
+      colors←'#f44336' '#4CAF50' '#2196F3' '#ff9800'
+      STYLE,←'body{padding: 20px;text-align:center;'
+      STYLE,←'background-color: ',⍕colors[types⍳⊂type]
+      STYLE,←'; color: white; font-size:xx-large;}'
+      BODY,←'<div class ="alert">'  
+      msgBr←breakRows msg
+      BODY,←'strong' wrapTag msgBr
+      BODY,←'</div>'
+      r←0
+    ∇   
+    
+    ∇ {r}←{label} addProgressBar args;l;start;max
+      :Access public 
+      start max←⍕¨args   
+      l←{(2=⎕NC'label'):label ⋄ ⍵}''  
+      BODY,←l  
+      BODY,←'<progress value ="',start
+      BODY,←'" max ="',max,'"></progress>'
+      r←0 
+    ∇  
+     
+    ∇ {r}←addTextInput labels;iDef   
+      :Access public  
+      iDef←'<input type="text" name="'
+      iDef addInput labels
+      r←0
+    ∇ 
+
+    ∇ {r}←addDateInput labels;iDef
+      :Access public        
+      iDef←'<input type="date" name="' 
+      iDef addInput labels
+      r←0
+    ∇    
+    
+    ∇ {r}←addFileInput labels;iDef
+      :Access public        
+      iDef←'<input type="file" multiple name="'  
+      iDef addInput ⊂labels
+      r←0
+    ∇ 
+    
+    ∇ {r}←addNumberInput labels;iDef
+      :Access public        
+       iDef←'<input type="number" step="any" name="'  
+       iDef addInput labels
+       r←0
+    ∇   
+    
+    
+    ∇ {r}←iDef addInput labels;gname;iDef
+      :Access public        
+      BODY,←openNewDiv
+      gname←createNewGroup 
+      iDef,←gname,'">' 
+      BODY,←∊iDef∘label¨labels 
+      BODY,←closeDiv    
+      r←0
+    ∇  
+    
+    ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝
+    ⍝ Private Utility Functions ⍝
+    ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝
+     
+    wrapTag←{'<',⍺,'>',⍵,'</',⍺,'>'} 
+
+    pair←{↓⍺,[.5],⍵}
+    
+    getFieldNames←{⎕THIS.⎕nl ¯2.2}
+    
+    breakRows←{∊⍵(,⍤1)BR}   
+    
+    resetSpacing←{
+    ⍝ Default <p> uses up too much space
+    ' p{padding:0;margin:0;} '
+    } 
+     
+    ∇ r←openNewDiv
+      divCounter+←1
+      r←'<div id ="div',(⍕divCounter),'">'
+    ∇  
+   
+    ∇ r←createNewGroup
+      groupCounter+←1
+      r←'g',⍕groupCounter
+    ∇   
+    
+    catenateAll←{
+    ⍝ Use this function with ∇link
+    ⍝ ⍺ ←→ s1..s3
+    ⍝ ⍵ ←→ 2 item pair of a value and its label
+      value label ← ⍕¨⍵ 
+      s1 s2 s3 ← ⍺     
+      'label' wrapTag ,/ s1 value s2 label BR s3 
+    }
+    
+    link←{
+    ⍝ ⍺ ←→ s1..s3
+    ⍝ ⍵ ←→ values labels
+    ⍝ ← ←→ catenate this string to BODY      
+      values labels ← ⍵   
+      ∊ ⍺∘catenateAll¨ values pair labels   
+    } 
+    
+    label←{
+    ⍝ Catenate a label and the input type
+    ⍝ And add a line break after each item
+    ⍝ ⍵ ←→ label
+    ⍝ ⍺ ←→ input type string    
+      'label' wrapTag (⍕⍵),BR,⍺,BR
+    }       
+                                
+    
+:EndClass

--- a/samples/APL/Leetcode1389.apln
+++ b/samples/APL/Leetcode1389.apln
@@ -1,0 +1,26 @@
+:Namespace Leetcode1389Ns
+      ⎕IO←0
+      ⍝ it all started with this video by RGS: https://www.youtube.com/watch?v=S8nMHo3dIm4
+      ⍝ run all these examples with `idx f nums`
+      ⍝ all these solutions assumes that both params are already arrays
+      ⍝ aka instead of `0 f 1`, you need to do `(,0) sol (,1)`
+
+      ⍝ My (Garklein's) original solution
+      SolBad ← {⍵[⍋⍺++/¨⍵≥(⍳≢⍵)↓¨⊂⍺]}
+      ⍝ Thanks to dzaima for improvements (was originally {⍵[⍋⍺+1-⍨+/¨(⊃≥⊢)(⍳≢⍵)↓¨⊂⍺]})
+
+      ⍝ Bubbler's solution for sorting the indices: ⌽{⍵+⍺≤⍵}⍀⍤⌽
+      ⍝ putting this all together gives
+      SolBubbler ← {⍵[⍋⌽{⍵+⍺≤⍵}⍀⍤⌽⍺]}
+
+      ⍝ later, I realized my solution doesn't work, there are some edge cases
+      SolWorking ← {⍵[⍋(⊢+≤)/¨⌽¨(⍳≢⍵)↓¨⊂⍺]} ⍝ works :)
+      SolTacit ← (⍋(⊢+≤)/∘⌽⍤↓¨⍨∘⍳∘≢)∘⌷ ⍝ dzaima golfing a tacit solution
+      ⍝ the solution requires that the left argument is enclosed
+      ⍝ it also doesn't work with all the cases
+      ⍝ (I'm too lazy to debug though)
+
+      ⍝ by combining Bubbler's version and my fork, you get ⌽(⊢+≤)⍀⍤⌽
+      ⍝ with under, it can be (⊢+≤)⍀⍢⌽
+      SolBest ← {⍵[⍋⌽(⊢+≤)⍀⍤⌽⍺]}
+:EndNamespace

--- a/samples/APL/Scanl.aplo
+++ b/samples/APL/Scanl.aplo
@@ -1,0 +1,9 @@
+ Scanl←{  ⍝ derived from discussion with Adám; https://chat.stackexchange.com/transcript/message/52811881#52811881
+     scanl_aux←⍺⍺{
+         (≢⍵)≤1-×⎕NC'⍺':⍵
+         0=⎕NC'⍺':r⊣⍺⍺⍨{r,←⊂⍵ ⍺⍺⊃⌽r}¨1↓⍵⊣r←⊂⊃⍵
+         r⊣⍺⍺⍨{r,←⊂⍵ ⍺⍺⊃⌽r}¨⍵⊣r←⊂⍺
+     }⍤1
+     0=⎕NC'⍺':scanl_aux ⍵
+     ⍺ scanl_aux ⍵
+ }

--- a/samples/APL/trap.aplo
+++ b/samples/APL/trap.aplo
@@ -1,0 +1,8 @@
+ r←(namespace trap fn)args
+ :Trap 0
+    ⍝ Attempt to run fn inside namespace with args
+     r←(namespace⍎fn) args
+ :Else
+    ⍝ Report if error occurs
+     r←,⊂#.config.error
+ :EndTrap


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Added some more APL extension. `.aplc` is for APL classes, `.aplf` is for APL functions, `.apln` is for APL namespaces and `.aplo` is for APL operators. `.aplc` and `.aplf` were already being highlighted properly for some reason, even though they weren't added here.

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Aaplc (775 results)
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Aaplf (10,847 results)
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Aapln (375 results)
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Aaplo (177 results)
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/Bubbler-4/advent-of-apl/blob/ec66fcd6661eecdc97eedd9801798a674b366224/Util/APLSource/Scanl.aplo (MIT License)
      - https://github.com/the-carlisle-group/Rumba/blob/master/APLSource/HTML-f/GetElementById-1409.aplf (MIT License)
      - https://github.com/JoshDavid/EasyGUI/blob/675a4918950794fb7711576a3e93ad7e2d7cc15b/APLSource/UserFunctions/HtmlFormBuilder.aplc (MIT License)
      - https://github.com/ndrogers/apltest/blob/c9a6ecc87c53416d9e31312343e2c2ed80b331ec/trap.aplo (no license, but I've recieved permission from the author)
      - https://github.com/aplteam/Tatin/blob/456387f67b1ba8ce7649e239fd4b65e513ba8997/APLSource/Registry/EstablishVariablesFromFiles.aplf (MIT License)
      - https://github.com/awagga/APL-Sorting-Algorithms/blob/master/transcripts/Leetcode1389.apln (I am the author)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

No other languages use these extensions. Also, `.aplo` has only 177 results.