### PR TITLE
Revert removal of `git.io` links

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -630,7 +630,7 @@ disambiguations:
   - language: Vim Help File
     pattern: '(?:(?:^|[ \t])(?:vi|Vi(?=m))(?:m[<=>]?[0-9]+|m)?|[ \t]ex)(?=:(?=[ \t]*set?[ \t][^\r\n:]+:)|:(?![ \t]*set?[ \t]))(?:(?:[ \t]*:[ \t]*|[ \t])\w*(?:[ \t]*=(?:[^\\\s]|\\.)*)?)*[ \t:](?:filetype|ft|syntax)[ \t]*=(help)(?=$|\s|:)'
     # HACK: This is a contrived use of heuristics needed to address
-    # an unusual edge-case. See https://github.com/github/linguist/pull/4734#discussion_r479653547 for discussion.
+    # an unusual edge-case. See https://git.io/JULye for discussion.
   - language: Text
 - extensions: ['.url']
   rules:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -10,9 +10,9 @@
 #                         a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
 #                         Use "text" if a mode does not exist.
 # codemirror_mode       - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
-#                         This must match a mode from https://github.com/codemirror/CodeMirror/tree/master/mode
+#                         This must match a mode from https://git.io/vi9Fx
 # codemirror_mime_type  - A String name of the file mime type used for highlighting whenever a file is edited.
-#                         This should match the `mime` associated with the mode from https://github.com/codemirror/CodeMirror/blob/master/mode/meta.js
+#                         This should match the `mime` associated with the mode from https://git.io/f4SoQ
 # wrap                  - Boolean wrap to enable line wrapping (default: false)
 # extensions            - An Array of associated extensions (the first one is
 #                         considered the primary extension, the others should be

--- a/script/add-grammar
+++ b/script/add-grammar
@@ -75,7 +75,7 @@ done
 for cmd in docker git sed ruby bundle; do
 	command -v "$cmd" >/dev/null 2>&1 || {
 		warn "Required command '$cmd' not found"
-		warn 'See CONTRIBUTING.md for help on getting started: https://github.com/github/linguist/blob/HEAD/CONTRIBUTING.md#dependencies'
+		warn 'See CONTRIBUTING.md for help on getting started: https://git.io/J0eqy'
 		exit 1
 	}
 done


### PR DESCRIPTION
There's been an update to GitHub's blog post about `git.io` deprecation:

> **2022-04-27 Update:**
While the git.io URL redirection service is [read-only](https://github.blog/2011-11-10-git-io-github-url-shortener/) and use of the service is limited, we have received feedback from developers and academic researchers who have published git.io links in print documentation and research papers. In order to preserve the integrity of these historical documents, we have decided to archive the current git.io links in a new read-only service that will allow us to serve redirects for those links longer term.

This PR restores three shortlinks that were removed in #5880 following the initial announcement.