### PR TITLE
Add support for `systemd(1)` configuration files

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7033,6 +7033,7 @@ desktop:
   extensions:
   - ".desktop"
   - ".desktop.in"
+  - ".service"
   tm_scope: source.desktop
   ace_mode: text
   language_id: 412

--- a/samples/desktop/nebula.service
+++ b/samples/desktop/nebula.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=nebula
+Wants=basic.target
+After=basic.target network.target
+Before=sshd.service
+
+[Service]
+SyslogIdentifier=nebula
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Description
This PR adds support for `systemd(1)` config files, [whose syntax](https://www.freedesktop.org/software/systemd/man/systemd.syntax.html) is based on `.desktop` files (which in turn are INI files).

Resolves: #5750.

## Checklist:
- [x] **I am associating a language with a new file extension.**
	- [x] **The new extension is used in hundreds of repositories on GitHub:**  
		[~535,653 results](https://github.com/search?q=extension%3Aservice+NOT+nothack&type=Code)
	- [x] **I have included a real-world usage sample.**
		- [`nebula.service`](https://github.com/slackhq/nebula/blob/13471f57925a23f1e1ddd579bbd025a2fee9d2b7/examples/service_scripts/nebula.service): [MIT-license](https://github.com/slackhq/nebula/blob/f22b4b584d64c945da3dfc22361a76b1f87bd8af/LICENSE)
	- [ ] ~~I have included a change to the heuristics to distinguish my language from others using the same extension.~~
