### PR TITLE
Remove references to Lightshow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,8 +27,7 @@
     - Sample source(s):
       - [URL to each sample source, if applicable]
     - Sample license(s):
-  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
-  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
+  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
   - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
 
 - [ ] **I am fixing a misclassified language**
@@ -39,9 +38,8 @@
   - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
 
 - [ ] **I am changing the source of a syntax highlighting grammar**
-  <!-- Update the Lightshow URLs below to show the new and old grammars in action. -->
-  - Old: https://github-lightshow.herokuapp.com/
-  - New: https://github-lightshow.herokuapp.com/
+  - Old: [URL to grammar repo]
+  - New: [URL to grammar repo]
 
 - [ ] **I am updating a grammar submodule**
   <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ You can also try to fix the bug yourself and submit a pull-request.
 [TextMate's documentation](https://manual.macromates.com/en/language_grammars) offers a good introduction on how to work with TextMate-compatible grammars.
 Note that Linguist uses [PCRE](https://www.pcre.org/) regular expressions, while TextMate uses [Oniguruma](https://github.com/kkos/oniguruma).
 Although they are mostly compatible there might be some differences in syntax and semantics between the two.
-You can test grammars using [Lightshow](https://github-lightshow.herokuapp.com).
+Linguist's grammar compiler will highlight any problems when the grammar is updated.
 
 Once the bug has been fixed upstream, we'll pick it up for GitHub in the next release of Linguist.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,6 @@ This is the procedure for making a new release of Linguist. The entire process n
 17. Update and deploy the following repositories to use the new gem in production:
     - `github/github` - label for backporting to the latest version of GitHub Enterprise Server only.
     - `github/treelights` - this only needs the Linguist version updated to pull the compiled grammars from the Linguist release. Label for backporting to the latest version of GitHub Enterprise Server only.
-    - `github/lightshow`
 
     Note: syntax highlighting changes won't take effect until the updated `github/treelights` repo has been deployed.
 


### PR DESCRIPTION
As detailed in https://github.com/github/linguist/issues/5844, GitHub is sunsetting Lightshow on 1 May 2022.

This PR removes all references to Lightshow from the documentation and PR templates.