### PR TITLE
Declare program version for `OptionParser`

### DIFF
--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -24,6 +24,7 @@ def github_linguist(args)
 
   parser = OptionParser.new do |opts|
     opts.banner = HELP_TEXT
+    opts.version = Linguist::VERSION
 
     opts.on("-b", "--breakdown", "Analyze entire repository and display detailed usage statistics") { breakdown = true }
     opts.on("-j", "--json", "Output results as JSON") { json_output = true }


### PR DESCRIPTION
## Description
This PR specifies the release version for `OptionParser` to display when `-v` or `--version` are passed via command-line. These options are implicitly supported by default, leading to unintuitive errors like the one reported by #5765:

~~~console
$ github-linguist --version
github-linguist: version unknown
~~~

Now it reports something sane:

~~~console
$ github-linguist --version
github-linguist 7.18.0
~~~

_(Checklist removed as it doesn't apply)_