### PR TITLE
Stop flagging Jest snapshots as generated files

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -83,7 +83,6 @@ module Linguist
       generated_apache_thrift? ||
       generated_jni_header? ||
       vcr_cassette? ||
-      jest_snapshot? ||
       generated_antlr? ||
       generated_module? ||
       generated_unity3d_meta? ||
@@ -442,18 +441,6 @@ module Linguist
       return false unless lines.count > 2
       # VCR Cassettes have "recorded_with: VCR" in the second last line.
       return lines[-2].include?("recorded_with: VCR")
-    end
-
-    # Is this a Jest Snapshot?
-    #
-    # Jest Snapshots always start with:
-    # // Jest Snapshot v1 ...
-    #
-    # Returns true or false
-    def jest_snapshot?
-      return false unless extname == '.snap'
-      return false unless lines.count > 1
-      return lines[0].include?("// Jest Snapshot ")
     end
 
     # Is this a generated ANTLR file?

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -193,4 +193,16 @@ class TestGenerated < Minitest::Test
     # poetry
     generated_sample_without_loading_data("TOML/filenames/poetry.lock")
   end
+
+  # We've whitelisted these files on purpose, even though they're machine-generated.
+  # Future contributors won't necessarily know that, so these checks are in-place to
+  # catch PRs that mark these files as generated (and prevent a forgetful maintainer
+  # from approving them).
+  def test_check_not_generated
+    # Jest snapshots (#3579)
+    generated_sample_without_loading_data("Jest Snapshot/css.test.tsx.snap", true)
+
+    # Yarn lockfiles (#4459)
+    generated_sample_without_loading_data("YAML/filenames/yarn.lock", true)
+  end
 end


### PR DESCRIPTION
See [5567](https://github.com/github/linguist/pull/5567#issuecomment-970906650). This is essentially #3579 part 2: Electric Boogaloo.

I've added regression tests to catch any future PRs that add Jest snapshots to the generated files list. I gave Yarn lockfiles the same treatment, since they're in the same boat.

/cc @joscha