### PR TITLE
Ungroup SugarSS from CSS

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6314,7 +6314,6 @@ SugarSS:
   type: markup
   color: "#2fcc9f"
   tm_scope: source.css.postcss.sugarss
-  group: CSS
   extensions:
   - ".sss"
   ace_mode: text


### PR DESCRIPTION
## Description
Ungroup SugarSS from CSS. Continuation of #4979 and similar PRs.

SugarSS is Indent-based and extremely different from CSS, so should absolutely be split.

*(Checklist removed as it doesn't apply)*