### PR TITLE
Add `.code-snippets` as a JSONC extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2780,6 +2780,7 @@ JSON with Comments:
   - jsonc
   extensions:
   - ".jsonc"
+  - ".code-snippets"
   - ".sublime-build"
   - ".sublime-commands"
   - ".sublime-completions"

--- a/samples/JSON with Comments/vue.code-snippets
+++ b/samples/JSON with Comments/vue.code-snippets
@@ -1,0 +1,80 @@
+{
+    // Place your snippets for vue here. Each snippet is defined under a snippet name and has a prefix, body and
+    // description. The prefix is what is used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+    // $1, $2 for tab stops, $0 for the final cursor position, and \${1:label}, \${2:another} for placeholders. Placeholders with the
+    // same ids are connected.
+    "script": {
+        "scope": "vue",
+        "prefix": "script",
+        "body": [
+            "<script lang=\"ts\">",
+            "import { defineComponent } from 'vue';",
+            "",
+            "export default defineComponent({",
+            "  $2",
+            "});",
+            "</script>"
+        ],
+        "description": "Create <script> block"
+    },
+    "script setup": {
+        "scope": "vue",
+        "prefix": "script setup",
+        "body": [
+            "<script lang=\"ts\" setup>",
+            "defineProps<{ $1 }>();",
+            "</script>"
+        ],
+        "description": "Create <script setup> + <script> blocks"
+    },
+    "style": {
+        "scope": "vue",
+        "prefix": "style",
+        "body": [
+            "<style lang=\"scss\" scoped>",
+            "$1",
+            "</style>"
+        ],
+        "description": "Create <style> block"
+    },
+    "v-for": {
+        "scope": "html",
+        "prefix": "v-for",
+        "body": [
+            "<template v-for=\"$1 in $2\">",
+            "  $3",
+            "</template>"
+        ],
+        "description": "Create html tag with v-for"
+    },
+    "v-if": {
+        "scope": "html",
+        "prefix": "v-if",
+        "body": [
+            "<template v-if=\"$1\">",
+            "  $2",
+            "</template>"
+        ],
+        "description": "Create html tag with v-if"
+    },
+    "v-else-if": {
+        "scope": "html",
+        "prefix": "v-else-if",
+        "body": [
+            "<template v-else-if=\"$1\">",
+            "  $2",
+            "</template>"
+        ],
+        "description": "Create html tag with v-else-if"
+    },
+    "v-else": {
+        "scope": "html",
+        "prefix": "v-else",
+        "body": [
+            "<template v-else>",
+            "  $2",
+            "</template>"
+        ],
+        "description": "Create html tag with v-else"
+    }
+}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
- Resolve #5574

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Adds `.code-snippets` to the list of JSONC filenames.
The files are used by vscode.
[Proof it's JSONC](https://cs.github.com/?scopeName=All+repos&scope=&q=path%3A%2Fcode-snippets%24%2F+%2F%5E+*%5C%2F%5C%2F%2F) (love the new search, shame its only got a 100-file limit atm)

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - [extension:code-snippets](https://github.com/search?q=extension%3Acode-snippets) - 21K+
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source: [file](https://github.com/johnsoncodehk/volar/blob/3f207a8372da6900dffad3d022e7005ed5174c6b/extensions/vscode-vue-language-features/templates/vue.code-snippets), with the code uncommented
    - Sample license: [MIT](https://github.com/johnsoncodehk/volar/blob/master/LICENSE)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
