### PR TITLE
Replace all `git.io` links with their actual URLs

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -630,7 +630,7 @@ disambiguations:
   - language: Vim Help File
     pattern: '(?:(?:^|[ \t])(?:vi|Vi(?=m))(?:m[<=>]?[0-9]+|m)?|[ \t]ex)(?=:(?=[ \t]*set?[ \t][^\r\n:]+:)|:(?![ \t]*set?[ \t]))(?:(?:[ \t]*:[ \t]*|[ \t])\w*(?:[ \t]*=(?:[^\\\s]|\\.)*)?)*[ \t:](?:filetype|ft|syntax)[ \t]*=(help)(?=$|\s|:)'
     # HACK: This is a contrived use of heuristics needed to address
-    # an unusual edge-case. See https://git.io/JULye for discussion.
+    # an unusual edge-case. See https://github.com/github/linguist/pull/4734#discussion_r479653547 for discussion.
   - language: Text
 - extensions: ['.url']
   rules:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -10,9 +10,9 @@
 #                         a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
 #                         Use "text" if a mode does not exist.
 # codemirror_mode       - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
-#                         This must match a mode from https://git.io/vi9Fx
+#                         This must match a mode from https://github.com/codemirror/CodeMirror/tree/master/mode
 # codemirror_mime_type  - A String name of the file mime type used for highlighting whenever a file is edited.
-#                         This should match the `mime` associated with the mode from https://git.io/f4SoQ
+#                         This should match the `mime` associated with the mode from https://github.com/codemirror/CodeMirror/blob/master/mode/meta.js
 # wrap                  - Boolean wrap to enable line wrapping (default: false)
 # extensions            - An Array of associated extensions (the first one is
 #                         considered the primary extension, the others should be

--- a/script/add-grammar
+++ b/script/add-grammar
@@ -75,7 +75,7 @@ done
 for cmd in docker git sed ruby bundle; do
 	command -v "$cmd" >/dev/null 2>&1 || {
 		warn "Required command '$cmd' not found"
-		warn 'See CONTRIBUTING.md for help on getting started: https://git.io/J0eqy'
+		warn 'See CONTRIBUTING.md for help on getting started: https://github.com/github/linguist/blob/HEAD/CONTRIBUTING.md#dependencies'
 		exit 1
 	}
 done


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace all git.io links with their actual URLs.