### PR TITLE
Add Cypher Query Language syntax highlighting and file extension detection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1242,3 +1242,6 @@
 [submodule "vendor/grammars/sublime-cypher"]
 	path = vendor/grammars/sublime-cypher
 	url = https://github.com/fredbenenson/sublime-cypher.git
+[submodule "vendor/grammars/openCypher"]
+	path = vendor/grammars/openCypher
+	url = https://github.com/opencypher/openCypher.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -115,9 +115,6 @@
 [submodule "vendor/grammars/Sublime-HTTP"]
 	path = vendor/grammars/Sublime-HTTP
 	url = https://github.com/samsalisbury/Sublime-HTTP
-[submodule "vendor/grammars/sublime-cypher"]
-	path = vendor/grammars/sublime-cypher
-	url = https://github.com/fredbenenson/sublime-cypher.git
 [submodule "vendor/grammars/Sublime-Lasso"]
 	path = vendor/grammars/Sublime-Lasso
 	url = https://github.com/bfad/Sublime-Lasso
@@ -1001,6 +998,9 @@
 [submodule "vendor/grammars/sublime-clips"]
 	path = vendor/grammars/sublime-clips
 	url = https://github.com/psicomante/CLIPS-sublime
+[submodule "vendor/grammars/sublime-cypher"]
+	path = vendor/grammars/sublime-cypher
+	url = https://github.com/fredbenenson/sublime-cypher.git
 [submodule "vendor/grammars/sublime-fantom"]
 	path = vendor/grammars/sublime-fantom
 	url = https://github.com/rkoeninger/sublime-fantom

--- a/.gitmodules
+++ b/.gitmodules
@@ -1239,3 +1239,6 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
+[submodule "vendor/grammars/sublime-cypher"]
+	path = vendor/grammars/sublime-cypher
+	url = https://github.com/fredbenenson/sublime-cypher.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1242,6 +1242,3 @@
 [submodule "vendor/grammars/sublime-cypher"]
 	path = vendor/grammars/sublime-cypher
 	url = https://github.com/fredbenenson/sublime-cypher.git
-[submodule "vendor/grammars/openCypher"]
-	path = vendor/grammars/openCypher
-	url = https://github.com/opencypher/openCypher.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -115,6 +115,9 @@
 [submodule "vendor/grammars/Sublime-HTTP"]
 	path = vendor/grammars/Sublime-HTTP
 	url = https://github.com/samsalisbury/Sublime-HTTP
+[submodule "vendor/grammars/sublime-cypher"]
+	path = vendor/grammars/sublime-cypher
+	url = https://github.com/fredbenenson/sublime-cypher.git
 [submodule "vendor/grammars/Sublime-Lasso"]
 	path = vendor/grammars/Sublime-Lasso
 	url = https://github.com/bfad/Sublime-Lasso
@@ -1239,6 +1242,3 @@
 [submodule "vendor/grammars/zephir-sublime"]
 	path = vendor/grammars/zephir-sublime
 	url = https://github.com/phalcon/zephir-sublime
-[submodule "vendor/grammars/sublime-cypher"]
-	path = vendor/grammars/sublime-cypher
-	url = https://github.com/fredbenenson/sublime-cypher.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,21 +192,6 @@ Just open a pull request and the bot will start cranking away.
 
 Here's our current build status: [![Actions Status](https://github.com/github/linguist/workflows/Run%20Tests/badge.svg)](https://github.com/github/linguist/actions)
 
-### Testing on your fork with github actions
-
-#### Enable github action on your fork
-https://github.com/github/linguist/actions
-
-#### Run commands to get tags and needed branches
-```bash
-git checkout master
-git fetch --tags git@github.com:github/linguist.git
-git fetch git@github.com:github/linguist.git master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
-git push --tags 
-git push --all
-```
-
-#### Create a pull request to your forks master branch, debug your runs
 
 ## Maintainers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,21 @@ Just open a pull request and the bot will start cranking away.
 
 Here's our current build status: [![Actions Status](https://github.com/github/linguist/workflows/Run%20Tests/badge.svg)](https://github.com/github/linguist/actions)
 
+### Testing on your fork with github actions
+
+#### Enable github action on your fork
+https://github.com/github/linguist/actions
+
+#### Run commands to get tags and needed branches
+```bash
+git checkout master
+git fetch --tags git@github.com:github/linguist.git
+git fetch git@github.com:github/linguist.git master:master v2.0.0:v2.0.0 test/attributes:test/attributes test/master:test/master
+git push --tags 
+git push --all
+```
+
+#### Create a pull request to your forks master branch, debug your runs
 
 ## Maintainers
 

--- a/grammars.yml
+++ b/grammars.yml
@@ -103,8 +103,6 @@ vendor/grammars/Stylus:
 - source.stylus
 vendor/grammars/Sublime-Coq:
 - source.coq
-vendor/grammars/sublime-cypher:
-- source.cypher
 vendor/grammars/Sublime-HTTP:
 - source.httpspec
 vendor/grammars/Sublime-Lasso:
@@ -894,6 +892,8 @@ vendor/grammars/sublime-cirru:
 - source.cirru
 vendor/grammars/sublime-clips:
 - source.clips
+vendor/grammars/sublime-cypher:
+- source.cypher
 vendor/grammars/sublime-fantom:
 - source.fan
 vendor/grammars/sublime-glsl:

--- a/grammars.yml
+++ b/grammars.yml
@@ -103,6 +103,8 @@ vendor/grammars/Stylus:
 - source.stylus
 vendor/grammars/Sublime-Coq:
 - source.coq
+vendor/grammars/sublime-cypher:
+- source.cypher
 vendor/grammars/Sublime-HTTP:
 - source.httpspec
 vendor/grammars/Sublime-Lasso:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1335,6 +1335,7 @@ Cypher:
   extensions:
   - ".cyp"
   - ".cypher"
+  ace_mode: text
   tm_scope: source.cypher
   language_id: 850806976
 Cython:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1336,6 +1336,7 @@ Cypher:
   - ".cyp"
   aliases:
   - cypher
+  tm_scope: source.cypher
 Cython:
   type: programming
   color: "#fedf5b"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1332,6 +1332,7 @@ Cycript:
   language_id: 78
 Cypher:
   type: programming
+  color: "#34c0eb"
   extensions:
   - ".cyp"
   - ".cypher"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1331,7 +1331,7 @@ Cycript:
   codemirror_mime_type: text/javascript
   language_id: 78
 Cypher:
-  type: data
+  type: programming
   extensions:
   - ".cyp"
   - ".cypher"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1335,8 +1335,6 @@ Cypher:
   extensions:
   - ".cyp"
   - ".cypher"
-  aliases:
-  - cypher
   tm_scope: source.cypher
   language_id: 850806976
 Cython:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1338,6 +1338,7 @@ Cypher:
   aliases:
   - cypher
   tm_scope: source.cypher
+  language_id: 850806976
 Cython:
   type: programming
   color: "#fedf5b"
@@ -4075,7 +4076,7 @@ Move:
   type: programming
   color: "#4a137a"
   extensions:
-    - ".move"
+  - ".move"
   tm_scope: source.move
   ace_mode: text
   language_id: 638334599

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1330,6 +1330,12 @@ Cycript:
   codemirror_mode: javascript
   codemirror_mime_type: text/javascript
   language_id: 78
+Cypher:
+  type: data
+  extensions:
+  - ".cyp"
+  aliases:
+  - cypher
 Cython:
   type: programming
   color: "#fedf5b"

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1334,6 +1334,7 @@ Cypher:
   type: data
   extensions:
   - ".cyp"
+  - ".cypher"
   aliases:
   - cypher
   tm_scope: source.cypher

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1335,8 +1335,8 @@ Cypher:
   extensions:
   - ".cyp"
   - ".cypher"
-  ace_mode: text
   tm_scope: source.cypher
+  ace_mode: text
   language_id: 850806976
 Cython:
   type: programming

--- a/samples/Cypher/binary-tree-1.cyp
+++ b/samples/Cypher/binary-tree-1.cyp
@@ -1,0 +1,31 @@
+// From: https://github.com/opencypher/openCypher/blob/master/tck/graphs/binary-tree-1/binary-tree-1.cypher
+
+CREATE (a:A {name: 'a'}),
+       (b1:X {name: 'b1'}),
+       (b2:X {name: 'b2'}),
+       (b3:X {name: 'b3'}),
+       (b4:X {name: 'b4'}),
+       (c11:X {name: 'c11'}),
+       (c12:X {name: 'c12'}),
+       (c21:X {name: 'c21'}),
+       (c22:X {name: 'c22'}),
+       (c31:X {name: 'c31'}),
+       (c32:X {name: 'c32'}),
+       (c41:X {name: 'c41'}),
+       (c42:X {name: 'c42'})
+CREATE (a)-[:KNOWS]->(b1),
+       (a)-[:KNOWS]->(b2),
+       (a)-[:FOLLOWS]->(b3),
+       (a)-[:FOLLOWS]->(b4)
+CREATE (b1)-[:FRIEND]->(c11),
+       (b1)-[:FRIEND]->(c12),
+       (b2)-[:FRIEND]->(c21),
+       (b2)-[:FRIEND]->(c22),
+       (b3)-[:FRIEND]->(c31),
+       (b3)-[:FRIEND]->(c32),
+       (b4)-[:FRIEND]->(c41),
+       (b4)-[:FRIEND]->(c42)
+CREATE (b1)-[:FRIEND]->(b2),
+       (b2)-[:FRIEND]->(b3),
+       (b3)-[:FRIEND]->(b4),
+       (b4)-[:FRIEND]->(b1);

--- a/samples/Cypher/binary-tree-2.cyp
+++ b/samples/Cypher/binary-tree-2.cyp
@@ -1,0 +1,31 @@
+// From: https://github.com/opencypher/openCypher/blob/master/tck/graphs/binary-tree-2/binary-tree-2.cypher
+
+CREATE (a:A {name: 'a'}),
+       (b1:X {name: 'b1'}),
+       (b2:X {name: 'b2'}),
+       (b3:X {name: 'b3'}),
+       (b4:X {name: 'b4'}),
+       (c11:X {name: 'c11'}),
+       (c12:Y {name: 'c12'}),
+       (c21:X {name: 'c21'}),
+       (c22:Y {name: 'c22'}),
+       (c31:X {name: 'c31'}),
+       (c32:Y {name: 'c32'}),
+       (c41:X {name: 'c41'}),
+       (c42:Y {name: 'c42'})
+CREATE (a)-[:KNOWS]->(b1),
+       (a)-[:KNOWS]->(b2),
+       (a)-[:FOLLOWS]->(b3),
+       (a)-[:FOLLOWS]->(b4)
+CREATE (b1)-[:FRIEND]->(c11),
+       (b1)-[:FRIEND]->(c12),
+       (b2)-[:FRIEND]->(c21),
+       (b2)-[:FRIEND]->(c22),
+       (b3)-[:FRIEND]->(c31),
+       (b3)-[:FRIEND]->(c32),
+       (b4)-[:FRIEND]->(c41),
+       (b4)-[:FRIEND]->(c42)
+CREATE (b1)-[:FRIEND]->(b2),
+       (b2)-[:FRIEND]->(b3),
+       (b3)-[:FRIEND]->(b4),
+       (b4)-[:FRIEND]->(b1);

--- a/samples/Cypher/graphgems.cyp
+++ b/samples/Cypher/graphgems.cyp
@@ -1,0 +1,162 @@
+// From: https://github.com/neo4j/cypher-shell/blob/4.3/cypher-shell/src/test/resources/org/neo4j/shell/parser/graphgems.cypher
+
+//GRAPHGEMS
+//10 (?) cypher queries that will blow your mind
+
+//1. The meta-graph
+MATCH (a)-[r]->(b)
+WITH labels(a) AS a_labels,type(r) AS rel_type,labels(b) AS b_labels
+UNWIND a_labels as l
+UNWIND b_labels as l2
+MERGE (a:Meta_Node {name:l})
+MERGE (b:Meta_Node {name:l2})
+MERGE (a)-[:META_RELATIONSHIP {name:rel_type}]->(b)
+RETURN distinct l as first_node, rel_type as connected_by, l2 as second_node
+
+//2. Betweenness centrality ftw
+MATCH p=allShortestPaths((source:Person)-[:KNOWS*]-(target:Person))
+WHERE id(source) < id(target) and length(p) > 1
+UNWIND nodes(p)[1..-1] as n
+RETURN n.firstname, n.lastname, count(*) as betweenness
+ORDER BY betweenness DESC;
+
+//3. Pagerank ftw
+//3.a Graph Theory: calculate the PageRank
+UNWIND range(1,2) AS round
+MATCH (n:Person)
+WHERE rand() < 0.1
+MATCH (n:Person)-[:KNOWS*..5]->(m:Person)
+SET m.rank = coalesce(m.rank,0) + 1
+
+//3.b Graph Theory: Show the PageRank
+match (n:Person)
+where n.rank is not null
+return n.firstname, n.lastname, n.rank
+order by n.rank desc
+limit 10;
+
+//4. Weighted shortest path
+START  startNode=node:node_auto_index(name="Start"),
+       endNode=node:node_auto_index(name="Finish")
+MATCH  p=(startNode)-[:NAVIGATE_TO*]->(endNode)
+RETURN p AS shortestPath,
+       reduce(distance=0, r in relationships(p) | distance+r.distance) AS totalDistance
+       ORDER BY totalDistance ASC
+       LIMIT 1;
+
+
+//5. Creating an in-graph index based on ordering node properties
+match (t:Time)--(d:Day {date: 20150506})
+with t
+order by t.time ASC
+with collect(t) as times
+  foreach (i in range(0,length(times)-2) |
+    foreach (t1 in [times[i]] |
+      foreach (t2 in [times[i+1]] |
+        merge (t1)-[:FOLLOWED_BY]->(t2))));
+
+//6. Graph Karaoke
+//create the karaoke graph
+load csv with headers from "https://docs.google.com/a/neotechnology.com/spreadsheets/d/1Q8W7hDOnkXiLanf2K3P85wAhqQG_qm7bTwI36MbB5fE/export?format=csv&id=1Q8W7hDOnkXiLanf2K3P85wAhqQG_qm7bTwI36MbB5fE&gid=0" as csv
+with csv.Sequence as seq, csv.Songsentence as row
+unwind row as text
+with seq, reduce(t=tolower(text), delim in [",",".","!","?",'"',":",";","'","-"] | replace(t,delim,"")) as normalized
+with seq, [w in split(normalized," ") | trim(w)] as words
+unwind range(0,size(words)-2) as idx
+MERGE (w1:Word {name:words[idx], seq:toInteger(seq)})
+MERGE (w2:Word {name:words[idx+1], seq:toInteger(seq)})
+MERGE (w1)-[r:NEXT {seq:toInteger(seq)}]->(w2)
+
+match (endword:Word), (startword:Word)
+where not ()-[:NEXT]->(startword)
+and not (endword)-[:NEXT]->()
+and startword.seq=endword.seq+1
+merge (endword)-[:NEXTSENTENCE]->(startword)
+
+
+//7. The Timetree
+WITH range(2011, 2014) AS years, range(1,12) as months
+FOREACH(year IN years |
+  MERGE (y:Year {year: year})
+  FOREACH(month IN months |
+    CREATE (m:Month {month: month})
+    MERGE (y)-[:HAS_MONTH]->(m)
+    FOREACH(day IN (CASE
+                      WHEN month IN [1,3,5,7,8,10,12] THEN range(1,31)
+                      WHEN month = 2 THEN
+                        CASE
+                          WHEN year % 4 <> 0 THEN range(1,28)
+                          WHEN year % 100 <> 0 THEN range(1,29)
+                          WHEN year % 400 <> 0 THEN range(1,29)
+                          ELSE range(1,28)
+                        END
+                      ELSE range(1,30)
+                    END) |
+      CREATE (d:Day {day: day})
+      MERGE (m)-[:HAS_DAY]->(d))))
+
+WITH *
+
+MATCH (year:Year)-[:HAS_MONTH]->(month)-[:HAS_DAY]->(day)
+WITH year,month,day
+ORDER BY year.year, month.month, day.day
+WITH collect(day) as days
+FOREACH(i in RANGE(0, length(days)-2) |
+    FOREACH(day1 in [days[i]] |
+        FOREACH(day2 in [days[i+1]] |
+            CREATE UNIQUE (day1)-[:NEXT]->(day2))))
+
+//8. Mark's recommendation query
+MATCH (me:Person {name: "Adam"})
+MATCH (me)-[:FRIEND_OF]-()-[:FRIEND_OF]-(potentialFriend)
+
+WITH me, potentialFriend, COUNT(*) AS friendsInCommon
+
+WITH me,
+     potentialFriend,
+     SIZE((potentialFriend)-[:LIVES_IN]->()<-[:LIVES_IN]-(me)) AS sameLocation,
+     abs( me.age - potentialFriend.age) AS ageDifference,
+     LABELS(me) = LABELS(potentialFriend) AS gender,
+     friendsInCommon
+
+WHERE NOT (me)-[:FRIEND_OF]-(potentialFriend)
+
+WITH potentialFriend,
+       // 100 -> maxScore, 10 -> eightyPercentLevel, friendsInCommon -> score (from the formula above)
+       100 * (1 - exp((-1.0 * (log(5.0) / 10)) * friendsInCommon)) AS friendsInCommon,
+       sameLocation * 10 AS sameLocation,
+       -1 * (10 * (1 - exp((-1.0 * (log(5.0) / 20)) * ageDifference))) AS ageDifference,
+       CASE WHEN gender THEN 10 ELSE 0 END as sameGender
+
+RETURN potentialFriend,
+      {friendsInCommon: friendsInCommon,
+       sameLocation: sameLocation,
+       ageDifference:ageDifference,
+       sameGender: sameGender} AS parts,
+     friendsInCommon + sameLocation + ageDifference + sameGender AS score
+ORDER BY score DESC
+
+//9. The Daisy!
+CREATE (a:Middle {name:""}) -[:STALK]-> (b:Root {name:""})
+FOREACH (i in RANGE(1,10) | CREATE (a) -[:PETAL]-> (a))
+RETURN a, b
+
+
+
+
+//10. MERGE on dense nodes
+// see http://stackoverflow.com/questions/30930311/how-can-i-optimise-a-neo4j-merge-query-on-a-node-with-many-relationships/30932777#30932777
+
+convert this
+MATCH (from:Node { id: 0 })
+UNWIND RANGE(1,10000) AS i
+MATCH (to:Node { id: i})
+MERGE (to)<-[:HAS]-(from);
+
+to
+
+MATCH (from:Node { id: 0 })
+UNWIND RANGE(1,100000) AS i
+MATCH (to:Node { id: i})
+WHERE shortestPath((to)<-[:HAS]-(from)) IS NULL
+CREATE (from)-[:HAS]->(to);

--- a/samples/Cypher/small-test.cyp
+++ b/samples/Cypher/small-test.cyp
@@ -1,0 +1,26 @@
+// From: https://github.com/neo4j/cypher-shell/blob/4.3/cypher-shell/src/test/resources/org/neo4j/shell/parser/small-test.cypher
+
+// This file when parsed should return 11 statements
+
+// This is a single line with a single statement...
+MATCH (n) RETURN n LIMIT 10
+
+// Similar single line with a single statement...
+MATCH (n) RETURN n LIMIT 10;
+
+// This is a single line with three statements...
+RETURN "testing"; RETURN "testing"; RETURN "one, two, three"
+
+// This is a single statement across multiple lines...
+
+MATCH (n)
+WHERE n.volume > 10
+RETURN n AS loud
+
+// And this is a mix of variable length statements, separated by ;...
+
+CREATE (n:Amplifier {volume:11})
+;
+MATCH (amps) WHERE n.volume > 10
+RETURN amps;
+RETURN "Encore!"; RETURN "Encore!!"; RETURN "Encore!!!"

--- a/samples/Cypher/torture-test.cypher
+++ b/samples/Cypher/torture-test.cypher
@@ -1,0 +1,25 @@
+// From: https://github.com/neo4j/cypher-shell/blob/4.3/cypher-shell/src/test/resources/org/neo4j/shell/parser/torture-test.cypher
+
+// This file contains 8 statements
+
+CREATE
+      (
+      // Comment haha!!
+      n
+      /* Block comment to confuse */ )
+  RETURN
+      n
+
+ // Some semicolons
+   RETURN 1; RETURN 2; /* Evil block comment! */ RETURN 3
+
+    // No semicolons! And newlines!!
+
+  RETURN 1 RETURN
+ 2 RETURN 3
+
+// This is one statement
+MATCH (null)-[:merge]->(true)
+with null.delete as foreach, `true`.false as null
+return 2 + foreach, coalesce(null, 3.1415)
+limit 10;

--- a/samples/Cypher/yago.cypher
+++ b/samples/Cypher/yago.cypher
@@ -1,0 +1,66 @@
+// From: https://github.com/opencypher/openCypher/blob/master/tck/graphs/yago/openCypher-yago-graph.cypher
+
+//
+// This graph is based upon YAGO, which is derived from Wikipedia.
+// The idea is to enlarge it over time.
+// http://www.mpi-inf.mpg.de/departments/databases-and-information-systems/research/yago-naga/yago/
+//
+
+CREATE (rachel:Person:Actor {name: 'Rachel Kempson', birthyear: 1910})
+CREATE (michael:Person:Actor {name: 'Michael Redgrave', birthyear: 1908})
+CREATE (vanessa:Person:Actor {name: 'Vanessa Redgrave', birthyear: 1937})
+CREATE (corin:Person:Actor {name: 'Corin Redgrave', birthyear: 1939})
+CREATE (liam:Person:Actor {name: 'Liam Neeson', birthyear: 1952})
+CREATE (natasha:Person:Actor {name: 'Natasha Richardson', birthyear: 1963})
+CREATE (richard:Person:Actor {name: 'Richard Harris', birthyear: 1930})
+CREATE (dennis:Person:Actor {name: 'Dennis Quaid', birthyear: 1954})
+CREATE (lindsay:Person:Actor {name: 'Lindsay Lohan', birthyear: 1986})
+CREATE (jemma:Person:Actor {name: 'Jemma Redgrave', birthyear: 1965})
+CREATE (roy:Person:Actor {name: 'Roy Redgrave', birthyear: 1873})
+
+CREATE (john:Person {name: 'John Williams', birthyear: 1932})
+CREATE (christopher:Person {name: 'Christopher Nolan', birthyear: 1970})
+
+CREATE (newyork:City {name: 'New York'})
+CREATE (london:City {name: 'London'})
+CREATE (houston:City {name: 'Houston'})
+
+CREATE (mrchips:Film {title: 'Goodbye, Mr. Chips'})
+CREATE (batmanbegins:Film {title: 'Batman Begins'})
+CREATE (harrypotter:Film {title: 'Harry Potter and the Sorcerer\'s Stone'})
+CREATE (parent:Film {title: 'The Parent Trap'})
+CREATE (camelot:Film {title: 'Camelot'})
+
+CREATE (rachel)-[:HAS_CHILD]->(vanessa),
+       (rachel)-[:HAS_CHILD]->(corin),
+       (michael)-[:HAS_CHILD]->(vanessa),
+       (michael)-[:HAS_CHILD]->(corin),
+       (corin)-[:HAS_CHILD]->(jemma),
+       (vanessa)-[:HAS_CHILD]->(natasha),
+       (roy)-[:HAS_CHILD]->(michael),
+
+       (rachel)-[:MARRIED]->(michael),
+       (michael)-[:MARRIED]->(rachel),
+       (natasha)-[:MARRIED]->(liam),
+       (liam)-[:MARRIED]->(natasha),
+
+       (vanessa)-[:BORN_IN]->(london),
+       (natasha)-[:BORN_IN]->(london),
+       (christopher)-[:BORN_IN]->(london),
+       (dennis)-[:BORN_IN]->(houston),
+       (lindsay)-[:BORN_IN]->(newyork),
+       (john)-[:BORN_IN]->(newyork),
+
+       (christopher)-[:DIRECTED]->(batmanbegins),
+
+       (john)-[:WROTE_MUSIC_FOR]->(harrypotter),
+       (john)-[:WROTE_MUSIC_FOR]->(mrchips),
+
+       (michael)-[:ACTED_IN {charactername: 'The Headmaster'}]->(mrchips),
+       (vanessa)-[:ACTED_IN {charactername: 'Guenevere'}]->(camelot),
+       (richard)-[:ACTED_IN {charactername: 'King Arthur'}]->(camelot),
+       (richard)-[:ACTED_IN {charactername: 'Albus Dumbledore'}]->(harrypotter),
+       (natasha)-[:ACTED_IN {charactername: 'Liz James'}]->(parent),
+       (dennis)-[:ACTED_IN {charactername: 'Nick Parker'}]->(parent),
+       (lindsay)-[:ACTED_IN {charactername: 'Halle/Annie'}]->(parent),
+       (liam)-[:ACTED_IN {charactername: 'Henri Ducard'}]->(batmanbegins)

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -120,6 +120,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Cue Sheet:** [relikd/CUE-Sheet_sublime](https://github.com/relikd/CUE-Sheet_sublime)
 - **Curry:** [fwcd/vscode-curry](https://github.com/fwcd/vscode-curry)
 - **Cycript:** [atom/language-javascript](https://github.com/atom/language-javascript)
+- **Cypher:** [fredbenenson/sublime-cypher](https://github.com/fredbenenson/sublime-cypher)
 - **Cython:** [textmate/cython.tmbundle](https://github.com/textmate/cython.tmbundle)
 - **D:** [textmate/d.tmbundle](https://github.com/textmate/d.tmbundle)
 - **D-ObjDump:** [nanoant/assembly.tmbundle](https://github.com/nanoant/assembly.tmbundle)


### PR DESCRIPTION
# Desciption
This ***PR*** adds the **_Cypher_** query language with the ```*.cyp``` and ```*.cypher``` extension. 

The language is a graph query language https://opencypher.org/ and it's ISO recognition is WIP

[There are already:](https://github.com/search?q=extension%3Acyp&type=code)
  - 1.4k code results
  - 382k package results
  - 895k topic results
  - 64586k user results

So It would be great to have syntax highlighting on github (and later search as well) :)

Godspeed!

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?q=extension%3Acyp&type=Code
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/opencypher/openCypher/blob/master/tck/graphs/yago/openCypher-yago-graph.cypher
      - https://github.com/opencypher/openCypher/blob/master/tck/graphs/binary-tree-1/binary-tree-1.cypher
      - https://github.com/opencypher/openCypher/blob/master/tck/graphs/binary-tree-2/binary-tree-2.cypher
      - https://github.com/neo4j/cypher-shell/blob/4.3/cypher-shell/src/test/resources/org/neo4j/shell/parser/graphgems.cypher
      - https://github.com/neo4j/cypher-shell/blob/4.3/cypher-shell/src/test/resources/org/neo4j/shell/parser/torture-test.cypher
      - https://github.com/neo4j/cypher-shell/blob/4.3/cypher-shell/src/test/resources/org/neo4j/shell/parser/small-test.cypher
    - Sample license(s):
      - https://github.com/opencypher/openCypher/blob/master/LICENSE
  - [x] I have included a syntax highlighting grammar: https://github.com/fredbenenson/sublime-cypher.git
