### PR TITLE
Add kshrc to Shell

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5630,6 +5630,7 @@ Shell:
   - ".env"
   - ".env.example"
   - ".flaskenv"
+  - ".kshrc"
   - ".login"
   - ".profile"
   - ".zlogin"
@@ -5645,6 +5646,7 @@ Shell:
   - bashrc
   - cshrc
   - gradlew
+  - kshrc
   - login
   - man
   - profile

--- a/samples/Shell/filenames/.kshrc
+++ b/samples/Shell/filenames/.kshrc
@@ -1,0 +1,21 @@
+case "$-" in
+    *i*) ;;
+    *) return 0 ;;
+esac
+
+export PAGER=less
+export LANG=en_US.UTF-8
+export LC_CTYPE=en_US.UTF-8
+
+HISTFILE=$HOME/.ksh_history
+HISTSIZE=20000
+HISTCONTROL=ignoredups
+
+set -o emacs
+
+alias ll='ls -l'
+alias la='ls -lA'
+
+PS1='\A $? \w \$ '
+
+set -A complete_sysctl -- $(sysctl | grep = | cut -d= -f1)

--- a/samples/Shell/filenames/kshrc
+++ b/samples/Shell/filenames/kshrc
@@ -1,0 +1,21 @@
+case "$-" in
+    *i*) ;;
+    *) return 0 ;;
+esac
+
+export PAGER=less
+export LANG=en_US.UTF-8
+export LC_CTYPE=en_US.UTF-8
+
+HISTFILE=$HOME/.ksh_history
+HISTSIZE=20000
+HISTCONTROL=ignoredups
+
+set -o emacs
+
+alias ll='ls -l'
+alias la='ls -lA'
+
+PS1='\A $? \w \$ '
+
+set -A complete_sysctl -- $(sysctl | grep = | cut -d= -f1)


### PR DESCRIPTION
Adding `kshrc` and `.kshrc`, config files for the Korn Shell, as file names for Shell. It already has support for the `.ksh` extension.

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=filename%3A.kshrc
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - A slightly stripped down version of my own kshrc
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
