### PR TITLE
Add Mule language

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -674,6 +674,10 @@ disambiguations:
     pattern: '^%(end|ctor|hook|group)\b'
   - language: Linker Script
     pattern: 'OUTPUT_ARCH\(|OUTPUT_FORMAT\(|SECTIONS'
+- extensions: ['.xml']
+  rules:
+  - language: Mule
+    pattern:  '<mule([^>]|\s)*xmlns="http:\/\/www\.mulesoft\.org\/schema\/mule\/core"'
 - extensions: ['.yaml']
   rules:
   - language: MiniYAML

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3986,6 +3986,16 @@ Motorola 68K Assembly:
   tm_scope: source.m68k
   ace_mode: assembly_x86
   language_id: 477582706
+Mule:
+  type: programming
+  color: "#00a1df"
+  tm_scope: text.xml
+  ace_mode: xml
+  codemirror_mode: xml
+  codemirror_mime_type: application/xml
+  extensions:
+  - ".xml"
+  language_id: 213085803
 Muse:
   type: prose
   extensions:

--- a/samples/Mule/dataweave.xml
+++ b/samples/Mule/dataweave.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+	xmlns="http://www.mulesoft.org/schema/mule/core"
+	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+	<http:listener-config name="DW_HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="4d265575-e82b-489e-af85-32c28ae51697" >
+		<http:listener-connection host="0.0.0.0" port="8082" />
+	</http:listener-config>
+	<flow name="dataweaveFlow" doc:id="fb9f311f-c951-4459-a094-387c076b2399" >
+		<http:listener doc:name="Listener" doc:id="5dc3e696-2c93-41f0-8952-a9003cee5361" config-ref="DW_HTTP_Listener_config" path="/"/>
+		<ee:transform doc:name="Transform Message" doc:id="b9d228d0-7e8d-46f0-97e4-a9043842fb90" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+classrooms: payload..*teacher groupBy $.subject mapObject ((teacherGroup, subject) -> {
+   class: {
+     name: subject,
+     teachers: { (teacherGroup map {
+       teacher:{
+           name: $.name,
+           lastName: $.lastName
+       }
+     })
+   }
+  }
+})]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+	</flow>
+</mule>

--- a/samples/Mule/empty.xml
+++ b/samples/Mule/empty.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd"></mule>

--- a/samples/Mule/global.xml
+++ b/samples/Mule/global.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:wsc="http://www.mulesoft.org/schema/mule/wsc"
+	xmlns:american-flights-api="http://www.mulesoft.org/schema/mule/american-flights-api"
+	xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/american-flights-api http://www.mulesoft.org/schema/mule/american-flights-api/current/mule-american-flights-api.xsd
+http://www.mulesoft.org/schema/mule/wsc http://www.mulesoft.org/schema/mule/wsc/current/mule-wsc.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+	<configuration-properties doc:name="Configuration properties" doc:id="8c9cdd94-6f21-4b4f-ab97-e29aad0baed2" file="config.yaml" />
+	<http:listener-config name="HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="a5df1eb0-4251-42de-9e1c-016a7e25c25a" >
+		<http:listener-connection host="0.0.0.0" port="${http.port}" />
+	</http:listener-config>
+	<american-flights-api:config name="American_Flights_API_Config" doc:name="American Flights API Config" doc:id="782b14ef-3f15-437d-a12b-f02b3b91eaf1" property_host="${american.host}" property_port="${american.port}" property_protocol="${american.protocol}" property_basePath="${american.basepath}"/>
+	<http:request-config name="HTTP_Request_config_training" doc:name="HTTP Request configuration" doc:id="9d95e3b0-dd8a-4077-b04b-b59cf15fd2ce" basePath="${training.basepath}" >
+		<http:request-connection host="${training.host}" port="${training.port}" />
+	</http:request-config>
+	<wsc:config name="Delta_Web_Service_Consumer_Config" doc:name="Web Service Consumer Config" doc:id="704b5225-f6b8-4f2b-9bb5-af6b6f96a364" >
+		<wsc:connection wsdlLocation="${delta.wsdl}" service="${delta.service}" port="${delta.port}" >
+			<reconnection >
+				<reconnect />
+			</reconnection>
+			<wsc:web-service-security actor="http://schemas.xmlsoap.org/soap/actor/next" />
+		</wsc:connection>
+	</wsc:config>
+	<configuration doc:name="Configuration" doc:id="e2b21b57-950c-4220-8885-86bc60cb12b4" defaultErrorHandler-ref="globalError_Handler" />
+	<error-handler name="globalError_Handler" doc:id="d052484b-2cee-45c8-b4ce-741f24971b2f" >
+			<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="4cf10751-6c0e-424a-b267-9dd6cc3302f6" type="APP:INVALID_DESTINATION">
+				<ee:transform doc:name="error.description" doc:id="24c132ab-664d-4142-9f78-4c926d4f5cdc" >
+					<ee:message >
+						<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+	"message": error.description
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+				<set-variable value="400" doc:name="httpStatus" doc:id="3b3e6176-df64-47a2-b839-cd06c32e1642" variableName="httpStatus"/>
+			</on-error-continue>
+		<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="97f3a0b0-e63e-4c67-827a-45a441dc6187" type="WSC:CONNECTIVITY, WSC:INVALID_WSDL">
+			<ee:transform doc:name="Data unavailable" doc:id="1f17158e-15f1-41c1-9502-76bbd30097af" >
+				<ee:message >
+					<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+{
+	"message": "Data unavailable. Try later. " ++ error.description as String
+}]]></ee:set-payload>
+				</ee:message>
+			</ee:transform>
+			<set-variable value="500" doc:name="httpStatus" doc:id="9101e996-fef2-4abd-afe5-1e4f80d0aa1d" variableName="httpStatus"/>
+		</on-error-continue>
+		<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="427ed494-100a-4ba0-a0e3-b168fe942f50" type="ANY">
+			<ee:transform doc:name="error.description" doc:id="20ac6986-d8a4-4f9d-b179-8c25d8c16de5">
+				<ee:message>
+					<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+	"message": error.description
+}]]></ee:set-payload>
+				</ee:message>
+			</ee:transform>
+			<set-variable value="500" doc:name="httpStatus" doc:id="e723383c-7a41-4900-83a5-26a1084d0a7a" variableName="httpStatus" />
+		</on-error-continue>
+	</error-handler>
+</mule>

--- a/samples/Mule/http-listener.xml
+++ b/samples/Mule/http-listener.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+	xmlns="http://www.mulesoft.org/schema/mule/core"
+	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+	<http:listener-config name="Basic_HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="4ecd07b9-dce8-494a-8f60-6a65dc2f05a1" >
+		<http:listener-connection host="0.0.0.0" port="8081" />
+	</http:listener-config>
+	<flow name="http-listenerFlow" doc:id="dbf78a12-7993-4a85-9c2f-c09357d3df33" >
+		<http:listener doc:name="Listener" doc:id="26f56fd5-fbdb-46af-a7e4-a5e20d1f6f70" config-ref="Basic_HTTP_Listener_config" path="/linguist"/>
+		<ee:transform doc:name="Transform Message" doc:id="47a03d1c-0ddc-4529-bed3-34b8f8db57fa" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output text/plain
+---
+"Hello " ++ (attributes.queryParams.name default "World") ++ "!!!"]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+	</flow>
+</mule>

--- a/samples/Mule/implementation.xml
+++ b/samples/Mule/implementation.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:validation="http://www.mulesoft.org/schema/mule/validation" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+	xmlns:wsc="http://www.mulesoft.org/schema/mule/wsc"
+	xmlns:american-flights-api="http://www.mulesoft.org/schema/mule/american-flights-api" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/american-flights-api http://www.mulesoft.org/schema/mule/american-flights-api/current/mule-american-flights-api.xsd
+http://www.mulesoft.org/schema/mule/wsc http://www.mulesoft.org/schema/mule/wsc/current/mule-wsc.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/validation http://www.mulesoft.org/schema/mule/validation/current/mule-validation.xsd">
+	<flow name="getFlights" doc:id="b1858593-4f0c-4e06-8a81-bf5818e9c852" >
+		<set-variable value="#[message.attributes.queryParams.airline]" doc:name="airline" doc:id="72758660-9d8e-4a5d-97dc-8daf8972525d" variableName="airline"/>
+		<flow-ref doc:name="setCode" doc:id="e433e034-996e-4e2d-8ac1-2fc63d529b5d" name="setCode"/>
+		<validation:is-true doc:name="Is valid destination" doc:id="e2216771-1795-457e-90a5-b5905ff6fbeb" expression="#[['SFO','LAX','CLE','PDX','PDF'] contains vars.code]" message="#['Invalid destination' ++ ' ' ++ (vars.code default ' ')]">
+			<error-mapping sourceType="VALIDATION:INVALID_BOOLEAN" targetType="APP:INVALID_DESTINATION" />
+		</validation:is-true>
+		<choice doc:name="Choice" doc:id="587664b4-2b66-428c-8b19-2e3bb955692e" >
+			<when expression='#[vars.airline == "american"]'>
+				<flow-ref doc:name="getAmericanFlights" doc:id="ef2e05ed-205f-4bc9-aad4-73687e4bbc15" name="getAmericanFlights" />
+			</when>
+			<when expression='#[vars.airline == "united"]'>
+				<flow-ref doc:name="getUnitedFlights" doc:id="7e7f573f-e39d-44cc-9cec-5ed684d6ee18" name="getUnitedFlights" />
+			</when>
+			<when expression='#[vars.airline == "delta"]'>
+				<flow-ref doc:name="getDeltaFlights" doc:id="55a821b1-4747-44c1-a257-b1a427ef1439" name="getDeltaFlights" />
+			</when>
+			<otherwise >
+				<flow-ref doc:name="getAllAirlineFlights" doc:id="5c62b7a7-bb4a-4890-8f8c-a9ee822c5de6" name="getAllAirlineFlights"/>
+			</otherwise>
+		</choice>
+		<ee:transform doc:name="[Flight] to JSON" doc:id="1c4e5f4c-458c-41fd-b7da-64340b2375ea" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/json
+---
+payload]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="ac96cc58-6bb6-4a99-ae16-09c2ffc61de8" />
+	</flow>
+	<flow name="getAllAirlineFlights" doc:id="445847ad-0e07-4019-88f6-806a6fd6dd91" >
+		<scatter-gather doc:name="Scatter-Gather" doc:id="2e7480a5-edbe-4d6f-8bd9-451ea368b18a">
+			<route>
+				<try doc:name="Try" doc:id="68d773dd-da48-4285-a8d3-fe65b142cdaa" >
+					<flow-ref doc:name="getAmericanFlights" doc:id="16313b86-63a0-47b7-b040-8d96bae8143b" name="getAmericanFlights" />
+					<error-handler >
+						<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="95f4d0e0-b98d-4d0c-b258-adaddfe2fee8" type="ANY">
+							<ee:transform doc:name="[]" doc:id="b3cfe1bb-faf1-489e-ad52-2ff66f02ad4c" >
+								<ee:message >
+									<ee:set-payload ><![CDATA[%dw 2.0
+output application/java
+---
+[]]]></ee:set-payload>
+								</ee:message>
+							</ee:transform>
+						</on-error-continue>
+					</error-handler>
+				</try>
+			</route>
+			<route>
+				<try doc:name="Try" doc:id="929ce273-b021-48a6-bada-04b60a1fd757" >
+					<flow-ref doc:name="getUnitedFlights" doc:id="c13f0b3f-4c5a-443b-b2d5-d0e8d704bc69" name="getUnitedFlights" />
+					<error-handler >
+						<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="429be0fc-4782-43b0-8bd9-812bdb9aa55c" type="ANY">
+							<ee:transform doc:name="[]" doc:id="910e3fb6-7715-4eb9-8217-baaa5a732a6a" >
+								<ee:message >
+									<ee:set-payload ><![CDATA[%dw 2.0
+output application/java
+---
+[]]]></ee:set-payload>
+								</ee:message>
+							</ee:transform>
+						</on-error-continue>
+					</error-handler>
+				</try>
+			</route>
+			<route>
+				<try doc:name="Try" doc:id="7b011a2c-e44d-488b-b945-1ee0cf7127ce" >
+					<flow-ref doc:name="getDeltaFlights" doc:id="37b6cae1-1e05-4214-89bc-0dca69948460" name="getDeltaFlights" />
+					<error-handler >
+						<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="63c9dc56-5e19-482f-817c-26ff2428ede9" type="ANY">
+							<ee:transform doc:name="[]" doc:id="58c4e315-968b-447d-a208-b8ccf3cf8266" >
+								<ee:message >
+									<ee:set-payload ><![CDATA[%dw 2.0
+output application/java
+---
+[]]]></ee:set-payload>
+								</ee:message>
+							</ee:transform>
+						</on-error-continue>
+					</error-handler>
+				</try>
+			</route>
+		</scatter-gather>
+		<ee:transform doc:name="flatten to [Flight]" doc:id="cdd79549-173b-4f1f-aac5-8c333d5cd731" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/java
+---
+flatten(payload..payload)
+]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="06cfe2b1-d039-4a74-b083-4b56ae445f08" />
+	</flow>
+	<sub-flow name="setCode" doc:id="528ed54d-7b7f-482c-b76f-70bd01eff06a" >
+		<set-variable value="#[message.attributes.queryParams.code]" doc:name="code" doc:id="d2491cd5-31f3-4006-a9f4-97ec1bd5f718" variableName="code"/>
+	</sub-flow>
+	<flow name="getAmericanFlights" doc:id="71886713-c8b8-4fc0-bdbf-3caed50bb9e8" >
+		<american-flights-api:get-flights doc:name="Get flights" doc:id="44f959ae-2b0f-46eb-af0b-0d69abc2cf9a" config-ref="American_Flights_API_Config" client-id="${american.client_id}" client-secret="${american.client_secret}" destination="#[vars.code]"/>
+		<ee:transform doc:name="JSON to [Flight]" doc:id="45820e39-eaf3-474e-bc13-a91acee01362" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/java
+---
+payload map ( payload01 , indexOfPayload01 ) -> {
+	airlineName: "American",
+	availableSeats: payload01.emptySeats,
+	departureDate: payload01.departureDate,
+	destination: payload01.destination,
+	flightCode: payload01.code,
+	origination: payload01.origin,
+	planeType: payload01.plane."type",
+	price: payload01.price
+} as Object {
+	class : "com.mulesoft.training.Flight"
+}]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="cfe846da-c63b-4927-842b-8e720bfb829e" />
+		<error-handler >
+			<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="147b577d-911b-4b1d-8f35-f8713d81c013" type="AMERICAN-FLIGHTS-API:BAD_REQUEST">
+				<ee:transform doc:name="No flights" doc:id="d379c5f5-1159-492a-878d-f190ff91df38">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+	"message": "No flights to " ++ vars.code as String
+}]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+				<set-variable value="200" doc:name="httpStatus" doc:id="fd1c71c8-d937-46f7-accb-24aee1b307b6" variableName="httpStatus" />
+			</on-error-continue>
+		</error-handler>
+	</flow>
+	<flow name="getUnitedFlights" doc:id="b51d483c-072e-41e9-9ba7-31ea43eaed2b" >
+		<http:request method="GET" doc:name="Get flights" doc:id="556e9e2a-f03a-4eb8-ab64-e0fdf0718da0" config-ref="HTTP_Request_config_training" path="/united/flights/{dest}">
+			<http:uri-params><![CDATA[#[output application/java
+---
+{
+	"dest" : vars.code
+}]]]></http:uri-params>
+		</http:request>
+		<ee:transform doc:name="JSON to [Flight]" doc:id="2072728d-be2e-4a1d-8b6f-60962beef868">
+			<ee:message>
+				<ee:set-payload><![CDATA[%dw 2.0
+output application/java
+---
+payload.flights map ( flight , indexOfFlight ) -> {
+	airlineName: flight.airlineName,
+	availableSeats: flight.emptySeats,
+	departureDate: flight.departureDate,
+	destination: flight.destination,
+	flightCode: flight.code,
+	origination: flight.origin,
+	planeType: flight.planeType,
+	price: flight.price
+} as Object {
+	class : "com.mulesoft.training.Flight"
+}]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="96f93b1d-63f5-4172-8819-8a676ce5495f" />
+	</flow>
+	<flow name="getDeltaFlights" doc:id="b5c97df1-febd-4c25-ba79-884bb995862b" >
+		<ee:transform doc:name="Pass code" doc:id="d1bc636b-02fd-40ca-b818-917571c58906" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/xml
+ns ns0 http://soap.training.mulesoft.com/
+---
+{
+	ns0#findFlight: {
+		destination: vars.code
+	}
+}]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<wsc:consume operation="findFlight" doc:name="Get flights" doc:id="c8b3a055-75c9-4146-8452-a135e39fd263" config-ref="Delta_Web_Service_Consumer_Config"/>
+		<ee:transform doc:name="SOAP to [Flight]" doc:id="e9ccdff9-6a62-4ed5-aea7-488c8433293f" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/java
+ns ns0 http://soap.training.mulesoft.com/
+---
+payload.body.ns0#findFlightResponse.*return map ( return , indexOfReturn ) -> {
+	airlineName: return.airlineName,
+	availableSeats: return.emptySeats,
+	departureDate: return.departureDate,
+	destination: return.destination,
+	flightCode: return.code,
+	origination: return.origin,
+	planeType: return.planeType,
+	price: return.price
+} as Object {
+	class : "com.mulesoft.training.Flight"
+}]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="ab5b9f1c-9252-46da-8820-ca87569e2139" />
+	</flow>
+	<flow name="postFlight" doc:id="c50624e5-7d40-49f2-a576-603b53d591de" >
+		<ee:transform doc:name="Transform Message" doc:id="743b7104-5a34-4922-9f3b-cfb3c8138464" >
+			<ee:message >
+				<ee:set-payload resource="json_flight_playground.dwl" />
+			</ee:message>
+			<ee:variables >
+				<ee:set-variable variableName="DWoutput" ><![CDATA[%dw 2.0
+output application/xml
+---
+data: {
+	hub: "MUA",
+	flight @(airline: payload.airline): {
+		code: payload.toAirportCode
+	}
+}]]></ee:set-variable>
+			</ee:variables>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="937ea40b-3c4c-4c35-80b6-6ebb87158268" message="#[vars.DWoutput]"/>
+	</flow>
+	<flow name="postMultipleFlights" doc:id="98b3afbc-fdc0-4efd-bf19-6519f0e8b982" >
+		<http:listener doc:name="POST /multipleflights" doc:id="c9775985-e458-46d8-8a16-d6f012d70e93" config-ref="HTTP_Listener_config" path="/multipleflights"/>
+		<ee:transform doc:name="Transform Message" doc:id="8769285f-5a52-4459-9e36-212e2ebe3406" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/dw
+
+//var numSeats = 400
+//var numSeats = (x=400) -> x
+/*
+var numSeats = (planeType: String) ->
+	if (planeType contains('737'))
+		150
+	else
+		300
+
+*/
+
+fun getNumSeats(planeType: String) =
+	if (planeType contains('737'))
+		150
+	else
+		300
+
+type Currency = String {format: "###.00"}
+type Flight = Object {class: "com.mulesoft.training.Flight"}
+---
+using(flights = 
+	payload..*return map (object, index) -> {
+		destination: object.destination,
+		price: object.price as Number as Currency,
+		//totalSeats: getNumSeats(object.planeType as String),
+		totalSeats: lookup("getTotalSeats", {planeType: object.planeType}),
+		planeType: upper(object.planeType as String),
+		departureDate: object.departureDate as Date {format: "yyyy/MM/dd"} as String {format: "MMM dd, yyyy"}
+	} as Object
+)
+
+flights
+]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="74c0c310-38a8-4a67-bd1c-81b85ec62781" />
+	</flow>
+	<flow name="getTotalSeats" doc:id="5b30cb54-b8bd-487b-a649-069223217732" >
+		<ee:transform doc:name="Transform Message" doc:id="9383e0ec-100c-49c4-97ba-a7b4ec0229de" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output application/java
+
+fun getNumSeats(planeType: String) =
+	if (planeType contains('737'))
+		150
+	else
+		300
+---
+getNumSeats(payload.planeType)
+]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+	</flow>
+</mule>

--- a/samples/Mule/interface.xml
+++ b/samples/Mule/interface.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:apikit="http://www.mulesoft.org/schema/mule/mule-apikit" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/mule-apikit http://www.mulesoft.org/schema/mule/mule-apikit/current/mule-apikit.xsd ">
+    <apikit:config name="mua-flights-api-config" api="mua-flights-api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
+    <flow name="mua-flights-api-main">
+        <http:listener path="/api/*" config-ref="HTTP_Listener_config">
+            <http:response statusCode="#[vars.httpStatus default 200]">
+                <http:headers><![CDATA[#[vars.outboundHeaders default {}]]]></http:headers>
+            </http:response>
+            <http:error-response statusCode="#[vars.httpStatus default 500]">
+                <http:body><![CDATA[#[payload]]]></http:body>
+                <http:headers><![CDATA[#[vars.outboundHeaders default {}]]]></http:headers>
+            </http:error-response>
+        </http:listener>
+        <apikit:router config-ref="mua-flights-api-config" />
+        <error-handler>
+            <on-error-propagate type="APIKIT:BAD_REQUEST">
+                <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+                    <ee:message>
+                        <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{message: "Bad request"}]]></ee:set-payload>
+                    </ee:message>
+                    <ee:variables>
+                        <ee:set-variable variableName="httpStatus">400</ee:set-variable>
+                    </ee:variables>
+                </ee:transform>
+            </on-error-propagate>
+            <on-error-propagate type="APIKIT:NOT_FOUND">
+                <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+                    <ee:message>
+                        <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{message: "Resource not found"}]]></ee:set-payload>
+                    </ee:message>
+                    <ee:variables>
+                        <ee:set-variable variableName="httpStatus">404</ee:set-variable>
+                    </ee:variables>
+                </ee:transform>
+            </on-error-propagate>
+            <on-error-propagate type="APIKIT:METHOD_NOT_ALLOWED">
+                <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+                    <ee:message>
+                        <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{message: "Method not allowed"}]]></ee:set-payload>
+                    </ee:message>
+                    <ee:variables>
+                        <ee:set-variable variableName="httpStatus">405</ee:set-variable>
+                    </ee:variables>
+                </ee:transform>
+            </on-error-propagate>
+            <on-error-propagate type="APIKIT:NOT_ACCEPTABLE">
+                <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+                    <ee:message>
+                        <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{message: "Not acceptable"}]]></ee:set-payload>
+                    </ee:message>
+                    <ee:variables>
+                        <ee:set-variable variableName="httpStatus">406</ee:set-variable>
+                    </ee:variables>
+                </ee:transform>
+            </on-error-propagate>
+            <on-error-propagate type="APIKIT:UNSUPPORTED_MEDIA_TYPE">
+                <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+                    <ee:message>
+                        <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{message: "Unsupported media type"}]]></ee:set-payload>
+                    </ee:message>
+                    <ee:variables>
+                        <ee:set-variable variableName="httpStatus">415</ee:set-variable>
+                    </ee:variables>
+                </ee:transform>
+            </on-error-propagate>
+            <on-error-propagate type="APIKIT:NOT_IMPLEMENTED">
+                <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+                    <ee:message>
+                        <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{message: "Not Implemented"}]]></ee:set-payload>
+                    </ee:message>
+                    <ee:variables>
+                        <ee:set-variable variableName="httpStatus">501</ee:set-variable>
+                    </ee:variables>
+                </ee:transform>
+            </on-error-propagate>
+        </error-handler>
+    </flow>
+    <flow name="mua-flights-api-console">
+        <http:listener path="/console/*" config-ref="HTTP_Listener_config">
+            <http:response statusCode="#[vars.httpStatus default 200]">
+                <http:headers><![CDATA[#[vars.outboundHeaders default {}]]]></http:headers>
+            </http:response>
+            <http:error-response statusCode="#[vars.httpStatus default 500]">
+                <http:body><![CDATA[#[payload]]]></http:body>
+                <http:headers><![CDATA[#[vars.outboundHeaders default {}]]]></http:headers>
+            </http:error-response>
+        </http:listener>
+        <apikit:console config-ref="mua-flights-api-config" />
+        <error-handler>
+            <on-error-propagate type="APIKIT:NOT_FOUND">
+                <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+                    <ee:message>
+                        <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{message: "Resource not found"}]]></ee:set-payload>
+                    </ee:message>
+                    <ee:variables>
+                        <ee:set-variable variableName="httpStatus">404</ee:set-variable>
+                    </ee:variables>
+                </ee:transform>
+            </on-error-propagate>
+        </error-handler>
+    </flow>
+    <flow name="get:\flights:mua-flights-api-config">
+		<flow-ref doc:name="getFlights" doc:id="b28ae1a1-8b12-4da0-a087-959379c57a08" name="getFlights"/>
+    </flow>
+    <flow name="post:\flights:application\json:mua-flights-api-config">
+		<flow-ref doc:name="postFlight" doc:id="09933ab4-c0f1-467c-8357-95f6336fc7fd" name="postFlight"/>
+    </flow>
+</mule>

--- a/samples/Mule/odata-metadata.xml
+++ b/samples/Mule/odata-metadata.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+	xmlns:apikit-odata="http://www.mulesoft.org/schema/mule/apikit-odata"
+	xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+	xmlns:http="http://www.mulesoft.org/schema/mule/http"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd 
+						http://www.mulesoft.org/schema/mule/apikit-odata http://www.mulesoft.org/schema/mule/apikit-odata/current/mule-apikit-odata.xsd
+						http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+						http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd ">
+  <apikit-odata:config name="odata-metadata-config" apiDefinition="api/odata-metadata.csdl.xml" />
+  <http:listener-config name="HTTP_Listener_Config">
+    <http:listener-connection host="0.0.0.0" port="8081" />
+  </http:listener-config>
+  <flow name="main-odata-flow">
+    <http:listener config-ref="HTTP_Listener_Config" path="/api/*">
+      <http:response statusCode="#[attributes.statusCode default 200]">
+        <http:headers>#[attributes.headers default {}]</http:headers>
+      </http:response>
+      <http:error-response statusCode="#[vars.statusCode default 500]">
+        <http:body>#[payload]</http:body>
+        <http:headers>#[vars.headers default {}]</http:headers>
+      </http:error-response>
+    </http:listener>
+    <apikit-odata:route config-ref="odata-metadata-config">
+      <apikit-odata:http-request-parameters listenerPath="#[attributes.listenerPath]" method="#[attributes.method]" scheme="#[upper(attributes.scheme)]" host="#[attributes.headers.'host']" httpHeaders="#[attributes.headers]" queryString="#[attributes.queryString]" maskedRequestPath="#[attributes.maskedRequestPath]" />
+    </apikit-odata:route>
+    <error-handler name="Error_Handler">
+      <on-error-propagate name="On_Error_Propagate" enableNotifications="true" logException="true" type="MULE:ANY">
+        <ee:transform>
+          <ee:message>
+            <ee:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+{
+	error: {
+		code: error.errorMessage.payload.code default "UNKNOWN",
+		message: error.errorMessage.payload.message default error.description,
+		target: error.errorMessage.payload.target,
+		details: error.errorMessage.payload.details default [{code: "UNKNOWN", message: error.detailedDescription, target: null}],
+		innererror: error.errorMessage.payload.innerError default error.childErrors
+	}
+}]]></ee:set-payload>
+          </ee:message>
+          <ee:variables>
+            <ee:set-variable variableName="statusCode"><![CDATA[error.errorMessage.payload.statusCode default 500]]></ee:set-variable>
+          </ee:variables>
+        </ee:transform>
+      </on-error-propagate>
+    </error-handler>
+  </flow>
+  <flow name="GET\Customers\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Customers" method="GET" />
+    <logger level="INFO" message="In GET\Customers\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Customers" method="GET">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="POST\Customers\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Customers" method="POST" />
+    <logger level="INFO" message="In POST\Customers\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Customers" method="POST">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="PATCH\Customers\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Customers" method="PATCH" />
+    <logger level="INFO" message="In PATCH\Customers\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Customers" method="PATCH">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="PUT\Customers\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Customers" method="PUT" />
+    <logger level="INFO" message="In PUT\Customers\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Customers" method="PUT">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="DELETE\Customers\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Customers" method="DELETE" />
+    <logger level="INFO" message="In DELETE\Customers\ENTITY flow" />
+  </flow>
+  <flow name="GET\Customers\ENTITY_COLLECTION">
+    <apikit-odata:request-entity-collection-listener config-ref="odata-metadata-config" path="/Customers" method="GET" />
+    <logger level="INFO" message="In GET\Customers\ENTITY_COLLECTION flow" />
+    <apikit-odata:serialize-entity-collection config-ref="odata-metadata-config" path="/Customers" method="GET">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- { "value": payload }]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity-collection>
+  </flow>
+  <flow name="GET\Orders\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Orders" method="GET" />
+    <logger level="INFO" message="In GET\Orders\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Orders" method="GET">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="POST\Orders\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Orders" method="POST" />
+    <logger level="INFO" message="In POST\Orders\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Orders" method="POST">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="PATCH\Orders\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Orders" method="PATCH" />
+    <logger level="INFO" message="In PATCH\Orders\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Orders" method="PATCH">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="PUT\Orders\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Orders" method="PUT" />
+    <logger level="INFO" message="In PUT\Orders\ENTITY flow" />
+    <apikit-odata:serialize-entity config-ref="odata-metadata-config" path="/Orders" method="PUT">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- payload]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity>
+  </flow>
+  <flow name="DELETE\Orders\ENTITY">
+    <apikit-odata:request-entity-listener config-ref="odata-metadata-config" path="/Orders" method="DELETE" />
+    <logger level="INFO" message="In DELETE\Orders\ENTITY flow" />
+  </flow>
+  <flow name="GET\Orders\ENTITY_COLLECTION">
+    <apikit-odata:request-entity-collection-listener config-ref="odata-metadata-config" path="/Orders" method="GET" />
+    <logger level="INFO" message="In GET\Orders\ENTITY_COLLECTION flow" />
+    <apikit-odata:serialize-entity-collection config-ref="odata-metadata-config" path="/Orders" method="GET">
+      <apikit-odata:inbound-content>#[%dw 2.0 output application/json --- { "value": payload }]</apikit-odata:inbound-content>
+    </apikit-odata:serialize-entity-collection>
+  </flow>
+</mule>

--- a/samples/Mule/secure-properties.xml
+++ b/samples/Mule/secure-properties.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:secure-properties="http://www.mulesoft.org/schema/mule/secure-properties"
+	xmlns="http://www.mulesoft.org/schema/mule/core"
+	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/secure-properties http://www.mulesoft.org/schema/mule/secure-properties/current/mule-secure-properties.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+	<secure-properties:config name="Secure_Properties_Config" doc:name="Secure Properties Config" doc:id="e541376a-edee-4bec-8237-3dc22fed8a5b" file="config-${env}-secure.yaml" key="${key}" >
+		<secure-properties:encrypt algorithm="Blowfish" />
+	</secure-properties:config>
+	<global-property doc:name="Global Property" doc:id="1663502c-9a9a-4023-ab3c-5a68d497059a" name="env" value="dev" />
+	<flow name="testFlow" doc:id="d43c4534-781e-4477-b247-764ca24e69fe" >
+		<scheduler doc:name="Scheduler" doc:id="bdc015d2-5c95-493e-95e4-04f017f395e4" >
+			<scheduling-strategy >
+				<fixed-frequency frequency="5000"/>
+			</scheduling-strategy>
+		</scheduler>
+		<ee:transform doc:name="Transform Message" doc:id="8ac0a1dd-2b3e-453f-8077-4f5f21d4f74f" >
+			<ee:message >
+				<ee:set-payload ><![CDATA[%dw 2.0
+output text/plain
+---
+"Decrypted value: " ++ Mule::p('secure::encrypted.value1') ++ "\nUncrypted: " ++ p('secure::testPropertyA')
+]]></ee:set-payload>
+			</ee:message>
+		</ee:transform>
+		<logger level="INFO" doc:name="Logger" doc:id="96bf41c1-989a-410b-b014-85ddb7b37ab1" message='#[payload]'/>
+	</flow>
+</mule>

--- a/samples/Mule/simple.xml
+++ b/samples/Mule/simple.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+	<flow name="simpleFlow" doc:id="6df8858f-4417-4761-aa88-db6f2c9535f5" >
+		<scheduler doc:name="Scheduler" doc:id="77c649bb-651b-4b6d-9b89-0039d660655a" >
+			<scheduling-strategy >
+				<fixed-frequency frequency="10" timeUnit="SECONDS"/>
+			</scheduling-strategy>
+		</scheduler>
+		<logger level="INFO" doc:name="Logger" doc:id="fd808869-b503-4647-87e8-87526eecf278" message="Hello Linguist World!!!"/>
+	</flow>
+</mule>

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -318,6 +318,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **MoonScript:** [leafo/moonscript-tmbundle](https://github.com/leafo/moonscript-tmbundle)
 - **Motoko:** [dfinity/vscode-motoko](https://github.com/dfinity/vscode-motoko)
 - **Motorola 68K Assembly:** [zerkman/language-m68k](https://github.com/zerkman/language-m68k)
+- **Mule:** [textmate/xml.tmbundle](https://github.com/textmate/xml.tmbundle)
 - **Muse:** [Alhadis/language-emacs-lisp](https://github.com/Alhadis/language-emacs-lisp)
 - **Mustache:** [textmate/php-smarty.tmbundle](https://github.com/textmate/php-smarty.tmbundle)
 - **NASL:** [tenable/sublimetext-nasl](https://github.com/tenable/sublimetext-nasl)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Adds a new language: `Mule`

Mule applications are written using XML language but unfortunately they don't have a specific file extension and uses `.xml`. But they have at least 2 distinctive characteristics:
- The root node is called `<mule>`
- The default namespace for `<mule>` node is `xmlns="http://www.mulesoft.org/schema/mule/core"`

In order to distinguish this language from other XML file an heuristic was added with a pattern to match those characteristics.

As reference, this was a brief discussion about how to add it: https://github.com/github/linguist/discussions/5922

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Axml+mule+%22http%3A%2F%2Fwww.mulesoft.org%2Fschema%2Fmule%2Fcore%22
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - Not applicable, I created them specially for this contribution.
    - Sample license(s): MIT
  - [ ] I have included a syntax highlighting grammar: Not applicable, reuses the one for XML.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.