### PR TITLE
Update TypeScript color to match official branding

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6312,7 +6312,7 @@ TSV:
   language_id: 1035892117
 TSX:
   type: programming
-  color: "#2b7489"
+  color: "#3178c6"
   group: TypeScript
   extensions:
   - ".tsx"
@@ -6538,7 +6538,7 @@ Type Language:
   language_id: 632765617
 TypeScript:
   type: programming
-  color: "#2b7489"
+  color: "#3178c6"
   aliases:
   - ts
   interpreters:

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -294,7 +294,7 @@ class TestLanguage < Minitest::Test
     assert_equal '#701516', Language['Ruby'].color
     assert_equal '#3572A5', Language['Python'].color
     assert_equal '#f1e05a', Language['JavaScript'].color
-    assert_equal '#2b7489', Language['TypeScript'].color
+    assert_equal '#3178c6', Language['TypeScript'].color
     assert_equal '#3d9970', Language['LSL'].color
   end
 


### PR DESCRIPTION
## Description

The current TypeScript color is close to, but not exactly, the official "TypeScript Blue" color. This PR updates it to match exactly.

## Checklist:

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - https://github.com/microsoft/TypeScript/issues/49389
    - [Official website CSS](https://github.com/microsoft/TypeScript-Website/blob/d83b3b671721f3801c238f89e51fbf21a8d7f805/packages/typescriptlang-org/src/style/globals.scss#L3)
