### PR TITLE
Change source for svelte

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1075,7 +1075,7 @@
 	url = https://github.com/tenable/sublimetext-nasl
 [submodule "vendor/grammars/svelte-atom"]
 	path = vendor/grammars/svelte-atom
-	url = https://github.com/umanghome/svelte-atom
+	url = https://github.com/sveltejs/svelte-atom.git
 [submodule "vendor/grammars/swift.tmbundle"]
 	path = vendor/grammars/swift.tmbundle
 	url = https://github.com/textmate/swift.tmbundle

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -491,7 +491,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **SubRip Text:** [Alhadis/language-subtitles](https://github.com/Alhadis/language-subtitles)
 - **SugarSS:** [hudochenkov/Syntax-highlighting-for-PostCSS](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS)
 - **SuperCollider:** [supercollider/language-supercollider](https://github.com/supercollider/language-supercollider)
-- **Svelte:** [umanghome/svelte-atom](https://github.com/umanghome/svelte-atom)
+- **Svelte:** [sveltejs/svelte-atom](https://github.com/sveltejs/svelte-atom)
 - **Swift:** [textmate/swift.tmbundle](https://github.com/textmate/swift.tmbundle)
 - **SystemVerilog:** [TheClams/SystemVerilog](https://github.com/TheClams/SystemVerilog)
 - **TLA:** [tlaplus-community/tree-sitter-tlaplus](https://github.com/tlaplus-community/tree-sitter-tlaplus) 🐌


### PR DESCRIPTION
## Description
Changes the source for Svelte from a seemingly abandoned fork to the original, active, repository. This change is prompted by a bug in the grammar; the fork has disabled issues, and the original repository has since added a compatible license (MIT) and commits, which possibly fix my issue.

## Checklist:

- [x] **I am changing the source of a syntax highlighting grammar**
  - Old: https://github.com/umanghome/svelte-atom
  - New: https://github.com/sveltejs/svelte-atom
