### PR TITLE
Rust syntax highlighting is now powered by treesitter

### DIFF
--- a/script/list-grammars
+++ b/script/list-grammars
@@ -19,6 +19,7 @@ TREE_SITTER_GRAMMARS = {
   "PHP" => "https://github.com/tree-sitter/tree-sitter-php",
   "Python" => "https://github.com/tree-sitter/tree-sitter-python",
   "Ruby" => "https://github.com/tree-sitter/tree-sitter-ruby",
+  "Rust" => "https://github.com/tree-sitter/tree-sitter-rust",
   "TLA" => "https://github.com/tlaplus-community/tree-sitter-tlaplus",
   "TypeScript" => "https://github.com/tree-sitter/tree-sitter-typescript"
 }

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -440,7 +440,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Roff Manpage:** [Alhadis/language-roff](https://github.com/Alhadis/language-roff)
 - **Rouge:** [atom/language-clojure](https://github.com/atom/language-clojure)
 - **Ruby:** [tree-sitter/tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby) 🐌
-- **Rust:** [zargony/atom-language-rust](https://github.com/zargony/atom-language-rust)
+- **Rust:** [tree-sitter/tree-sitter-rust](https://github.com/tree-sitter/tree-sitter-rust) 🐌
 - **SAS:** [rpardee/sas.tmbundle](https://github.com/rpardee/sas.tmbundle)
 - **SCSS:** [atom/language-sass](https://github.com/atom/language-sass)
 - **SELinux Policy:** [google/selinux-policy-languages](https://github.com/google/selinux-policy-languages)


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Rust has just been added to the list of languages highlighted directly by the highlighting engine using the treesitter grammar.

This PR updates the README to reflect this.
