### PR TITLE
Add support for Unity extensions

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2971,6 +2971,8 @@ JavaScript:
   - ".ssjs"
   - ".xsjs"
   - ".xsjslib"
+  - ".jslib"
+  - ".jspre"
   filenames:
   - Jakefile
   interpreters:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2961,7 +2961,9 @@ JavaScript:
   - ".jsb"
   - ".jscad"
   - ".jsfl"
+  - ".jslib"
   - ".jsm"
+  - ".jspre"
   - ".jss"
   - ".jsx"
   - ".mjs"
@@ -2971,8 +2973,6 @@ JavaScript:
   - ".ssjs"
   - ".xsjs"
   - ".xsjslib"
-  - ".jslib"
-  - ".jspre"
   filenames:
   - Jakefile
   interpreters:


### PR DESCRIPTION
Unity uses the extensions .jslib and .jspre to attach (pure) javascript code to WebGL applications

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=extension%3Ajslib+NOT+nothack&type=Code
      - https://github.com/search?q=extension%3Ajspre+NOT+nothack&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://docs.unity3d.com/Manual/webgl-interactingwithbrowserscripting.html
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
