### PR TITLE
Limit CI to master branch or PRs targeting it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: Run Tests
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request, but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run:


### PR DESCRIPTION
## Description

This has been annoying me for a while: we run CI twice for every PR. This is unnecessary and a waste of resources and can unnecessarily extend the time we have to wait for CI.

This PR adjusts our CI config to only run on pushes to `master` (ie when PRs are merged) and on PRs targetting `master`

_[ Checklist removed as it doesn't apply]_