### PR TITLE
Register `.url` as a generic INI extension

### DIFF
--- a/lib/linguist/generic.yml
+++ b/lib/linguist/generic.yml
@@ -16,3 +16,4 @@ extensions:
 - ".9"
 - ".cmp"
 - ".sol"
+- ".url"

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -632,6 +632,10 @@ disambiguations:
     # HACK: This is a contrived use of heuristics needed to address
     # an unusual edge-case. See https://git.io/JULye for discussion.
   - language: Text
+- extensions: ['.url']
+  rules:
+  - language: INI
+    pattern: '^\[InternetShortcut\]\R(?>[^\s\[][^\n]*\R)*URL='
 - extensions: ['.v']
   rules:
   - language: Coq

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2630,6 +2630,7 @@ INI:
   - ".prefs"
   - ".pro"
   - ".properties"
+  - ".url"
   filenames:
   - ".flake8"
   - buildozer.spec

--- a/test/fixtures/Generic/url/INI/extended.url
+++ b/test/fixtures/Generic/url/INI/extended.url
@@ -1,0 +1,10 @@
+[DEFAULT]
+BASEURL=http://www.someaddress.com
+[DOC#4#5]
+BASEURL=http://www.someaddress.com/frame1.html
+ORIGURL=frame1.html
+[DOC#4#6]
+BASEURL=http://www.someaddress.com/frame2.html
+ORIGURL=frame2.html
+[InternetShortcut]
+URL=http://www.someaddress.com/

--- a/test/fixtures/Generic/url/INI/frameset.url
+++ b/test/fixtures/Generic/url/INI/frameset.url
@@ -1,0 +1,16 @@
+[DEFAULT]
+BASEURL=http://www.someaddress.com
+[DOC#4#5]
+BASEURL=http://www.someaddress.com/frame1.html
+ORIGURL=frame1.html
+[DOC#4#5#4#6]
+BASEURL=http://www.someaddress.com/frame1a.html
+ORIGURL=frame1a.html
+[DOC#4#5#4#7]
+BASEURL=http://www.someaddress.com/frame1b.html
+ORIGURL=frame1b.html
+[DOC#4#6]
+BASEURL=http://www.someaddress.com/frame2.html
+ORIGURL=frame2.html
+[InternetShortcut]
+URL=http://www.someaddress.com/

--- a/test/fixtures/Generic/url/INI/minimal.http.url
+++ b/test/fixtures/Generic/url/INI/minimal.http.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=https://fileinfo.com/extension/url

--- a/test/fixtures/Generic/url/INI/minimal.mailto.url
+++ b/test/fixtures/Generic/url/INI/minimal.mailto.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=mailto:feedback@fileinfo.com

--- a/test/fixtures/Generic/url/INI/other-fields.url
+++ b/test/fixtures/Generic/url/INI/other-fields.url
@@ -1,0 +1,8 @@
+[InternetShortcut]
+URL=http://www.lyberty.com/encyc/articles/tech/dot_url_format_-_an_unofficial_guide.html
+WorkingDirectory=C:\WINDOWS\
+ShowCommand=7
+IconIndex=1
+IconFile=C:\WINDOWS\SYSTEM\url.dll
+Modified=20F06BA06D07BD014D
+HotKey=1601

--- a/test/fixtures/Generic/url/INI/绿盟.url
+++ b/test/fixtures/Generic/url/INI/绿盟.url
@@ -1,0 +1,10 @@
+[DEFAULT]
+BASEURL=http://xdowns.com
+[InternetShortcut]
+URL=http://www.xdowns.com/
+Modified=00BE40B83DF5C801B1
+IconFile=C:\WINDOWS\System32\shell32.dll
+IconIndex=130
+[InternetShortcut.A]
+[InternetShortcut.W]
+IconFile=C:+AFw-Documents and Settings+AFw-Administrator+AFxoTJdiAFw-logo.ico

--- a/test/fixtures/Generic/url/nil/broken-assignment.url
+++ b/test/fixtures/Generic/url/nil/broken-assignment.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL = http://localhost/

--- a/test/fixtures/Generic/url/nil/broken-header.url
+++ b/test/fixtures/Generic/url/nil/broken-header.url
@@ -1,0 +1,2 @@
+[ Internet Shortcut ]
+URL=Shouldn't happen (embedded whitespace)

--- a/test/fixtures/Generic/url/nil/broken-section.url
+++ b/test/fixtures/Generic/url/nil/broken-section.url
@@ -1,0 +1,3 @@
+[InternetShortcut]
+
+URL=http://foo.bar/

--- a/test/fixtures/Generic/url/nil/literal.url
+++ b/test/fixtures/Generic/url/nil/literal.url
@@ -1,0 +1,1 @@
+https://youtu.be/g18u5elxY5Q

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -873,6 +873,13 @@ class TestHeuristics < Minitest::Test
     })
   end
 
+  def test_url_by_heuristics
+    assert_heuristics({
+      "INI" => Dir.glob("#{fixtures_path}/Generic/url/INI/*"),
+      nil => Dir.glob("#{fixtures_path}/Generic/url/nil/*")
+    })
+  end
+
   def test_v_by_heuristics
     assert_heuristics({
       "Coq" => all_fixtures("Coq", "*.v"),


### PR DESCRIPTION
This PR adds support for Internet Shortcuts (`.url` files), an undocumented format used by Windows to save URL shortcuts on the desktop.

**Resolves:** [`#5836`](https://github.com/github/linguist/issues/5836)

## Description
I've added this as a generic extension, as there appear to be too many unrelated files on GitHub whose names end with `.url`. The requisite heuristic looks for lines of the form

~~~ini
[InternetShortcut]
URL=…
~~~

(This appears[^1^] to be the bare minimum required of a URL file on Windows. I say _"appears"_ because there doesn't[^2^] seem to be any authoritative reference documenting the Microsoft's `.url` format).

## Checklist:
- [x] **I am associating a language with a new file extension.**
	- [x] **The new extension is used in hundreds of repositories on GitHub.com**
		- **With `InternetShortcut`:** [~220,222 results](https://github.com/search?q=extension%3Aurl+InternetShortcut+NOT+nothack&type=Code)
		- **Without `InternetShortcut`:** [~382,208 results](https://github.com/search?q=extension%3Aurl+NOT+InternetShortcut&type=Code)
	- [x] **I have included a real-world usage sample:**
		- `test/fixtures/Generic/url/INI/绿盟.url`: [Source](https://github.com/666999z/3/blob/f32552a4d5d84350552c68801aed281ca1f48e66/ScriptShare/0my/Some-PoC-oR-ExP-master/%E9%AA%8C%E8%AF%81Joomla%E6%98%AF%E5%90%A6%E5%AD%98%E5%9C%A8%E5%8F%8D%E5%BA%8F%E5%88%97%E5%8C%96%E6%BC%8F%E6%B4%9E%E7%9A%84%E8%84%9A%E6%9C%AC/%E6%89%B9%E9%87%8F/hackUtils-master/pinginfoview/%E7%BB%BF%E7%9B%9F.url) | [GPL v3.0](https://github.com/666999z/3/blob/f32552a4d5d84350552c68801aed281ca1f48e66/LICENSE)
	- [x] **I have included a change to the heuristics**

[^1^]: https://fileinfo.com/extension/url Under _"More Information"_
[^2^]: http://www.lyberty.com/encyc/articles/tech/dot_url_format_-_an_unofficial_guide.html
