### PR TITLE
Update Docker installation instructions for macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ These components have their own dependencies - `icu4c`, and `cmake` and `pkg-con
 For example, on macOS with [Homebrew](http://brew.sh/):
 ```bash
 brew install cmake pkg-config icu4c
-brew cask install docker
+brew install --cask docker
 ```
 
 On Ubuntu:


### PR DESCRIPTION
CONTRIBUTING.md contained an out-of-date brew command, using `brew cask` instead of `brew install --cask`

_Template removed as it doesn't apply._