### PR TITLE
Update Astro URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -250,7 +250,7 @@
 	url = https://github.com/nanoant/assembly.tmbundle
 [submodule "vendor/grammars/astro"]
 	path = vendor/grammars/astro
-	url = https://github.com/snowpackjs/astro
+	url = https://github.com/withastro/astro
 [submodule "vendor/grammars/atom-editorconfig"]
 	path = vendor/grammars/atom-editorconfig
 	url = https://github.com/sindresorhus/atom-editorconfig

--- a/samples/Astro/index.astro
+++ b/samples/Astro/index.astro
@@ -11,7 +11,7 @@ import Tour from '../components/Tour.astro';
 let title = 'My Astro Site';
 
 // Full Astro Component Syntax:
-// https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/astro-components.md
+// https://github.com/withastro/astro/blob/main/docs/core-concepts/astro-components.md
 ---
 <html lang="en">
 <head>
@@ -48,7 +48,7 @@ let title = 'My Astro Site';
            - Note: by default, these components are NOT interactive on the client.
            - The `:visible` directive tells Astro to make it interactive.
            -
-           - See https://github.com/snowpackjs/astro/blob/main/docs/core-concepts/component-hydration.md
+           - See https://github.com/withastro/astro/blob/main/docs/core-concepts/component-hydration.md
            -->
         <!-- ASTRO:COMPONENT_MARKUP -->
     </main>

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -38,7 +38,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **AsciiDoc:** [zuckschwerdt/asciidoc.tmbundle](https://github.com/zuckschwerdt/asciidoc.tmbundle)
 - **AspectJ:** [pchaigno/sublime-aspectj](https://github.com/pchaigno/sublime-aspectj)
 - **Assembly:** [Nessphoro/sublimeassembly](https://github.com/Nessphoro/sublimeassembly)
-- **Astro:** [snowpackjs/astro](https://github.com/snowpackjs/astro)
+- **Astro:** [withastro/astro](https://github.com/withastro/astro)
 - **Asymptote:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **AutoHotkey:** [ahkscript/SublimeAutoHotkey](https://github.com/ahkscript/SublimeAutoHotkey)
 - **AutoIt:** [AutoIt/SublimeAutoItScript](https://github.com/AutoIt/SublimeAutoItScript)

--- a/vendor/licenses/git_submodule/astro.dep.yml
+++ b/vendor/licenses/git_submodule/astro.dep.yml
@@ -2,7 +2,7 @@
 name: astro
 version: f798663570a0d10adc83b7aec93bfee6ee96d8dd
 type: git_submodule
-homepage: https://github.com/snowpackjs/astro
+homepage: https://github.com/withastro/astro
 license: mit
 licenses:
 - sources: LICENSE


### PR DESCRIPTION
The Astro URL has changed from https://github.com/snowpackjs/astro to https://github.com/withastro/astro.

## Checklist: 
None applied to a simple update like this, but happy to fill one out if desired.