### PR TITLE
Add build-essential to list of Ubuntu required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ brew install cmake pkg-config icu4c
 On Ubuntu:
 
 ```bash
-sudo apt-get install cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev
+sudo apt-get install build-essential cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev
 ```
 
 ## Usage


### PR DESCRIPTION
Linguist needs to install native extensions during installation so we need a compiler to be installed. This is documented in the CONTRIBUTING.md file but we missed it in the README.md file.

This PR adds `build-essential` to the list of required dependencies for Ubuntu.

Fixes https://github.com/github/linguist/issues/5966