### PR TITLE
Fix note in docs about which types are included

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -34,7 +34,7 @@ File and folder paths inside `.gitattributes` are calculated relative to the pos
 
 ### Detectable
 
-By default only languages of type `programming` or `markup` in [`languages.yml`] are included in the language statistics, with `data` and `prose` languages excluded.
+By default only languages of type `programming` or `markup` in [`languages.yml`] are included in the language statistics.
 Languages of a different type in [`languages.yml`] are not "detectable" by default, causing them not to be included in the language statistics,
 but can be made detectable as shown below.  Languages that are not yet mentioned in [`languages.yml`] will not be included in the language
 statistics, even if you specify something like `*.mycola linguist-language=MyCoolLang linguist-detectable` in the `.gitattributes` file.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -34,7 +34,7 @@ File and folder paths inside `.gitattributes` are calculated relative to the pos
 
 ### Detectable
 
-By default only languages of `type: programming` in [`languages.yml`] are included in the language statistics.
+By default only languages of type `programming` or `markup` in [`languages.yml`] are included in the language statistics, with `data` and `prose` languages excluded.
 Languages of a different type in [`languages.yml`] are not "detectable" by default, causing them not to be included in the language statistics,
 but can be made detectable as shown below.  Languages that are not yet mentioned in [`languages.yml`] will not be included in the language
 statistics, even if you specify something like `*.mycola linguist-language=MyCoolLang linguist-detectable` in the `.gitattributes` file.


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
The docs misstated which languages are included in lang stats.
Fixes the line and mentions the other types too.

## Checklist
n.a.