### PR TITLE
Perform full depth checkout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         ruby: [ '3.0', '2.7', '2.6', '2.5' ]
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
I completely missed that the dependabot update meant the default checkout depth changed. This puts back the old behaviour we rely upon.