### PR TITLE
Replace escape_utils with cgi

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.extensions = ['ext/linguist/extconf.rb']
   s.require_paths = ['lib', 'ext']
 
+  s.add_dependency 'cgi',             '>= 0'
   s.add_dependency 'charlock_holmes', '~> 0.7.7'
-  s.add_dependency 'escape_utils',    '~> 1.2.0'
   s.add_dependency 'mini_mime',       '~> 1.0'
   s.add_dependency 'rugged',          '~> 1.0'
 

--- a/lib/linguist/blob_helper.rb
+++ b/lib/linguist/blob_helper.rb
@@ -1,6 +1,6 @@
 require 'linguist/generated'
+require 'cgi'
 require 'charlock_holmes'
-require 'escape_utils'
 require 'mini_mime'
 require 'yaml'
 
@@ -94,7 +94,7 @@ module Linguist
       elsif name.nil?
         "attachment"
       else
-        "attachment; filename=#{EscapeUtils.escape_url(name)}"
+        "attachment; filename=#{CGI.escape(name)}"
       end
     end
 

--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -1,4 +1,4 @@
-require 'escape_utils'
+require 'cgi'
 require 'yaml'
 begin
   require 'yajl'
@@ -434,7 +434,7 @@ module Linguist
     #
     # Returns the escaped String.
     def escaped_name
-      EscapeUtils.escape_url(name).gsub('+', '%20')
+      CGI.escape(name).gsub('+', '%20')
     end
 
     # Public: Get default alias name


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

EscapeUtils.escape_url is deprecated since escape_utils 1.3.0. Upstream suggests to use 'cgi' instead.

from CHANGELOG.md [1]:
- Deprecate EscapeUtils.escape_url and EscapeUtils.unescape_url given
  that Ruby 2.5 provides an optimized CGI.escape and CGI.unescape with
  mostly similar performance.

[1] https://github.com/brianmario/escape_utils/blob/v1.3.0/CHANGELOG.md