### PR TITLE
Add support for ShellCheck configuration files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3737,7 +3737,7 @@ MoonScript:
   language_id: 238
 Motoko:
   type: programming
-  color: '#fbb03b'
+  color: "#fbb03b"
   extensions:
   - ".mo"
   tm_scope: source.mo
@@ -5664,6 +5664,18 @@ Shell:
   codemirror_mode: shell
   codemirror_mime_type: text/x-sh
   language_id: 346
+ShellCheck Config:
+  type: data
+  color: "#cecfcb"
+  filenames:
+  - ".shellcheckrc"
+  aliases:
+  - shellcheckrc
+  tm_scope: source.shellcheckrc
+  ace_mode: ini
+  codemirror_mode: properties
+  codemirror_mime_type: text/x-properties
+  language_id: 687511714
 ShellSession:
   type: programming
   extensions:

--- a/samples/ShellCheck Config/filenames/.shellcheckrc
+++ b/samples/ShellCheck Config/filenames/.shellcheckrc
@@ -1,0 +1,9 @@
+shell=sh
+enable=avoid-nullary-conditions,deprecate-which,quote-safe-variables
+
+# Solaris 8-9 compatibility
+disable=SC2006  # Don't suggest $(…) instead of `…`
+disable=SC2021  # Ignore bracketed tr(1) ranges
+
+# Don't suggest explicit “-n” operators in tests
+disable=SC2244

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -432,6 +432,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Scilab:** [textmate/scilab.tmbundle](https://github.com/textmate/scilab.tmbundle)
 - **ShaderLab:** [tgjones/shaders-tmLanguage](https://github.com/tgjones/shaders-tmLanguage)
 - **Shell:** [atom/language-shellscript](https://github.com/atom/language-shellscript)
+- **ShellCheck Config:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
 - **ShellSession:** [atom/language-shellscript](https://github.com/atom/language-shellscript)
 - **Shen:** [rkoeninger/sublime-shen](https://github.com/rkoeninger/sublime-shen)
 - **Sieve:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)


### PR DESCRIPTION
## Description
[ShellCheck](https://www.shellcheck.net/) is a well-known linting and static analysis tool for shell-scripts. It supports a [basic configuration format](https://github.com/koalaman/shellcheck/wiki/Directive) stored in files named `.shellcheckrc`, which typically reside in the root of one's project.

Language colour sourced from the [project's logo](https://www.shellcheck.net/favicon.ico).

## Checklist:
- [x] **I am adding a new language.**
	- [x] **The filename of the new language is used in hundreds of repositories on GitHub.com:**  
		- [371 files sampled](https://github.com/Alhadis/Silos/blob/761db7dde76576a056f364fa5237de72e74048e2/urls.log) / [673 files total](https://github.com/search?q=filename%3Ashellcheckrc+NOT+nothack&type=Code)
		- [366 repos](https://github.com/Alhadis/Silos/blob/761db7dde76576a056f364fa5237de72e74048e2/repos.log)
		- [263 users](https://github.com/Alhadis/Silos/blob/761db7dde76576a056f364fa5237de72e74048e2/users.log)
	- [x] **I have included a real-world usage sample:**  
	[`.shellcheckrc`](https://github.com/Alhadis/.files/blob/ee18db1ac7944cfb4812177597adbe2155cbbb39/.shellcheckrc) taken from my own dotfiles
	- [x] **I ~~have included~~ already wrote a syntax highlighting grammar:**  
		- Source: [`Alhadis/language-etc`](https://github.com/Alhadis/language-etc/blob/240978efb1f24df1aa1397843bbd73bb8203a64e/grammars/shellcheckrc.cson), written ages ago
		- Previews: [&nbsp;1&nbsp;](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FAlhadis%2Flanguage-etc%2Fblob%2Fmaster%2Fgrammars%2Fshellcheckrc.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2FAlhadis%2F.files%2Fmaster%2F.shellcheckrc&code=) | [&nbsp;2&nbsp;](https://github.com/emmanuel2804/outline-server/blob/9d80b6d448515b0f4752d2ed6f5383c56702764d/.shellcheckrc)
	- [ ] I have updated the heuristics
