### PR TITLE
Revert "Add github-actions to the dependabot config"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule: 
-     interval: daily
-  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ jobs:
       matrix:
         ruby: [ '3.0', '2.7', '2.6', '2.5' ]
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -40,7 +38,7 @@ jobs:
     name: Test Dockerfile
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - name: Build container
       run: docker build -t linguist .
     - name: Analyse current directory
@@ -51,7 +49,7 @@ jobs:
     name: Classifier cross-validation
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Reverts github/linguist#5894 and https://github.com/github/linguist/pull/5911 and my initial attempt to fix this in https://github.com/github/linguist/pull/5912

On second thoughts, I don't think this is a good idea. This will lead me to blindly accept Dependabot updates which will break things like it has for our tests on `master`.

I don't have any more time now to dig into how we can fix this using `actions/checkout@v3` so I'm reverting this change and putting us back the way we were.

We can address this if and when we're forced to update.