### PR TITLE
Include Containerfile equivalency

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1340,11 +1340,14 @@ DirectX 3D File:
   language_id: 201049282
 Dockerfile:
   type: programming
+  aliases:
+  - Containerfile
   color: "#384d54"
   tm_scope: source.dockerfile
   extensions:
   - ".dockerfile"
   filenames:
+  - Containerfile
   - Dockerfile
   ace_mode: dockerfile
   codemirror_mode: dockerfile


### PR DESCRIPTION
## Description

This file is [exactly equivalent](https://meta.stackoverflow.com/questions/407966/generalize-dockerfile-to-containerfile-for-now-and-the-future) in every way and context.  Exact same highlighting rules and handling should be provided for either name style.

## Checklist:
- [x] **I am associating a language with a new filename.**
	- [x] **The new filename is used in hundreds of repositories on GitHub.com:**  
	[~1,640 search results](https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=filename%3Acontainerfile+NOT+nothack)
