### PR TITLE
add syntax highlight for *.kdu component files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -653,6 +653,9 @@
 [submodule "vendor/grammars/language-kak"]
 	path = vendor/grammars/language-kak
 	url = https://github.com/kakoune-editor/language-kak
+[submodule "vendor/grammars/kdu-syntax-highlight"]
+	path = vendor/grammars/kdu-syntax-highlight
+	url = https://github.com/KduJS/kdu-syntax-highlight
 [submodule "vendor/grammars/language-kotlin"]
 	path = vendor/grammars/language-kotlin
 	url = https://github.com/nishtahir/language-kotlin

--- a/grammars.yml
+++ b/grammars.yml
@@ -613,6 +613,8 @@ vendor/grammars/language-jsonnet:
 - source.jsonnet
 vendor/grammars/language-kak:
 - source.kakscript
+vendor/grammars/kdu-syntax-highlight:
+  - text.html.kdu
 vendor/grammars/language-kotlin:
 - source.kotlin
 vendor/grammars/language-less:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3278,6 +3278,14 @@ KakouneScript:
   - kakrc
   ace_mode: text
   language_id: 603336474
+Kdu:
+  type: markup
+  color: "#03a9f4"
+  extensions:
+    - ".kdu"
+  tm_scope: text.html.kdu
+  ace_mode: html
+  language_id: 1407
 KiCad Layout:
   type: data
   color: "#2f4aab"

--- a/samples/Kdu/basic.kdu
+++ b/samples/Kdu/basic.kdu
@@ -1,0 +1,21 @@
+<style>
+.red {
+  color: #f00;
+}
+</style>
+
+<template>
+<div>
+  <h2 k-class="red">{{msg}}</h2>
+</div>
+</template>
+
+<script>
+module.exports = {
+  data: function () {
+    return {
+      msg: 'Hello from Kdu!'
+    }
+  }
+}
+</script>

--- a/samples/Kdu/pre-processors.kdu
+++ b/samples/Kdu/pre-processors.kdu
@@ -1,0 +1,30 @@
+<style lang="stylus">
+font-stack = Helvetica, sans-serif
+primary-color = #999
+body
+  font 100% font-stack
+  color primary-color
+</style>
+
+<template lang="jade">
+div
+  h1 {{msg}}
+  comp-a
+  comp-b
+</template>
+
+<script lang="babel">
+import compA from './components/a.kdu'
+import compB from './components/b.kdu'
+export default {
+  data () {
+    return {
+      msg: 'Hello from Babel!'
+    }
+  },
+  components: {
+    'comp-a': compA,
+    'comp-b': compB
+  }
+}
+</script>


### PR DESCRIPTION
This PR adds detection and highlighting for Kdu.js components with the `*.kdu` extension, using [kdu-syntax-highlight](https://github.com/kdujs/kdu-syntax-highlight).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Akdu+NOT+xml
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [arrow.kdu](https://github.com/KduJS/kdu-syntax-highlight/blob/main/samples/arrow.kdu)
      - [basic.kdu](https://github.com/KduJS/kdu-syntax-highlight/blob/main/samples/basic.kdu)
      - [langs.kdu](https://github.com/KduJS/kdu-syntax-highlight/blob/main/samples/langs.kdu)
    - Sample license(s):
      - MIT
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
