### PR TITLE
Improve heuristic for C#

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -141,7 +141,7 @@ disambiguations:
   - language: Smalltalk
     pattern: '![\w\s]+methodsFor: '
   - language: 'C#'
-    pattern: '^(\s*namespace\s*[\w\.]+\s*{|\s*\/\/)'
+    pattern: '^(\s*namespace\s*[\w\.]+\s*(;|{|\s*\/\/))'
 - extensions: ['.csc']
   rules:
   - language: GSC

--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -141,7 +141,7 @@ disambiguations:
   - language: Smalltalk
     pattern: '![\w\s]+methodsFor: '
   - language: 'C#'
-    pattern: '^(\s*namespace\s*[\w\.]+\s*(;|{|\s*\/\/))'
+    pattern: '^(\s*namespace\s*[\w\.]+\s*({|;)|\s*\/\/)'
 - extensions: ['.csc']
   rules:
   - language: GSC

--- a/samples/C#/FileScopedNamespace.cs
+++ b/samples/C#/FileScopedNamespace.cs
@@ -1,0 +1,10 @@
+namespace SampleNamespace;
+
+class AnotherSampleClass
+{
+    public void AnotherSampleMethod()
+    {
+        System.Console.WriteLine(
+            "SampleMethod inside SampleNamespace");
+    }
+}


### PR DESCRIPTION
Support file scoped namespace declarations.

See: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/namespace

## Description
The current regex doesn't handle file scoped namespace declarations. Currently, it expects a block of code like `namespace Old { ... }` the new regex also allows for `namespace New;`

Fixes https://github.com/github/linguist/issues/5870

## Checklist:
- [X] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source:
      - https://github.com/dotnet/docs/blob/7e12aa327ea040e41af0e229383b22cc31ce1d2f/docs/csharp/fundamentals/types/snippets/namespaces/filescopednamespace.cs
    - Sample license: MIT
  - [X] I have included a change to the heuristics to distinguish my language from others using the same extension.
