### PR TITLE
Use OpenSSL instead of LibreSSL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --update add --virtual build_deps \
     libc-dev \
     linux-headers \
     cmake \
-    && apk --no-cache add icu-dev libressl-dev \
+    && apk --no-cache add icu-dev openssl-dev \
     && gem install github-linguist \
     && apk del build_deps build-base libc-dev linux-headers cmake
 


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Something changed recently in libgit2 which means it doesn't want to play nicely with LibreSSL so the installation of the rugged gem fails in our Docker container like this:

```
[...]
-- Build files have been written to: /usr/local/bundle/gems/rugged-1.2.0/vendor/libgit2/build
 -- /usr/bin/make
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/local/bin/$(RUBY_BASE_NAME)
        --with-sha1dc
        --without-sha1dc
        --use-system-libraries
extconf.rb:23:in `sys': ERROR: '/usr/bin/make' failed (RuntimeError)
        from extconf.rb:107:in `block (2 levels) in <main>'
        from extconf.rb:103:in `chdir'
        from extconf.rb:103:in `block in <main>'
        from extconf.rb:100:in `chdir'
        from extconf.rb:100:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/bundle/extensions/x86_64-linux-musl/2.7.0/rugged-1.2.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/bundle/gems/rugged-1.2.0 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux-musl/2.7.0/rugged-1.2.0/gem_make.out
The command '/bin/sh -c apk --update add --virtual build_deps     build-base     libc-dev     linux-headers     cmake     && apk --no-cache add icu-dev libressl-dev     && gem install github-linguist     && apk del build_deps build-base libc-dev linux-headers cmake' returned a non-zero code: 1
```

Closer examination of `mkmf.log` reveals the cause:

```
[...]
Scanning dependencies of target ntlmclient
[  1%] Building C object deps/ntlmclient/CMakeFiles/ntlmclient.dir/ntlm.c.o
[  2%] Building C object deps/ntlmclient/CMakeFiles/ntlmclient.dir/util.c.o
[  3%] Building C object deps/ntlmclient/CMakeFiles/ntlmclient.dir/unicode_builtin.c.o
[  3%] Building C object deps/ntlmclient/CMakeFiles/ntlmclient.dir/crypt_openssl.c.o
/usr/local/bundle/gems/rugged-1.2.0/vendor/libgit2/deps/ntlmclient/crypt_openssl.c:49:20: error: static declaration of 'HMAC_CTX_cleanup' follows non-static declaration
   49 | static inline void HMAC_CTX_cleanup(HMAC_CTX *ctx)
      |                    ^~~~~~~~~~~~~~~~
In file included from /usr/local/bundle/gems/rugged-1.2.0/vendor/libgit2/deps/ntlmclient/crypt_openssl.c:18:
/usr/include/openssl/hmac.h:90:6: note: previous declaration of 'HMAC_CTX_cleanup' was here
   90 | void HMAC_CTX_cleanup(HMAC_CTX *ctx);
      |      ^~~~~~~~~~~~~~~~
cc1: note: unrecognized command-line option '-Wno-documentation-deprecated-sync' may have been intended to silence earlier diagnostics
make[2]: *** [deps/ntlmclient/CMakeFiles/ntlmclient.dir/build.make:121: deps/ntlmclient/CMakeFiles/ntlmclient.dir/crypt_openssl.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:288: deps/ntlmclient/CMakeFiles/ntlmclient.dir/all] Error 2
make: *** [Makefile:149: all] Error 2
```

I'm really not up for fighting with LibreSSL so this PR resolves the issue by switching out using `libressl-dev` for `openssl-dev`.

## Checklist:

_[ Rest of template removed as it doesn't apply ]_