### PR TITLE
Updated color of mcfunction.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7097,7 +7097,7 @@ mIRC Script:
   language_id: 517654727
 mcfunction:
   type: programming
-  color: "#E22837"
+  color: "#1DB53C"
   extensions:
   - ".mcfunction"
   tm_scope: source.mcfunction


### PR DESCRIPTION
Changed the color of the mcfunction language.

## Description
The current color has nothing to do with minecraft or the command functionality.
I suggest changing it so something more fitting like #1DB53C (the color of the creeper face logo often used by mojang, it also looks very similar to the grass texture color).
Since I don't think the mcfunction files or commands have a logo or even a color, it is appropriate to change them to a color that is even remotely related to the purpose and use cases of the language.


- [x] **I am changing the color associated with a language**   
I searched for information on the internet but i couldnt find anything related to a color or logo for this language.
### As far as I can tell, the previous color was chosen completely randomly and I think it is appropriate now to choose a color that represents the language better. Since the language is only relevant for minecraft, it is appropriate to choose a color with which the minecraft community and thus also the datapack community that uses this language can identify.