### PR TITLE
Changed DenizenScript grammar to point to official org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -385,7 +385,7 @@
 	url = https://github.com/mulesoft-labs/data-weave-tmLanguage
 [submodule "vendor/grammars/denizenscript-grammar"]
 	path = vendor/grammars/denizenscript-grammar
-	url = https://github.com/BreadcrumbIsTaken/denizenscript-grammar.git
+	url = https://github.com/DenizenScript/denizenscript-grammar.git
 [submodule "vendor/grammars/desktop.tmbundle"]
 	path = vendor/grammars/desktop.tmbundle
 	url = https://github.com/Mailaender/desktop.tmbundle.git

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -121,7 +121,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Dart:** [dart-lang/dart-syntax-highlight](https://github.com/dart-lang/dart-syntax-highlight)
 - **DataWeave:** [mulesoft-labs/data-weave-tmLanguage](https://github.com/mulesoft-labs/data-weave-tmLanguage)
 - **Debian Package Control File:** [tsbarnes/language-debian](https://github.com/tsbarnes/language-debian)
-- **DenizenScript:** [BreadcrumbIsTaken/denizenscript-grammar](https://github.com/BreadcrumbIsTaken/denizenscript-grammar)
+- **DenizenScript:** [DenizenScript/denizenscript-grammar](https://github.com/DenizenScript/denizenscript-grammar)
 - **Dhall:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
 - **Diff:** [textmate/diff.tmbundle](https://github.com/textmate/diff.tmbundle)
 - **Dockerfile:** [asbjornenge/Docker.tmbundle](https://github.com/asbjornenge/Docker.tmbundle)


### PR DESCRIPTION
Hello, it's me again! I changed the grammar file for DenizenScript (which was merged just a few days ago in #5773) to point to the official DenizenScript organization where the grammar was relocated.
<!--- Briefly describe your changes in the field above. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am changing the source of a syntax highlighting grammar**
  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
  - Old: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FBreadcrumbIsTaken%2Fdenizenscript-grammar%2Fblob%2Fmain%2Fgrammars%2Fdenizenscript.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2FBreadcrumbIsTaken%2FBreadVibesMC%2Fblob%2Fmain%2FFactions%2520-%252025567%2Fplugins%2FDenizen%2Fscripts%2FFactions%2520Core.dsc&code=
  - New: https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2FDenizenScript%2Fdenizenscript-grammar%2Fblob%2Fmain%2Fgrammars%2Fdenizenscript.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2FBreadcrumbIsTaken%2FBreadVibesMC%2Fblob%2Fmain%2FFactions%2520-%252025567%2Fplugins%2FDenizen%2Fscripts%2FFactions%2520Core.dsc&code=

The grammar file stayed the same, it was just relocated. 