### PR TITLE
Add detection of generated IntelliJ files

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -52,6 +52,7 @@ module Linguist
     # Return true or false
     def generated?
       xcode_file? ||
+      intellij_file? ||
       cocoapods? ||
       carthage_build? ||
       generated_graphql_relay? ||
@@ -112,6 +113,13 @@ module Linguist
     # Returns true or false.
     def xcode_file?
       ['.nib', '.xcworkspacedata', '.xcuserstate'].include?(extname)
+    end
+    
+    # Is the blob an IntelliJ IDEA file (IDE-specific files that are sometimes checked in)? 
+    #
+    # Returns true or false.
+    def intellij_file?
+      !!name.match(/.idea\//)
     end
 
     # Internal: Is the blob part of Pods/, which contains dependencies not meant for humans in pull requests.

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -119,7 +119,7 @@ module Linguist
     #
     # Returns true or false.
     def intellij_file?
-      !!name.match(/.idea\//)
+      !!name.match(/(?:^|\/)\.idea\//)
     end
 
     # Internal: Is the blob part of Pods/, which contains dependencies not meant for humans in pull requests.

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -115,7 +115,10 @@ module Linguist
       ['.nib', '.xcworkspacedata', '.xcuserstate'].include?(extname)
     end
     
-    # Is the blob an IntelliJ IDEA file (IDE-specific files that are sometimes checked in)? 
+    # Internal: Is the blob an IntelliJ IDEA project file?
+    #
+    # JetBrains IDEs generate project files under an `.idea` directory
+    # that are sometimes checked into version control.
     #
     # Returns true or false.
     def intellij_file?


### PR DESCRIPTION
Classify the [`.idea/` files](https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-) generated by the IntelliJ IDEA family of IDEs (IDEA, PhpStorm, RubyMine, GoLand, etc) as generated.

