### PR TITLE
Remove language group recursion

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -291,12 +291,11 @@ module Linguist
 
       # If group name is set, save the name so we can lazy load it later
       if attributes[:group_name]
-        @group = nil
         @group_name = attributes[:group_name]
 
       # Otherwise we can set it to self now
       else
-        @group = self
+        @group_name = self.name
       end
     end
 


### PR DESCRIPTION
After over 11 years within Linguist, and over 5 year of direct usage, it's been discovered `Linguist::Language` has a recursion problem that doesn't play nicely with Rails' `.to_json`:

```ruby
[1] pry(main)> require 'linguist'
=> true
[2] pry(main)> require 'active_support/all'
=> true
[3] pry(main)> ld = Linguist::Language.find_by_name("Markdown")
=> #<Linguist::Language name=Markdown>
[4] pry(main)> ld.to_json
SystemStackError: stack level too deep
from /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:180:in `initialize_dup'
[5] pry(main)> wtf -v
[...]
9152: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:179:in `as_json'
9153: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:63:in `as_json'
9154: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:180:in `block in as_json'
9155: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:179:in `each'
9156: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:179:in `as_json'
9157: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:63:in `as_json'
9158: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/json/encoding.rb:38:in `encode'
9159: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/json/encoding.rb:23:in `encode'
9160: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:42:in `to_json'
9161: (pry):4:in `__pry__'
9162: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/pry-0.13.1/lib/pry/pry_instance.rb:290:in `eval'
9163: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/pry-0.13.1/lib/pry/pry_instance.rb:290:in `evaluate_ruby'
9164: /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/pry-0.13.1/lib/pry/pry_instance.rb:659:in `handle_line'
[...]
[6] pry(main)>
```

Closer examination (ie doing what Rails [does](https://github.com/rails/rails/blob/69078b08203e9d3d5421c0f881048a7fe25a5e14/activesupport/lib/active_support/core_ext/object/json.rb#L58-L66)) shows where the recursion is:

```ruby
[7] pry(main)> ld.respond_to?(:to_hash)
=> false
[8] pry(main)> ld.instance_values.as_json
SystemStackError: stack level too deep
from /workspaces/github/vendor/gems/3.1.2/ruby/3.1.0/gems/activesupport-7.1.0.alpha.bb68040de4/lib/active_support/core_ext/object/json.rb:100:in `as_json'
[9] pry(main)> ld.instance_values
=> {"name"=>"Markdown",
 "fs_name"=>nil,
 "type"=>:prose,
 "types"=>[:data, :markup, :programming, :prose],
 "color"=>"#083fa1",
 "aliases"=>["markdown", "pandoc"],
 "tm_scope"=>"source.gfm",
 "ace_mode"=>"markdown",
 "codemirror_mode"=>"gfm",
 "codemirror_mime_type"=>"text/x-gfm",
 "wrap"=>true,
 "language_id"=>222,
 "extensions"=>[".md", ".livemd", ".markdown", ".mdown", ".mdwn", ".mdx", ".mkd", ".mkdn", ".mkdown", ".ronn", ".scd", ".workbook"],
 "interpreters"=>[],
 "filenames"=>["contents.lr"],
 "popular"=>false,
 "group"=>#<Linguist::Language name=Markdown>}
[10] pry(main)> 
```

💥 there's our recursion: `"group"=>#<Linguist::Language name=Markdown>`

We don't really need this as we have a `group()` method which gets the same information as and when it is needed so all we really need is the name.

This PR removes the recursive assignment.
