### PR TITLE
Added markdown detection

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3343,6 +3343,12 @@ M:
   codemirror_mime_type: text/x-mumps
   language_id: 214
   tm_scope: none
+Markdown:
+  type: markup
+  extensions:
+  - ".md"
+  color: "#5770c9"
+  language_id: 2155
 M4:
   type: programming
   extensions:


### PR DESCRIPTION
Although is not a language it is very commonly used for documentation and the only thing in the repo.

Added "detection" support for markdown files

## Description
Adding the .md filetype to linguist detection system

extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ x ] **I am adding a new language.**
  - [ x ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      README.md
      Documentation

