### PR TITLE
Slightly adjust bootstrap regex

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -74,7 +74,7 @@
 - ([^\s]*)import\.(css|less|scss|styl)$
 
 # Bootstrap css and js
-- (^|/)bootstrap([^.]*)\.(js|css|less|scss|styl)$
+- (^|/)bootstrap([^/.]*)\.(js|css|less|scss|styl)$
 - (^|/)custom\.bootstrap([^\s]*)(js|css|less|scss|styl)$
 
 # Font Awesome

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -569,6 +569,10 @@ class TestFileBlob < Minitest::Test
 
     # Jenkins
     assert sample_blob("Jenkinsfile").vendored?
+
+    # Bootstrap
+    assert !sample_blob("src/bootstraps/settings.js").vendored?
+    assert sample_blob("src/bootstrap-custom.js").vendored?
   end
 
   def test_documentation


### PR DESCRIPTION
The bootstrap regex here is a big excessive, e.g. it matches paths like:

`/src/bootstraps/settings.js`

which is human writen code, whereas I think it was intended to match things like

`/src/bootstrap-custom.js`

I made it so that the wildcard (which currently doesn't match dots) also doesn't match slashes, which restrains it a bit. 