### PR TITLE
Add INI filenames coveragerc & pylintrc

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2661,8 +2661,11 @@ INI:
   - ".properties"
   - ".url"
   filenames:
+  - ".coveragerc"
   - ".flake8"
+  - ".pylintrc"
   - buildozer.spec
+  - pylintrc
   tm_scope: source.ini
   aliases:
   - dosini

--- a/samples/INI/filenames/.coveragerc
+++ b/samples/INI/filenames/.coveragerc
@@ -1,0 +1,30 @@
+[run]
+branch = True
+dynamic_context = test_function
+
+source =
+    warehouse
+
+omit =
+    # We don't want to get coverage information for our migrations.
+    warehouse/migrations/*
+
+    # We don't want to actually cover our __main__.py file because it is hard
+    # to cover and it really just acts as a tiny shim to a function.
+    warehouse/__main__.py
+
+    # Again, tiny shim code that we don't actually need to test and trying to
+    # do so would just get in the way.
+    warehouse/wsgi.py
+
+    # And again, tiny shim code.
+    warehouse/celery.py
+
+
+[report]
+exclude_lines =
+    pragma: no cover
+    class \w+\(Interface\):
+
+# Don't show us anything that's already 100% covered.
+skip_covered = True

--- a/samples/INI/filenames/.pylintrc
+++ b/samples/INI/filenames/.pylintrc
@@ -1,0 +1,21 @@
+[BASIC]
+
+# Allow tests and private functions without docstrings
+no-docstring-rgx=(test_.*|_.*)
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# String used as indentation unit. We differ from PEP8's normal 4 spaces.
+indent-string='  '
+
+# Allow long lines which are just a string
+ignore-long-lines = ^\s*\"[^\"]+\",?$
+
+
+[MESSAGES CONTROL]
+
+# The order must be different internally vs externally
+disable=wrong-import-order

--- a/samples/INI/filenames/pylintrc
+++ b/samples/INI/filenames/pylintrc
@@ -1,0 +1,79 @@
+# The format of this file isn't really documented; just use --generate-rcfile
+
+[Messages Control]
+# C0111: Don't require docstrings on every method
+# C0301: Handled by pep8
+# C0325: Parens are required on print in py3x
+# F0401: Imports are check by other linters
+# W0511: TODOs in code comments are fine.
+# W0142: *args and **kwargs are fine.
+# W0622: Redefining id is fine.
+
+# TODO(browne): fix these in the future
+# C0103: invalid-name
+# C0201: consider-iterating-dictionary
+# C1801: len-as-condition
+# E1101: no-member
+# E1111: assignment-from-no-return
+# R0902: too-many-instance-attributes
+# R0912: too-many-branches
+# R0913: too-many-arguments
+# R0914: too-many-locals
+# R0915: too-many-statements
+# R1702: too-many-nested-blocks
+# R1705: no-else-return
+# R1710: inconsistent-return-statements
+# W0110: deprecated-lambda
+# W0141: bad-builtin
+# W0201: attribute-defined-outside-init
+# W0212: protected-access
+# W0401: wildcard-import
+# W0603: global-statement
+# W0613: unused-argument
+# W0621: redefined-outer-name
+# W0703: broad-except
+# W1201: logging-not-lazy
+# W1505: deprecated-method
+disable=C0111,C0201,C0301,C0325,C1801,F0401,W0511,W0142,W0622,C0103,E1101,E1111,R0902,R0912,R0913,R0914,R0915,R1702,R1705,R1710,W0110,W0141,W0201,W0401,W0603,W0212,W0613,W0621,W0703,W1201,W1505
+
+[Basic]
+# Variable names can be 1 to 31 characters long, with lowercase and underscores
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Argument names can be 2 to 31 characters long, with lowercase and underscores
+argument-rgx=[a-z_][a-z0-9_]{1,30}$
+
+# Method names should be at least 3 characters long
+# and be lowecased with underscores
+method-rgx=([a-z_][a-z0-9_]{2,50}|setUp|tearDown)$
+
+# Module names matching manila-* are ok (files in bin/)
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+)|(manila-[a-z0-9_-]+))$
+
+# Don't require docstrings on tests.
+no-docstring-rgx=((__.*__)|([tT]est.*)|setUp|tearDown)$
+
+[Design]
+max-public-methods=100
+min-public-methods=0
+max-args=6
+
+[Variables]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+# _ is used by our localization
+additional-builtins=_
+
+[Similarities]
+# Minimum lines number of a similarity.
+min-similarity-lines=10
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Add INI filenames `.coveragerc`, `.pylintrc` and `pylintrc`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?q=filename%3A.coveragerc&type=Code
      - https://github.com/search?q=filename%3A.pylintrc&type=Code
      - https://github.com/search?q=filename%3Apylintrc&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample sources:
      - <https://github.com/pypa/warehouse/blob/c57752eec2234f70fa3ac67ebb972487b379e465/.coveragerc>
      - ~~<https://github.com/kubeflow/examples/blob/cc93a80420755f4eb09dc505b79c2d1ec77de46d/.pylintrc>~~ https://github.com/google/semantic-locators/blob/a67c4b8a49d7274040c18201e7f70f4f7b4894f3/webdriver_python/.pylintrc
      - <https://github.com/PyCQA/bandit/blob/c4372a095f2ccdb6665bc8f3d555957473aeb8b1/pylintrc>
    - Sample licenses:
      - Apache-2.0 license
      - ~~Apache-2.0 license~~ Apache-2.0 license
      - Apache-2.0 license
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

## Additional information

- `.coveragerc`
  - <https://coverage.readthedocs.io/en/stable/config.html#syntax>
- `.pylintrc` and `pylintrc`
  - <https://pylint.pycqa.org/en/latest/user_guide/run.html#command-line-options>
  - <https://github.com/PyCQA/pylint/blob/020aea5797eb9f858b44dc6157f4b018234df50a/pylint/config/config_file_parser.py#L112>
