### PR TITLE
Mark .github as vendored

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -383,3 +383,6 @@
 
 # Gitpod
 - (^|/)\.gitpod\.Dockerfile$
+
+# GitHub.com
+- (^|/)\.github/

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -573,6 +573,10 @@ class TestFileBlob < Minitest::Test
     # Bootstrap
     assert !sample_blob("src/bootstraps/settings.js").vendored?
     assert sample_blob("src/bootstrap-custom.js").vendored?
+
+    # GitHub.com
+    assert sample_blob(".github/CODEOWNERS").vendored?
+    assert sample_blob(".github/workflows/test.yml").vendored?
   end
 
   def test_documentation


### PR DESCRIPTION
## Description

Things in `.github/` are used to configure behaviour on GitHub.com, such
as issue templates, or GitHub Actions. They should not be taken into
consideration when trying to figure out the language(s) of a repository.

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
