### PR TITLE
Fix typo/error in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Once the bug has been fixed upstream, we'll pick it up for GitHub in the next re
 ## Changing the source of a syntax highlighting grammar
 
 We'd like to ensure Linguist and GitHub.com are using the latest and greatest grammars that are consistent with the current usage but understand that sometimes a grammar can lag behind the evolution of a language or even stop being developed.
-This often results in someone grasping the opportunity to create a newer and better and more actively maintained grammar, and we'd love to use it and pass on it's functionality to our users.
+This often results in someone grasping the opportunity to create a newer and better and more actively maintained grammar, and we'd love to use it and pass on its functionality to our users.
 
 Switching the source of a grammar is really easy:
 


### PR DESCRIPTION
As opposed to most of the possessive forms, `it's` does not mean something that belongs to `it`. `it's` is a contraction of `it is`, and the correct way to write something that belongs to `it` is `its`.

Old sentence : 
`This often results in someone grasping the opportunity to create a newer and better and more actively maintained grammar, and we'd love to use it and pass on it's functionality to our users.`. That meant `This often results in someone grasping the opportunity to create a newer and better and more actively maintained grammar, and we'd love to use it and pass on it is functionality to our users.`, which I think was not the intended meaning.

Therefore, I changed the `it's` into an `its`: 
`This often results in someone grasping the opportunity to create a newer and better and more actively maintained grammar, and we'd love to use it and pass on its functionality to our users.`

<!--- Briefly describe your changes in the field above. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
- [ ] **I am adding a new language.**
- [ ] **I am fixing a misclassified language**
- [ ] **I am changing the source of a syntax highlighting grammar**
- [ ] **I am updating a grammar submodule**
- [ ] **I am adding new or changing current functionality**
- [ ] **I am changing the color associated with a language**

None of the above applies. I am simply fixing an error in CONTRIBUTING.md.