### PR TITLE
Add Vyper smart contract langauge

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6586,6 +6586,14 @@ Vue:
   tm_scope: text.html.vue
   ace_mode: html
   language_id: 391
+Vyper:
+  type: programming
+  extensions:
+  - ".vy"
+  color: "#2980b9"
+  ace_mode: text
+  tm_scope: source.vyper
+  language_id: 1055641948
 Wavefront Material:
   type: data
   extensions:

--- a/samples/Vyper/ERC20.vy
+++ b/samples/Vyper/ERC20.vy
@@ -1,0 +1,154 @@
+# @dev Implementation of ERC-20 token standard.
+# @author Takayuki Jimba (@yudetamago)
+# https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})
+Approval: event({_owner: indexed(address), _spender: indexed(address), _value: uint256})
+
+name: public(string[64])
+symbol: public(string[32])
+decimals: public(uint256)
+
+# NOTE: By declaring `balanceOf` as public, vyper automatically generates a 'balanceOf()' getter
+#       method to allow access to account balances.
+#       The _KeyType will become a required parameter for the getter and it will return _ValueType.
+#       See: https://vyper.readthedocs.io/en/v0.1.0-beta.8/types.html?highlight=getter#mappings
+balanceOf: public(map(address, uint256))
+allowances: map(address, map(address, uint256))
+total_supply: uint256
+minter: address
+
+
+@public
+def __init__(_name: string[64], _symbol: string[32], _decimals: uint256, _supply: uint256):
+    init_supply: uint256 = _supply * 10 ** _decimals
+    self.name = _name
+    self.symbol = _symbol
+    self.decimals = _decimals
+    self.balanceOf[msg.sender] = init_supply
+    self.total_supply = init_supply
+    self.minter = msg.sender
+    log.Transfer(ZERO_ADDRESS, msg.sender, init_supply)
+
+
+@public
+@constant
+def totalSupply() -> uint256:
+    """
+    @dev Total number of tokens in existence.
+    """
+    return self.total_supply
+
+
+@public
+@constant
+def allowance(_owner : address, _spender : address) -> uint256:
+    """
+    @dev Function to check the amount of tokens that an owner allowed to a spender.
+    @param _owner The address which owns the funds.
+    @param _spender The address which will spend the funds.
+    @return An uint256 specifying the amount of tokens still available for the spender.
+    """
+    return self.allowances[_owner][_spender]
+
+
+@public
+def transfer(_to : address, _value : uint256) -> bool:
+    """
+    @dev Transfer token for a specified address
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    # NOTE: vyper does not allow unterflows
+    #       so the following subtraction would revert on insufficient balance
+    self.balanceOf[msg.sender] -= _value
+    self.balanceOf[_to] += _value
+    log.Transfer(msg.sender, _to, _value)
+    return True
+
+
+@public
+def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    """
+     @dev Transfer tokens from one address to another.
+          Note that while this function emits a Transfer event, this is not required as per the specification,
+          and other compliant implementations may not emit the event.
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    # NOTE: vyper does not allow unterflows
+    #       so the following subtraction would revert on insufficient balance
+    self.balanceOf[_from] -= _value
+    self.balanceOf[_to] += _value
+    # NOTE: vyper does not allow underflows
+    #      so the following subtraction would revert on insufficient allowance
+    self.allowances[_from][msg.sender] -= _value
+    log.Transfer(_from, _to, _value)
+    return True
+
+
+@public
+def approve(_spender : address, _value : uint256) -> bool:
+    """
+    @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+         Beware that changing an allowance with this method brings the risk that someone may use both the old
+         and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
+         race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
+         https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will spend the funds.
+    @param _value The amount of tokens to be spent.
+    """
+    self.allowances[msg.sender][_spender] = _value
+    log.Approval(msg.sender, _spender, _value)
+    return True
+
+
+@public
+def mint(_to: address, _value: uint256):
+    """
+    @dev Mint an amount of the token and assigns it to an account. 
+         This encapsulates the modification of balances such that the
+         proper events are emitted.
+    @param _to The account that will receive the created tokens.
+    @param _value The amount that will be created.
+    """
+    assert msg.sender == self.minter
+    assert _to != ZERO_ADDRESS
+    self.total_supply += _value
+    self.balanceOf[_to] += _value
+    log.Transfer(ZERO_ADDRESS, _to, _value)
+
+
+@private
+def _burn(_to: address, _value: uint256):
+    """
+    @dev Internal function that burns an amount of the token of a given
+         account.
+    @param _to The account whose tokens will be burned.
+    @param _value The amount that will be burned.
+    """
+    assert _to != ZERO_ADDRESS
+    self.total_supply -= _value
+    self.balanceOf[_to] -= _value
+    log.Transfer(_to, ZERO_ADDRESS, _value)
+
+
+@public
+def burn(_value: uint256):
+    """
+    @dev Burn an amount of the token of msg.sender.
+    @param _value The amount that will be burned.
+    """
+    self._burn(msg.sender, _value)
+
+
+@public
+def burnFrom(_to: address, _value: uint256):
+    """
+    @dev Burn an amount of the token from a given account.
+    @param _to The account whose tokens will be burned.
+    @param _value The amount that will be burned.
+    """
+    self.allowances[_to][msg.sender] -= _value
+    self._burn(_to, _value)

--- a/samples/Vyper/ERC721.vy
+++ b/samples/Vyper/ERC721.vy
@@ -1,0 +1,362 @@
+# @dev Implementation of ERC-721 non-fungible token standard.
+# @author Ryuya Nakamura (@nrryuya)
+# Modified from: https://github.com/vyperlang/vyper/blob/de74722bf2d8718cca46902be165f9fe0e3641dd/examples/tokens/ERC721.vy
+
+from vyper.interfaces import ERC721
+
+implements: ERC721
+
+# Interface for the contract called by safeTransferFrom()
+interface ERC721Receiver:
+    def onERC721Received(
+            _operator: address,
+            _from: address,
+            _tokenId: uint256,
+            _data: Bytes[1024]
+        ) -> bytes32: view
+
+
+# @dev Emits when ownership of any NFT changes by any mechanism. This event emits when NFTs are
+#      created (`from` == 0) and destroyed (`to` == 0). Exception: during contract creation, any
+#      number of NFTs may be created and assigned without emitting Transfer. At the time of any
+#      transfer, the approved address for that NFT (if any) is reset to none.
+# @param _from Sender of NFT (if address is zero address it indicates token creation).
+# @param _to Receiver of NFT (if address is zero address it indicates token destruction).
+# @param _tokenId The NFT that got transfered.
+event Transfer:
+    sender: indexed(address)
+    receiver: indexed(address)
+    tokenId: indexed(uint256)
+
+# @dev This emits when the approved address for an NFT is changed or reaffirmed. The zero
+#      address indicates there is no approved address. When a Transfer event emits, this also
+#      indicates that the approved address for that NFT (if any) is reset to none.
+# @param _owner Owner of NFT.
+# @param _approved Address that we are approving.
+# @param _tokenId NFT which we are approving.
+event Approval:
+    owner: indexed(address)
+    approved: indexed(address)
+    tokenId: indexed(uint256)
+
+# @dev This emits when an operator is enabled or disabled for an owner. The operator can manage
+#      all NFTs of the owner.
+# @param _owner Owner of NFT.
+# @param _operator Address to which we are setting operator rights.
+# @param _approved Status of operator rights(true if operator rights are given and false if
+# revoked).
+event ApprovalForAll:
+    owner: indexed(address)
+    operator: indexed(address)
+    approved: bool
+
+
+# @dev Mapping from NFT ID to the address that owns it.
+idToOwner: HashMap[uint256, address]
+
+# @dev Mapping from NFT ID to approved address.
+idToApprovals: HashMap[uint256, address]
+
+# @dev Mapping from owner address to count of his tokens.
+ownerToNFTokenCount: HashMap[address, uint256]
+
+# @dev Mapping from owner address to mapping of operator addresses.
+ownerToOperators: HashMap[address, HashMap[address, bool]]
+
+# @dev Address of minter, who can mint a token
+minter: address
+
+# @dev Mapping of interface id to bool about whether or not it's supported
+supportedInterfaces: HashMap[bytes32, bool]
+
+# @dev ERC165 interface ID of ERC165
+ERC165_INTERFACE_ID: constant(bytes32) = 0x0000000000000000000000000000000000000000000000000000000001ffc9a7
+
+# @dev ERC165 interface ID of ERC721
+ERC721_INTERFACE_ID: constant(bytes32) = 0x0000000000000000000000000000000000000000000000000000000080ac58cd
+
+
+@external
+def __init__():
+    """
+    @dev Contract constructor.
+    """
+    self.supportedInterfaces[ERC165_INTERFACE_ID] = True
+    self.supportedInterfaces[ERC721_INTERFACE_ID] = True
+    self.minter = msg.sender
+
+
+@view
+@external
+def supportsInterface(_interfaceID: bytes32) -> bool:
+    """
+    @dev Interface identification is specified in ERC-165.
+    @param _interfaceID Id of the interface
+    """
+    return self.supportedInterfaces[_interfaceID]
+
+
+### VIEW FUNCTIONS ###
+
+@view
+@external
+def balanceOf(_owner: address) -> uint256:
+    """
+    @dev Returns the number of NFTs owned by `_owner`.
+         Throws if `_owner` is the zero address. NFTs assigned to the zero address are considered invalid.
+    @param _owner Address for whom to query the balance.
+    """
+    assert _owner != ZERO_ADDRESS
+    return self.ownerToNFTokenCount[_owner]
+
+
+@view
+@external
+def ownerOf(_tokenId: uint256) -> address:
+    """
+    @dev Returns the address of the owner of the NFT.
+         Throws if `_tokenId` is not a valid NFT.
+    @param _tokenId The identifier for an NFT.
+    """
+    owner: address = self.idToOwner[_tokenId]
+    # Throws if `_tokenId` is not a valid NFT
+    assert owner != ZERO_ADDRESS
+    return owner
+
+
+@view
+@external
+def getApproved(_tokenId: uint256) -> address:
+    """
+    @dev Get the approved address for a single NFT.
+         Throws if `_tokenId` is not a valid NFT.
+    @param _tokenId ID of the NFT to query the approval of.
+    """
+    # Throws if `_tokenId` is not a valid NFT
+    assert self.idToOwner[_tokenId] != ZERO_ADDRESS
+    return self.idToApprovals[_tokenId]
+
+
+@view
+@external
+def isApprovedForAll(_owner: address, _operator: address) -> bool:
+    """
+    @dev Checks if `_operator` is an approved operator for `_owner`.
+    @param _owner The address that owns the NFTs.
+    @param _operator The address that acts on behalf of the owner.
+    """
+    return (self.ownerToOperators[_owner])[_operator]
+
+
+### TRANSFER FUNCTION HELPERS ###
+
+@view
+@internal
+def _isApprovedOrOwner(_spender: address, _tokenId: uint256) -> bool:
+    """
+    @dev Returns whether the given spender can transfer a given token ID
+    @param spender address of the spender to query
+    @param tokenId uint256 ID of the token to be transferred
+    @return bool whether the msg.sender is approved for the given token ID,
+        is an operator of the owner, or is the owner of the token
+    """
+    owner: address = self.idToOwner[_tokenId]
+    spenderIsOwner: bool = owner == _spender
+    spenderIsApproved: bool = _spender == self.idToApprovals[_tokenId]
+    spenderIsApprovedForAll: bool = (self.ownerToOperators[owner])[_spender]
+    return (spenderIsOwner or spenderIsApproved) or spenderIsApprovedForAll
+
+
+@internal
+def _addTokenTo(_to: address, _tokenId: uint256):
+    """
+    @dev Add a NFT to a given address
+         Throws if `_tokenId` is owned by someone.
+    """
+    # Throws if `_tokenId` is owned by someone
+    assert self.idToOwner[_tokenId] == ZERO_ADDRESS
+    # Change the owner
+    self.idToOwner[_tokenId] = _to
+    # Change count tracking
+    self.ownerToNFTokenCount[_to] += 1
+
+
+@internal
+def _removeTokenFrom(_from: address, _tokenId: uint256):
+    """
+    @dev Remove a NFT from a given address
+         Throws if `_from` is not the current owner.
+    """
+    # Throws if `_from` is not the current owner
+    assert self.idToOwner[_tokenId] == _from
+    # Change the owner
+    self.idToOwner[_tokenId] = ZERO_ADDRESS
+    # Change count tracking
+    self.ownerToNFTokenCount[_from] -= 1
+
+
+@internal
+def _clearApproval(_owner: address, _tokenId: uint256):
+    """
+    @dev Clear an approval of a given address
+         Throws if `_owner` is not the current owner.
+    """
+    # Throws if `_owner` is not the current owner
+    assert self.idToOwner[_tokenId] == _owner
+    if self.idToApprovals[_tokenId] != ZERO_ADDRESS:
+        # Reset approvals
+        self.idToApprovals[_tokenId] = ZERO_ADDRESS
+
+
+@internal
+def _transferFrom(_from: address, _to: address, _tokenId: uint256, _sender: address):
+    """
+    @dev Exeute transfer of a NFT.
+         Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
+         address for this NFT. (NOTE: `msg.sender` not allowed in private function so pass `_sender`.)
+         Throws if `_to` is the zero address.
+         Throws if `_from` is not the current owner.
+         Throws if `_tokenId` is not a valid NFT.
+    """
+    # Check requirements
+    assert self._isApprovedOrOwner(_sender, _tokenId)
+    # Throws if `_to` is the zero address
+    assert _to != ZERO_ADDRESS
+    # Clear approval. Throws if `_from` is not the current owner
+    self._clearApproval(_from, _tokenId)
+    # Remove NFT. Throws if `_tokenId` is not a valid NFT
+    self._removeTokenFrom(_from, _tokenId)
+    # Add NFT
+    self._addTokenTo(_to, _tokenId)
+    # Log the transfer
+    log Transfer(_from, _to, _tokenId)
+
+
+### TRANSFER FUNCTIONS ###
+
+@external
+def transferFrom(_from: address, _to: address, _tokenId: uint256):
+    """
+    @dev Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
+         address for this NFT.
+         Throws if `_from` is not the current owner.
+         Throws if `_to` is the zero address.
+         Throws if `_tokenId` is not a valid NFT.
+    @notice The caller is responsible to confirm that `_to` is capable of receiving NFTs or else
+            they maybe be permanently lost.
+    @param _from The current owner of the NFT.
+    @param _to The new owner.
+    @param _tokenId The NFT to transfer.
+    """
+    self._transferFrom(_from, _to, _tokenId, msg.sender)
+
+
+@external
+def safeTransferFrom(
+        _from: address,
+        _to: address,
+        _tokenId: uint256,
+        _data: Bytes[1024]=b""
+    ):
+    """
+    @dev Transfers the ownership of an NFT from one address to another address.
+         Throws unless `msg.sender` is the current owner, an authorized operator, or the
+         approved address for this NFT.
+         Throws if `_from` is not the current owner.
+         Throws if `_to` is the zero address.
+         Throws if `_tokenId` is not a valid NFT.
+         If `_to` is a smart contract, it calls `onERC721Received` on `_to` and throws if
+         the return value is not `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
+         NOTE: bytes4 is represented by bytes32 with padding
+    @param _from The current owner of the NFT.
+    @param _to The new owner.
+    @param _tokenId The NFT to transfer.
+    @param _data Additional data with no specified format, sent in call to `_to`.
+    """
+    self._transferFrom(_from, _to, _tokenId, msg.sender)
+    if _to.is_contract: # check if `_to` is a contract address
+        returnValue: bytes32 = ERC721Receiver(_to).onERC721Received(msg.sender, _from, _tokenId, _data)
+        # Throws if transfer destination is a contract which does not implement 'onERC721Received'
+        assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes32)
+
+
+@external
+def approve(_approved: address, _tokenId: uint256):
+    """
+    @dev Set or reaffirm the approved address for an NFT. The zero address indicates there is no approved address.
+         Throws unless `msg.sender` is the current NFT owner, or an authorized operator of the current owner.
+         Throws if `_tokenId` is not a valid NFT. (NOTE: This is not written the EIP)
+         Throws if `_approved` is the current owner. (NOTE: This is not written the EIP)
+    @param _approved Address to be approved for the given NFT ID.
+    @param _tokenId ID of the token to be approved.
+    """
+    owner: address = self.idToOwner[_tokenId]
+    # Throws if `_tokenId` is not a valid NFT
+    assert owner != ZERO_ADDRESS
+    # Throws if `_approved` is the current owner
+    assert _approved != owner
+    # Check requirements
+    senderIsOwner: bool = self.idToOwner[_tokenId] == msg.sender
+    senderIsApprovedForAll: bool = (self.ownerToOperators[owner])[msg.sender]
+    assert (senderIsOwner or senderIsApprovedForAll)
+    # Set the approval
+    self.idToApprovals[_tokenId] = _approved
+    log Approval(owner, _approved, _tokenId)
+
+
+@external
+def setApprovalForAll(_operator: address, _approved: bool):
+    """
+    @dev Enables or disables approval for a third party ("operator") to manage all of
+         `msg.sender`'s assets. It also emits the ApprovalForAll event.
+         Throws if `_operator` is the `msg.sender`. (NOTE: This is not written the EIP)
+    @notice This works even if sender doesn't own any tokens at the time.
+    @param _operator Address to add to the set of authorized operators.
+    @param _approved True if the operators is approved, false to revoke approval.
+    """
+    # Throws if `_operator` is the `msg.sender`
+    assert _operator != msg.sender
+    self.ownerToOperators[msg.sender][_operator] = _approved
+    log ApprovalForAll(msg.sender, _operator, _approved)
+
+
+### MINT & BURN FUNCTIONS ###
+
+@external
+def mint(_to: address, _tokenId: uint256) -> bool:
+    """
+    @dev Function to mint tokens
+         Throws if `msg.sender` is not the minter.
+         Throws if `_to` is zero address.
+         Throws if `_tokenId` is owned by someone.
+    @param _to The address that will receive the minted tokens.
+    @param _tokenId The token id to mint.
+    @return A boolean that indicates if the operation was successful.
+    """
+    # Throws if `msg.sender` is not the minter
+    assert msg.sender == self.minter
+    # Throws if `_to` is zero address
+    assert _to != ZERO_ADDRESS
+    # Add NFT. Throws if `_tokenId` is owned by someone
+    self._addTokenTo(_to, _tokenId)
+    log Transfer(ZERO_ADDRESS, _to, _tokenId)
+    return True
+
+
+@external
+def burn(_tokenId: uint256):
+    """
+    @dev Burns a specific ERC721 token.
+         Throws unless `msg.sender` is the current owner, an authorized operator, or the approved
+         address for this NFT.
+         Throws if `_tokenId` is not a valid NFT.
+    @param _tokenId uint256 id of the ERC721 token to be burned.
+    """
+    # Check requirements
+    assert self._isApprovedOrOwner(msg.sender, _tokenId)
+    owner: address = self.idToOwner[_tokenId]
+    # Throws if `_tokenId` is not a valid NFT
+    assert owner != ZERO_ADDRESS
+    self._clearApproval(owner, _tokenId)
+    self._removeTokenFrom(owner, _tokenId)
+    log Transfer(owner, ZERO_ADDRESS, _tokenId)

--- a/samples/Vyper/ballot.vy
+++ b/samples/Vyper/ballot.vy
@@ -1,0 +1,178 @@
+# Voting with delegation.
+
+# Information about voters
+struct Voter:
+    # weight is accumulated by delegation
+    weight: int128
+    # if true, that person already voted (which includes voting by delegating)
+    voted: bool
+    # person delegated to
+    delegate: address
+    # index of the voted proposal, which is not meaningful unless `voted` is True.
+    vote: int128
+
+# Users can create proposals
+struct Proposal:
+    # short name (up to 32 bytes)
+    name: bytes32
+    # number of accumulated votes
+    voteCount: int128
+
+voters: public(HashMap[address, Voter])
+proposals: public(HashMap[int128, Proposal])
+voterCount: public(int128)
+chairperson: public(address)
+int128Proposals: public(int128)
+
+
+@view
+@internal
+def _delegated(addr: address) -> bool:
+    return self.voters[addr].delegate != ZERO_ADDRESS
+
+
+@view
+@external
+def delegated(addr: address) -> bool:
+    return self._delegated(addr)
+
+
+@view
+@internal
+def _directlyVoted(addr: address) -> bool:
+    return self.voters[addr].voted and (self.voters[addr].delegate == ZERO_ADDRESS)
+
+
+@view
+@external
+def directlyVoted(addr: address) -> bool:
+    return self._directlyVoted(addr)
+
+
+# Setup global variables
+@external
+def __init__(_proposalNames: bytes32[2]):
+    self.chairperson = msg.sender
+    self.voterCount = 0
+    for i in range(2):
+        self.proposals[i] = Proposal({
+            name: _proposalNames[i],
+            voteCount: 0
+        })
+        self.int128Proposals += 1
+
+# Give a `voter` the right to vote on this ballot.
+# This may only be called by the `chairperson`.
+@external
+def giveRightToVote(voter: address):
+    # Throws if the sender is not the chairperson.
+    assert msg.sender == self.chairperson
+    # Throws if the voter has already voted.
+    assert not self.voters[voter].voted
+    # Throws if the voter's voting weight isn't 0.
+    assert self.voters[voter].weight == 0
+    self.voters[voter].weight = 1
+    self.voterCount += 1
+
+# Used by `delegate` below, callable externally via `forwardWeight`
+@internal
+def _forwardWeight(delegate_with_weight_to_forward: address):
+    assert self._delegated(delegate_with_weight_to_forward)
+    # Throw if there is nothing to do:
+    assert self.voters[delegate_with_weight_to_forward].weight > 0
+
+    target: address = self.voters[delegate_with_weight_to_forward].delegate
+    for i in range(4):
+        if self._delegated(target):
+            target = self.voters[target].delegate
+            # The following effectively detects cycles of length <= 5,
+            # in which the delegation is given back to the delegator.
+            # This could be done for any int128ber of loops,
+            # or even infinitely with a while loop.
+            # However, cycles aren't actually problematic for correctness;
+            # they just result in spoiled votes.
+            # So, in the production version, this should instead be
+            # the responsibility of the contract's client, and this
+            # check should be removed.
+            assert target != delegate_with_weight_to_forward
+        else:
+            # Weight will be moved to someone who directly voted or
+            # hasn't voted.
+            break
+
+    weight_to_forward: int128 = self.voters[delegate_with_weight_to_forward].weight
+    self.voters[delegate_with_weight_to_forward].weight = 0
+    self.voters[target].weight += weight_to_forward
+
+    if self._directlyVoted(target):
+        self.proposals[self.voters[target].vote].voteCount += weight_to_forward
+        self.voters[target].weight = 0
+
+    # To reiterate: if target is also a delegate, this function will need
+    # to be called again, similarly to as above.
+
+# Public function to call _forwardWeight
+@external
+def forwardWeight(delegate_with_weight_to_forward: address):
+    self._forwardWeight(delegate_with_weight_to_forward)
+
+# Delegate your vote to the voter `to`.
+@external
+def delegate(to: address):
+    # Throws if the sender has already voted
+    assert not self.voters[msg.sender].voted
+    # Throws if the sender tries to delegate their vote to themselves or to
+    # the default address value of 0x0000000000000000000000000000000000000000
+    # (the latter might not be problematic, but I don't want to think about it).
+    assert to != msg.sender
+    assert to != ZERO_ADDRESS
+
+    self.voters[msg.sender].voted = True
+    self.voters[msg.sender].delegate = to
+
+    # This call will throw if and only if this delegation would cause a loop
+        # of length <= 5 that ends up delegating back to the delegator.
+    self._forwardWeight(msg.sender)
+
+# Give your vote (including votes delegated to you)
+# to proposal `proposals[proposal].name`.
+@external
+def vote(proposal: int128):
+    # can't vote twice
+    assert not self.voters[msg.sender].voted
+    # can only vote on legitimate proposals
+    assert proposal < self.int128Proposals
+
+    self.voters[msg.sender].vote = proposal
+    self.voters[msg.sender].voted = True
+
+    # transfer msg.sender's weight to proposal
+    self.proposals[proposal].voteCount += self.voters[msg.sender].weight
+    self.voters[msg.sender].weight = 0
+
+# Computes the winning proposal taking all
+# previous votes into account.
+@view
+@internal
+def _winningProposal() -> int128:
+    winning_vote_count: int128 = 0
+    winning_proposal: int128 = 0
+    for i in range(2):
+        if self.proposals[i].voteCount > winning_vote_count:
+            winning_vote_count = self.proposals[i].voteCount
+            winning_proposal = i
+    return winning_proposal
+
+@view
+@external
+def winningProposal() -> int128:
+    return self._winningProposal()
+
+
+# Calls winningProposal() function to get the index
+# of the winner contained in the proposals array and then
+# returns the name of the winner
+@view
+@external
+def winnerName() -> bytes32:
+    return self.proposals[self._winningProposal()].name

--- a/samples/Vyper/crowdfund.vy
+++ b/samples/Vyper/crowdfund.vy
@@ -1,0 +1,61 @@
+# Setup private variables (only callable from within the contract)
+
+struct Funder :
+  sender: address
+  value: wei_value
+
+funders: map(int128, Funder)
+nextFunderIndex: int128
+beneficiary: address
+deadline: public(timestamp)
+goal: public(wei_value)
+refundIndex: int128
+timelimit: public(timedelta)
+
+
+# Setup global variables
+@public
+def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
+    self.beneficiary = _beneficiary
+    self.deadline = block.timestamp + _timelimit
+    self.timelimit = _timelimit
+    self.goal = _goal
+
+
+# Participate in this crowdfunding campaign
+@public
+@payable
+def participate():
+    assert block.timestamp < self.deadline, "deadline not met (yet)"
+
+    nfi: int128 = self.nextFunderIndex
+
+    self.funders[nfi] = Funder({sender: msg.sender, value: msg.value})
+    self.nextFunderIndex = nfi + 1
+
+
+# Enough money was raised! Send funds to the beneficiary
+@public
+def finalize():
+    assert block.timestamp >= self.deadline, "deadline not met (yet)"
+    assert self.balance >= self.goal, "invalid balance"
+
+    selfdestruct(self.beneficiary)
+
+# Not enough money was raised! Refund everyone (max 30 people at a time
+# to avoid gas limit issues)
+@public
+def refund():
+    assert block.timestamp >= self.deadline and self.balance < self.goal
+
+    ind: int128 = self.refundIndex
+
+    for i in range(ind, ind + 30):
+        if i >= self.nextFunderIndex:
+            self.refundIndex = self.nextFunderIndex
+            return
+
+        send(self.funders[i].sender, self.funders[i].value)
+        clear(self.funders[i])
+
+    self.refundIndex = ind + 30

--- a/samples/Vyper/name_registry.vy
+++ b/samples/Vyper/name_registry.vy
@@ -1,0 +1,13 @@
+
+registry: HashMap[Bytes[100], address]
+
+@external
+def register(name: Bytes[100], owner: address):
+    assert self.registry[name] == ZERO_ADDRESS  # check name has not been set yet.
+    self.registry[name] = owner
+
+
+@view
+@external
+def lookup(name: Bytes[100]) -> address:
+    return self.registry[name]

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -509,6 +509,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Visual Basic .NET:** [peters-ben-0007/VBDotNetSyntax](https://github.com/peters-ben-0007/VBDotNetSyntax)
 - **Volt:** [textmate/d.tmbundle](https://github.com/textmate/d.tmbundle)
 - **Vue:** [vuejs/vue-syntax-highlight](https://github.com/vuejs/vue-syntax-highlight)
+- **Vyper:** [davidhq/SublimeEthereum](https://github.com/davidhq/SublimeEthereum)
 - **Wavefront Material:** [Alhadis/language-wavefront](https://github.com/Alhadis/language-wavefront)
 - **Wavefront Object:** [Alhadis/language-wavefront](https://github.com/Alhadis/language-wavefront)
 - **Web Ontology Language:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

I noticed that [there was a discussion](https://github.com/github/linguist/pull/5749) about adding [Vyper language](https://vyper.readthedocs.io).

[SublimeEthereum](https://github.com/davidhq/SublimeEthereum) repo is currently used for Solidity and Vyper grammars [in SublimeText](https://packagecontrol.io/packages/Ethereum) and the same repo (branch _liguist_) is used by linguist for `source.solidity`.

Because I saw that pull request which included quite incorrect grammar for Vyper (basically just Python), I commented and pointed to more correct grammar which can be used. Today I also revisited that grammar and brought it up to speed so it's now complete and in sync with current version of Vyper:

<img width="592" alt="Screenshot 2022-02-10 at 04 16 10" src="https://user-images.githubusercontent.com/3899/153330577-f28287f0-3cce-46fb-a2cc-6d35ee19d3d6.png">

Language is still rather small (I believe) so you please evaluate criteria for its inclusion as you see fit. Vyper is one of the languages that helps move billions through the emerging stateful Internet of value, even if amount of files or repos on GitHub might be low. Vyper is used a) for prototyping b) as a complementary language to Solidity for subset of smart contracts (see one example of mixing `.sol` and `.vy` inside [this repo](https://github.com/ribbon-finance/governance/tree/main/contracts)). 

Here is a time chart of proxied general interest for Solidity:

<img width="589" alt="Screenshot 2022-02-09 at 23 32 24" src="https://user-images.githubusercontent.com/3899/153303534-3c44eb11-9247-4cfd-a4ec-5a968b2c15bf.png">

as said `.vy` files often appear alongside many more `.sol` files in repos... so I guess one way to look at Vyper is through the similar exponential graph... interest is rising and many thousands (soon millions) of people see `.vy` files on GitHub and probably wonder why they are missing the syntax highlighting... and so I do think it would be beneficial if linguist did apply highlighting to Vyper source code whenever possible / convenient.

regards

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding a new language.**
  - [X] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?q=extension%3Avy&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):    
      - [URL to each sample source, if applicable]
      - https://github.com/vyperlang/vyper/tree/master/examples  →  included in samples/Vyper in linguist repo
    - Sample license(s):
    - https://github.com/vyperlang/vyper/blob/master/LICENSE
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [X] I have included a syntax highlighting grammar: https://github.com/davidhq/SublimeEthereum/blob/linguist/Vyper.YAML-tmLanguage
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

