### PR TITLE
Change Yarn PnP regex to include all `.pnp.*` files

### DIFF
--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -413,7 +413,7 @@ module Linguist
     #
     # Returns true or false.
     def generated_yarn_plugnplay?
-      !!name.match(/(^|\/)\.pnp\.(c|m)?js$/)
+      !!name.match(/(^|\/)\.pnp.*$/)
     end
 
     # Internal: Is the blob part of Godeps/,

--- a/lib/linguist/generated.rb
+++ b/lib/linguist/generated.rb
@@ -413,7 +413,7 @@ module Linguist
     #
     # Returns true or false.
     def generated_yarn_plugnplay?
-      !!name.match(/(^|\/)\.pnp.*$/)
+      !!name.match(/(^|\/)\.pnp\..*$/)
     end
 
     # Internal: Is the blob part of Godeps/,

--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -97,6 +97,7 @@ class TestGenerated < Minitest::Test
     generated_sample_without_loading_data(".pnp.js")
     generated_sample_without_loading_data(".pnp.cjs")
     generated_sample_without_loading_data(".pnp.mjs")
+    generated_sample_without_loading_data(".pnp.loader.mjs")
 
     # Godep saved dependencies
     generated_sample_without_loading_data("Godeps/Godeps.json")


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

According to Yarn docs, they may generate any `.pnp.*` file ([ref](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)). Currently only `.pnp.cjs`, `.pnp.mjs`, `.pnp.js` are ignored from stats, but Yarn now also generates `.pnp.loader.mjs`.

With old regex: https://regexr.com/6dchf
With new regex: https://regexr.com/6dchc

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.