### PR TITLE
Update Ace mode paths for tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,8 +35,9 @@ task :fetch_ace_modes do
   File.delete(ACE_FIXTURE_PATH) if File.exist?(ACE_FIXTURE_PATH)
 
   begin
-    ace_github_modes = URI.open("https://api.github.com/repos/ajaxorg/ace/contents/src/mode").read
-    File.write(ACE_FIXTURE_PATH, ace_github_modes)
+    ace_github_modes_lib = URI.open("https://api.github.com/repos/ajaxorg/ace/contents/lib/ace/mode").read
+    ace_github_modes_src = URI.open("https://api.github.com/repos/ajaxorg/ace/contents/src/mode").read
+    File.write(ACE_FIXTURE_PATH, "[#{ace_github_modes_lib},#{ace_github_modes_src}]")
   rescue OpenURI::HTTPError, SocketError
       # no internet? no problem.
   end

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ task :fetch_ace_modes do
   File.delete(ACE_FIXTURE_PATH) if File.exist?(ACE_FIXTURE_PATH)
 
   begin
-    ace_github_modes = URI.open("https://api.github.com/repos/ajaxorg/ace/contents/lib/ace/mode").read
+    ace_github_modes = URI.open("https://api.github.com/repos/ajaxorg/ace/contents/src/mode").read
     File.write(ACE_FIXTURE_PATH, ace_github_modes)
   rescue OpenURI::HTTPError, SocketError
       # no internet? no problem.

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -406,7 +406,8 @@ class TestLanguage < Minitest::Test
     ace_fixture_path = File.join('test', 'fixtures', 'ace_modes.json')
     skip("No ace_modes.json file") unless File.exist?(ace_fixture_path)
 
-    ace_github_modes = Yajl.load(File.read(ace_fixture_path))
+    ace_modes = Yajl.load(File.read(ace_fixture_path))
+    ace_github_modes = ace_modes[0].concat(ace_modes[1])
     existing_ace_modes = ace_github_modes.map do |ace_github_mode|
       File.basename(ace_github_mode["name"], ".js") if ace_github_mode["name"]  !~ /_highlight_rules|_test|_worker/
     end.compact.uniq.sort.map(&:downcase)


### PR DESCRIPTION
The upstream directory structure was changed in https://github.com/ajaxorg/ace/pull/4851 which means we're looking in the wrong place for all the languages supported by the Ace editor. We now need to look in the old location for `jsoniq` and `xquery` and the new location for everything else.

These changes have been made as they plan to release Ace as an NPM.