### PR TITLE
Change Inform7 grammar source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -631,7 +631,7 @@
 	url = https://github.com/byte-physics/language-igor
 [submodule "vendor/grammars/language-inform7"]
 	path = vendor/grammars/language-inform7
-	url = https://github.com/erkyrath/language-inform7
+	url = https://github.com/iftechfoundation/language-inform7
 [submodule "vendor/grammars/language-javascript"]
 	path = vendor/grammars/language-javascript
 	url = https://github.com/atom/language-javascript

--- a/.gitmodules
+++ b/.gitmodules
@@ -631,7 +631,7 @@
 	url = https://github.com/byte-physics/language-igor
 [submodule "vendor/grammars/language-inform7"]
 	path = vendor/grammars/language-inform7
-	url = https://github.com/iftechfoundation/language-inform7
+	url = https://github.com/iftechfoundation/language-inform7.git
 [submodule "vendor/grammars/language-javascript"]
 	path = vendor/grammars/language-javascript
 	url = https://github.com/atom/language-javascript

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -232,7 +232,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **INI:** [textmate/ini.tmbundle](https://github.com/textmate/ini.tmbundle)
 - **Idris:** [idris-hackers/idris-sublime](https://github.com/idris-hackers/idris-sublime)
 - **Ignore List:** [Alhadis/language-etc](https://github.com/Alhadis/language-etc)
-- **Inform 7:** [erkyrath/language-inform7](https://github.com/erkyrath/language-inform7)
+- **Inform 7:** [iftechfoundation/language-inform7](https://github.com/iftechfoundation/language-inform7)
 - **Inno Setup:** [idleberg/atom-language-innosetup](https://github.com/idleberg/atom-language-innosetup)
 - **Io:** [textmate/io.tmbundle](https://github.com/textmate/io.tmbundle)
 - **Ioke:** [vic/ioke-outdated](https://github.com/vic/ioke-outdated)

--- a/vendor/licenses/git_submodule/language-inform7.dep.yml
+++ b/vendor/licenses/git_submodule/language-inform7.dep.yml
@@ -1,10 +1,12 @@
 ---
-type: git_submodule
 name: language-inform7
-version: 4b3db3ec095c63f68b7c5b4bf14466ea32236542
+version: fed775fdc2f2a3b5057f586fe97d2013c912cf48
+type: git_submodule
+homepage: https://github.com/erkyrath/language-inform7
 license: mit
 licenses:
-- text: |-
+- sources: LICENSE
+  text: |
     The MIT License
 
     Copyright (c) 2016, Andrew Plotkin


### PR DESCRIPTION
The Inform 7 grammar module has been transferred to the [Interactive Fiction Technology Foundation][iftf].

[iftf]: https://iftechfoundation.org/

## Description
The Inform 7 grammar module has been updated to v1.0.3. The grammar has not changed; this just updates the metadata to reflect the new ownership.

## Checklist:

- [X] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo](https://github.com/erkyrath/language-inform7)
  - New: [URL to grammar repo](https://github.com/iftechfoundation/language-inform7)

