### PR TITLE
Fix incorrect capitalisation of 'Unity3D Asset' heuristic

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -335,7 +335,7 @@ disambiguations:
   - language: 'M4'
 - extensions: ['.mask']
   rules:
-  - language: Unity3d Asset
+  - language: Unity3D Asset
     pattern: 'tag:unity3d.com'
 - extensions: ['.md']
   rules:


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
```diff
-- language: Unity3d Asset
+- language: Unity3D Asset
```

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Fixes a capitalization typo in the heuristics file.
Same problem to #5434 and caused the same issue
I ran a script to check all of the other language names in the file and all other ones should be good - the only values it found didn't have a corresponding entry were `Unity3d Asset`, and `[ 'Linux Kernel Module', 'AMPL' ]` which both have corresponding entries.

## Checklist:

- [ ] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
         &uarr; probably should be done