### PR TITLE
Add `.vimrc` to supported Vim Script extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6414,6 +6414,7 @@ Vim Script:
   extensions:
   - ".vim"
   - ".vba"
+  - ".vimrc"
   - ".vmb"
   filenames:
   - ".exrc"

--- a/samples/Vim Script/settings.vimrc
+++ b/samples/Vim Script/settings.vimrc
@@ -1,0 +1,96 @@
+set encoding=utf-8
+silent! set modelineexpr
+filetype on
+syntax enable
+
+" Configure Vundle
+if getftype("~/.vim/bundle/Vundle.vim") ==? "dir"
+	filetype off
+	set nocompatible
+	set rtp+=~/.vim/bundle/Vundle.vim
+	call vundle#begin()
+	Plugin "VundleVim/Vundle.vim"
+	call vundle#end()
+	filetype on
+endif
+
+" Configure Pathogen
+if exists("g:loaded_pathogen")
+	execute pathogen#infect()
+	syntax on
+	filetype plugin indent on
+endif
+
+" Use Solarized theme if running graphically
+if has("gui_running")
+	set background=dark
+	colorscheme solarized
+endif
+
+"======================================================================*
+set number
+set autoread
+set backspace=indent,eol,start
+set tabstop=4 softtabstop=0 noexpandtab shiftwidth=4
+set hlsearch
+set ignorecase
+set incsearch
+set modelines=50
+set showmatch
+
+highlight OverLength ctermbg=red ctermfg=white guibg=#592929
+fun! UpdateMatch()
+	if exists("b:current_syntax")
+		if b:current_syntax =~ "gitcommit"
+			match OverLength /\%>72v.\+/
+		else
+			match NONE
+		endif
+	endif
+endfun
+autocmd BufEnter,BufWinEnter * call UpdateMatch()
+
+
+"======================================================================*
+" Status line colours
+highlight statusline ctermbg=DarkGreen ctermfg=Black
+
+" Display highlighting group at cursor
+fun! StatusLineHighlightGroup()
+	return synIDattr(synID(line("."), col("."), 1), "name")
+endfun
+
+" Name of currently-active filetype
+fun! StatusLineFileType()
+	return strlen(&ft) ? &ft : "none"
+endfun
+
+" Character encoding and byte-order mark indicators
+fun! StatusLineEncoding()
+	let encoding = toupper (&fenc == "" ? &enc : &fenc)
+	if exists("+bomb") && &bomb
+	 	encoding += "(BOM)"
+	endif
+	return encoding
+endfun
+
+" Line-ending style
+fun! StatusLineEOLStyle()
+	if     (&fileformat ==? "unix") | return "LF"
+	elseif (&fileformat ==? "dos")  | return "CRLF"
+	elseif (&fileformat ==? "mac")  | return "CR"
+	endif; return type
+endfun
+
+if has("statusline")
+	set laststatus=2
+	set statusline=%#Question#%-2.2n\               " Buffer number
+	set statusline+=%#WarningMsg#%<%f\ %#Question#  " Filename
+	set statusline+=\ %l:%c                         " Line:column
+	set statusline+=\ %{StatusLineHighlightGroup()} " Highlighting group at cursor
+	set statusline+=%=                              " Left/right divider
+	set statusline+=%{StatusLineEOLStyle()}\ \      " What line terminators are used
+	set statusline+=%{StatusLineEncoding()}\ \      " Encoding + BOM
+	set statusline+=%{StatusLineFileType()}\ \      " Filetype
+	set statusline+=%h%m%r%w\                       " Flags
+endif


### PR DESCRIPTION
## Description
This PR adds support for `.vimrc` as a file-extension (in addition to a standalone filename).

Fixes: #5618

## Checklist:
- [x] **I am associating a language with a new file extension.**
	- [x] **The new extension is used in hundreds of repositories on GitHub.com:**  
	[~6,477 search results](https://github.com/search?q=extension%3Avimrc&type=code), with healthy distribution between users
	- [x] **I have included a real-world usage sample:**
	My own [`.vimrc`](https://github.com/Alhadis/.files/blob/e41f931a097091abd2f5f02c9eed1d65b1f9be0d/.vimrc) file, albeit under a different name.
	- [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
