### PR TITLE
Exclude compiled extension from gem

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
     "github_repo" => "ssh://github.com/github/linguist"
   }
 
-  s.files = Dir['lib/**/*', 'ext/**/*', 'grammars/*', 'LICENSE'].reject {|f| f.match(%r{lib/linguist/linguist\.(so|bundle)}) }
+  s.files = Dir['{lib,ext}/**/*', 'grammars/*', 'LICENSE'] - Dir['lib/linguist/linguist.{so,bundle}']
   s.platform = Gem::Platform::RUBY
   s.executables = ['github-linguist', 'git-linguist']
   s.extensions = ['ext/linguist/extconf.rb']

--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
     "github_repo" => "ssh://github.com/github/linguist"
   }
 
-  s.files = Dir['lib/**/*'] + Dir['ext/**/*'] + Dir['grammars/*'] + ['LICENSE']
+  s.files = Dir['lib/**/*', 'ext/**/*', 'grammars/*', 'LICENSE'].reject {|f| f.match(%r{lib/linguist/linguist\.(so|bundle)}) }
+  s.platform = Gem::Platform::RUBY
   s.executables = ['github-linguist', 'git-linguist']
   s.extensions = ['ext/linguist/extconf.rb']
   s.require_paths = ['lib', 'ext']


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

For a long time now we've been accidentally including the compiled C extension used by Linguist for token parsing when creating the gem.

This has gone unnoticed until https://github.com/github/linguist/issues/5808 because I used to build the gem on macOS and the resulting gem included the macOS library and not the Linux library. The Linux library would then have been built at the time of installation, hence no problem.

I've recently switched to using Codespaces and so now the Linux library is being built against the version of Ruby on the Codespace env at the time and then included in the gem, which at the time of building the 7.19.0 gem was running Ruby 2.7.2. This wouldn't be a problem in envs with  Ruby 2.7 installed, but is if the env only has Ruby 3 installed.

This PR fixes that by explicitly excluding the macOS `linguist.bundle` and Linux `linguist.so` files when building the gem.

Once merged, I'll start a new release to get a working gem out.

Fixes https://github.com/github/linguist/issues/5808

_[ Checklist removed as it doesn't apply ]_