### PR TITLE
Add heuristics for the association of `.frag` extension for JavaScript to deconflict with GLSL fragment shaders

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -190,6 +190,11 @@ disambiguations:
   - language: Frege
     pattern: '^\s*(import|module|package|data|type) '
   - language: Text
+- extensions: ['.frag']
+  rules:
+  - language: JavaScript
+    pattern: '^\s*(?:;\s*)?[(!]function\s*\('
+  - language: GLSL
 - extensions: ['.fs']
   rules:
   - language: Forth

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2847,6 +2847,7 @@ JavaScript:
   - ".gs"
   - ".jake"
   - ".javascript"
+  - ".js.frag"
   - ".jsb"
   - ".jscad"
   - ".jsfl"


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

This PR removes the association of `.frag` extension for JavaScript, or rather, makes it more specific. This was added in #1178 with the example usage of JS code fragments which would be concatenated with a main program to wrap it into an IIFE (immediately-invoked function expression), but the thing is that JS development has since moved on from source code concatenation, so now it is hard to find legitimate usages of this file extension in contemporary JS projects. Moreover, nothing about `.frag` tells that it is JS-specific - it can stand for "fragment" as in a fragment of some program, but a way more frequently-occurring usage of this extension are GLSL fragment shaders. And so, because of the lack of a rule in `heuristics.yml`, thousands of GLSL files are now very frequently misclassified as JavaScript.

And so, I think that rather than introducing a regex for separating one from the other, association of `.frag` with JS can be removed altogether as an artifact of the past. I did make it more specific though, by changing it to `.js.frag`, as to ensure that the tests still pass.

## Checklist:

- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [Search results for `extension:frag language:js in:path,file NOT node_modules NOT glslang NOT void NOT struct NOT asm`](https://github.com/search?p=1&q=extension%3Afrag+language%3Ajs+in%3Apath%2Cfile+NOT+node_modules+NOT+glslang+NOT+void+NOT+struct+NOT+asm&type=Code) (~99k results) - this was supposed to exclude GLSL usages of this extension, compiled SPIR-V code and find the JS ones, but you would be hard-pressed to discover the latter ones here. One thing that sometimes pops up is the [node-forge](https://github.com/digitalbazaar/forge) (4k stars) package in committed `node_modules` directories, but [they have moved on to Webpack](https://github.com/digitalbazaar/forge/commit/ff04382e07653aced52be0f63019b66eefea7935).
      - [Search results for `extension:frag language:js in:path,file prototype NOT node_modules NOT glslang NOT void NOT struct NOT asm`](https://github.com/search?q=extension%3Afrag+language%3Ajs+in%3Apath%2Cfile+prototype+NOT+node_modules+NOT+glslang+NOT+void+NOT+struct+NOT+asm&type=Code) (~50 results) - next I tried searching for keywords which are unique to JS and not used in GLSL, e.g. `prototype`. Most of the results are either SPIR-V assembly or the examples from this repository (`samples/JavaScript/intro.js.frag` and `samples/JavaScript/outro.js.frag`) where Linguist itself has been vendored (its heuristics are often used in text editor plugins for file extension detection).
      - [Search results for `extension:frag language:js in:path,file window NOT node_modules NOT glslang NOT void NOT struct NOT asm`](https://github.com/search?q=extension%3Afrag+language%3Ajs+in%3Apath%2Cfile+window+NOT+node_modules+NOT+glslang+NOT+void+NOT+struct+NOT+asm&type=Code) (~600 results) - `window` is another word I thought wouldn't occur randomly in GLSL code. Notable results here include: some C code from a frequently vendored X11 library, some Java sample file from Firefox called `ThemedView.java.frag`, and legitimate JS code fragments for wrapping the program in an IIFE, from ~2014.
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
