### PR TITLE
Disambiguate .g (GAP, G-code)

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -245,6 +245,12 @@ disambiguations:
     pattern: '^(?:<|[a-zA-Z-][a-zA-Z0-9_-]+[ \t]+\w)|\${\w+[^\n]*?}|^[ \t]*(?:<#--.*?-->|<#([a-z]+)(?=\s|>)[^>]*>.*?</#\1>|\[#--.*?--\]|\[#([a-z]+)(?=\s|\])[^\]]*\].*?\[#\2\])'
   - language: Fluent
     pattern: '^-?[a-zA-Z][a-zA-Z0-9_-]* *=|\{\$-?[a-zA-Z][-\w]*(?:\.[a-zA-Z][-\w]*)?\}'
+- extensions: ['.g']
+  rules:
+  - language: GAP
+    pattern: '\s*(Declare|BindGlobal|KeyDependentOperation|Install(Method|GlobalFunction)|SetPackageInfo)'
+  - language: G-code
+    pattern: '^[MG][0-9]+\n'
 - extensions: ['.gd']
   rules:
   - language: GAP

--- a/test/test_heuristics.rb
+++ b/test/test_heuristics.rb
@@ -428,6 +428,13 @@ class TestHeuristics < Minitest::Test
     }, alt_name="main.ftl")
   end
 
+  def test_g_by_heuristics
+    assert_heuristics({
+      "GAP" => all_fixtures("GAP", "*.g*"),
+      "G-code" => all_fixtures("G-code", "*.g")
+    }, alt_name="test.g")
+  end
+
   def test_gd_by_heuristics
     assert_heuristics({
       "GAP" => all_fixtures("GAP", "*.gd"),


### PR DESCRIPTION
## Description

Disambiguate .g (GAP, G-code).

Related: #1528 #4404

## Checklist:

- [x] **I am fixing a misclassified language**
  - ~[ ] I have included a new sample for the misclassified language:~ New heuristic based on current samples. Some examples of misclassified files: https://github.com/search?q=G1+M0+extension%3Ag+language%3AGAP&type=Code
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
