### PR TITLE
Add support for Jest Snapshots

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1080,6 +1080,9 @@
 [submodule "vendor/grammars/vscode-hy"]
 	path = vendor/grammars/vscode-hy
 	url = https://github.com/leveson/vscode-hy
+[submodule "vendor/grammars/vscode-jest"]
+	path = vendor/grammars/vscode-jest
+	url = https://github.com/jest-community/vscode-jest
 [submodule "vendor/grammars/vscode-lean"]
 	path = vendor/grammars/vscode-lean
 	url = https://github.com/leanprover/vscode-lean

--- a/grammars.yml
+++ b/grammars.yml
@@ -940,6 +940,8 @@ vendor/grammars/vscode-hack:
 - source.hack
 vendor/grammars/vscode-hy:
 - source.hy
+vendor/grammars/vscode-jest:
+- source.jest.snap
 vendor/grammars/vscode-lean:
 - markdown.lean.codeblock
 - source.lean

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -83,6 +83,7 @@ module Linguist
       generated_apache_thrift? ||
       generated_jni_header? ||
       vcr_cassette? ||
+      jest_snapshot? ||
       generated_antlr? ||
       generated_module? ||
       generated_unity3d_meta? ||
@@ -441,6 +442,18 @@ module Linguist
       return false unless lines.count > 2
       # VCR Cassettes have "recorded_with: VCR" in the second last line.
       return lines[-2].include?("recorded_with: VCR")
+    end
+
+    # Is this a Jest Snapshot?
+    #
+    # Jest Snapshots always start with:
+    # // Jest Snapshot v1 ...
+    #
+    # Returns true or false
+    def jest_snapshot?
+      return false unless extname == '.snap'
+      return false unless lines.count > 1
+      return lines[0].include?("// Jest Snapshot ")
     end
 
     # Is this a generated ANTLR file?

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2880,6 +2880,16 @@ JavaScript+ERB:
   codemirror_mode: javascript
   codemirror_mime_type: application/javascript
   language_id: 914318960
+Jest Snapshot:
+  type: data
+  color: "#15c213"
+  tm_scope: source.jest.snap
+  extensions:
+  - ".snap"
+  ace_mode: javascript
+  codemirror_mode: javascript
+  codemirror_mime_type: application/javascript
+  language_id: 774635084
 Jinja:
   type: markup
   color: "#a52a22"

--- a/samples/Jest Snapshot/css.test.tsx.snap
+++ b/samples/Jest Snapshot/css.test.tsx.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inlines styles 1`] = `
+Object {
+  "Tag": [Function],
+  "children": Array [
+    <Defs>
+      <missingTag
+        type="text/css"
+      >
+
+      /* tag selector */
+      rect {
+        stroke: blue;
+        fill: yellow
+      }
+
+      /* class selector */
+      .redbox { fill: red; }
+
+      /* multiple selectors */
+      g .class-1, g .class-2 {
+        stroke-width: 16
+      }
+
+      /* two classes */
+      .class-2.transparent {
+        fill-opacity: 0.3;
+      }
+
+      /* Commented out
+      rect {
+        fill: black;
+      }
+      */
+
+      </missingTag>
+    </Defs>,
+    <G>
+      <Rect
+        class="redbox class-1"
+        height={200}
+        style={
+          Object {
+            "fill": "red",
+            "stroke": "blue",
+            "strokeWidth": "16",
+          }
+        }
+        width={1000}
+        x={100}
+        y={0}
+      />
+    </G>,
+    <G>
+      <Rect
+        class="redbox class-2 transparent"
+        height={200}
+        style={
+          Object {
+            "fill": "red",
+            "fillOpacity": "0.3",
+            "stroke": "blue",
+            "strokeWidth": "16",
+          }
+        }
+        width={750}
+        x={100}
+        y={350}
+      />
+    </G>,
+  ],
+  "parent": null,
+  "props": Object {
+    "height": "100%",
+    "version": 1.1,
+    "viewBox": "0 0 1000 500",
+    "width": "100%",
+    "xmlns": "http://www.w3.org/2000/svg",
+  },
+  "tag": "svg",
+}
+`;
+
+exports[`supports CSS in style element 1`] = `
+<RNSVGSvgView
+  align="xMidYMid"
+  bbHeight="100%"
+  bbWidth="100%"
+  focusable={false}
+  height="100%"
+  meetOrSlice={0}
+  minX={0}
+  minY={0}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "borderWidth": 0,
+      },
+      Object {
+        "flex": 0,
+        "height": "100%",
+        "width": "100%",
+      },
+    ]
+  }
+  vbHeight={500}
+  vbWidth={1000}
+  version={1.1}
+  width="100%"
+  xml="<?xml version=\\"1.0\\" standalone=\\"no\\"?>
+<!DOCTYPE svg PUBLIC \\"-//W3C//DTD SVG 1.1//EN\\"
+  \\"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\\">
+<svg xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\"
+     width=\\"100%\\" height=\\"100%\\" viewBox=\\"0 0 1000 500\\">
+  <defs>
+    <style type=\\"text/css\\">
+      /* tag selector */
+      rect {
+        stroke: blue;
+        fill: yellow
+      }
+
+      /* class selector */
+      .redbox { fill: red; }
+
+      /* multiple selectors */
+      g .class-1, g .class-2 {
+        stroke-width: 16
+      }
+
+      /* two classes */
+      .class-2.transparent {
+        fill-opacity: 0.3;
+      }
+
+      /* Commented out
+      rect {
+        fill: black;
+      }
+      */
+    </style>
+  </defs>
+  <g>
+    <rect class=\\"redbox class-1\\" x=\\"100\\" y=\\"0\\" width=\\"1000\\" height=\\"200\\" />
+  </g>
+  <g>
+    <rect class=\\"redbox class-2 transparent\\" x=\\"100\\" y=\\"350\\" width=\\"750\\" height=\\"200\\" />
+  </g>
+</svg>"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <RNSVGGroup>
+    <RNSVGDefs />
+    <RNSVGGroup>
+      <RNSVGRect
+        fill={4294901760}
+        height={200}
+        propList={
+          Array [
+            "fill",
+            "stroke",
+            "strokeWidth",
+          ]
+        }
+        stroke={4278190335}
+        strokeWidth="16"
+        width={1000}
+        x={100}
+        y={0}
+      />
+    </RNSVGGroup>
+    <RNSVGGroup>
+      <RNSVGRect
+        fill={4294901760}
+        fillOpacity={0.3}
+        height={200}
+        propList={
+          Array [
+            "fill",
+            "fillOpacity",
+            "stroke",
+            "strokeWidth",
+          ]
+        }
+        stroke={4278190335}
+        strokeWidth="16"
+        width={750}
+        x={100}
+        y={350}
+      />
+    </RNSVGGroup>
+  </RNSVGGroup>
+</RNSVGSvgView>
+`;

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -229,6 +229,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Java Server Pages:** [textmate/java.tmbundle](https://github.com/textmate/java.tmbundle)
 - **JavaScript:** [atom/language-javascript](https://github.com/atom/language-javascript)
 - **JavaScript+ERB:** [atom/language-javascript](https://github.com/atom/language-javascript)
+- **Jest Snapshot:** [jest-community/vscode-jest](https://github.com/jest-community/vscode-jest)
 - **Jinja:** [textmate/python-django.tmbundle](https://github.com/textmate/python-django.tmbundle)
 - **Jison:** [cdibbs/language-jison](https://github.com/cdibbs/language-jison)
 - **Jison Lex:** [cdibbs/language-jison](https://github.com/cdibbs/language-jison)

--- a/vendor/licenses/git_submodule/vscode-jest.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-jest.dep.yml
@@ -1,0 +1,31 @@
+---
+name: vscode-jest
+version: fa71673b5834e593b5f8b021e28530ec2a466853
+type: git_submodule
+homepage: https://github.com/react-native-svg/react-native-svg
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) [2015-2016] [Horcrux]
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/vendor/licenses/git_submodule/vscode-jest.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-jest.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: vscode-jest
-version: fa71673b5834e593b5f8b021e28530ec2a466853
+version: a7573b089a206d42102e2cb39c1e70c3c83b87b1
 type: git_submodule
 homepage: https://github.com/react-native-svg/react-native-svg
 license: mit


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
- Close #5564

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Support [Jest Snapshot](https://jestjs.io/docs/snapshot-testing) files.
Basically JavaScript, but has its own tm-scope to support the highlighting inside \`backticks\`.
Classify these as generated.

## Checklist

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - [.snap](https://github.com/search?q=extension%3Asnap+%22jest%22&type=code) -- 680K files
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample: [source](https://github.com/react-native-svg/react-native-svg/blob/develop/__tests__/__snapshots__/css.test.tsx.snap)
    - Sample license: [MIT](https://github.com/react-native-svg/react-native-svg/blob/develop/LICENSE)
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [x] I have included a syntax highlighting grammar: [source](https://github.com/jest-community/vscode-jest/blob/master/syntaxes/jest-snapshot.tmLanguage), [preview](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fjest-community%2Fvscode-jest%2Fblob%2Fmaster%2Fsyntaxes%2Fjest-snapshot.tmLanguage%3Frgh-link-date%3D2021-09-10T06%253A10%253A32Z&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Freact-native-svg%2Freact-native-svg%2Fblob%2Fdevelop%2F__tests__%2F__snapshots__%2Fcss.test.tsx.snap&code=) (slightly broken)
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
