### PR TITLE
Fix links in `troubleshooting.md`

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,7 +34,7 @@ If the language statistics bar is not showing your language at all, it could be 
 1. The extension you have chosen is not associated with your language in [`languages.yml`](/lib/linguist/languages.yml).
 1. All the files in your repository fall into one of the categories listed above that Linguist excludes by default.
 
-If Linguist doesn't know about the language or the extension you're using, consider [contributing](CONTRIBUTING.md) to Linguist by opening a pull request to add support for your language or extension.
+If Linguist doesn't know about the language or the extension you're using, consider [contributing](/CONTRIBUTING.md) to Linguist by opening a pull request to add support for your language or extension.
 For everything else, you can use the [manual overrides](/docs/overrides.md) feature to tell Linguist to include your files in the language statistics.
 
 ## There's a problem with the syntax highlighting of a file

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,14 +8,14 @@ If the language stats bar is reporting a language that you don't expect:
    Keep in mind this performs a search so the [code search restrictions][search-limits] may result in files identified in the language statistics not appearing in the search results.
    [Installing Linguist locally](/README.md/#installation) and running it from the [command line](/README.md#command-line-usage) will give you accurate results.
 1. If you see files that you didn't write in the search results, consider moving the files into one of the [paths for vendored code](/lib/linguist/vendor.yml), or use the [manual overrides](/docs/overrides.md) feature to ignore them.
-1. If the files are misclassified, search for [open issues][issues] to see if anyone else has already reported the issue.
+1. If the files are misclassified, search for [open issues](https://github.com/github/linguist/issues) to see if anyone else has already reported the issue.
    Any information you can add, especially links to public repositories, is helpful.
    You can also use the [manual overrides](/docs/overrides.md) feature to correctly classify them in your repository.
-1. If there are no reported issues of this misclassification, [open an issue][new-issue] and include a link to the repository or a sample of the code that is being misclassified.
+1. If there are no reported issues of this misclassification, [open an issue](https://github.com/github/linguist/issues/new) and include a link to the repository or a sample of the code that is being misclassified.
 
 [search-limits]: https://docs.github.com/github/searching-for-information-on-github/searching-code#considerations-for-code-search
 
-Keep in mind that the repository language stats are only [updated when you push changes](#how-linguist-works-on-githubcom), and the results are cached for the lifetime of your repository.
+Keep in mind that the repository language stats are only [updated when you push changes](how-linguist-works.md#how-linguist-works-on-githubcom), and the results are cached for the lifetime of your repository.
 If you have not made any changes to your repository in a while, you may find pushing another change will correct the stats.
 
 ## My C/C++/Objective-C `.h` header file is detected as the wrong language
@@ -52,7 +52,7 @@ repositories and thus changes need to be committed as individual files don't sho
 As a work around you could initialise a temporary Git repository in your directory as demonstrated in this
 [script](https://gist.github.com/PuZZleDucK/a45fd1fac3758235ffed9fe0e8aab643).
 
-Alternatively you can run Linguist on individual files, see [above](/README.md#single-file).
+Alternatively you can run Linguist on individual files, see [here](/README.md#single-file).
 
 ## I am unable to install Linguist on macOS
 


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Tiny typo/link fix to Troubleshooting documentation. No functionality changed, just documentation.
## Description

Previous link 404s with https://github.com/github/linguist/blob/master/docs/CONTRIBUTING.md

This corrects it to the intended https://github.com/github/linguist/blob/master/CONTRIBUTING.md

<!--- If necessary, go into depth of what this pull request is doing. -->

