### PR TITLE
Dockerfile Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ruby:2-alpine3.13
 RUN apk --update add --virtual build_deps \
     build-base \
     libc-dev \
-    linux-headers \
     cmake \
-    && apk --no-cache add icu-dev openssl-dev \
+    && apk add icu-dev openssl-dev \
     && gem install github-linguist \
-    && apk del build_deps build-base libc-dev linux-headers cmake
+    && apk del build_deps \
+	&& rm /var/cache/apk/*
 
 CMD ["github-linguist"]


### PR DESCRIPTION
This PR does not introduce any changes to installed packages, but it does change the filesystem by deleting the package caches.

- The `linux-headers` package is found in the base image, such that adding it is not required
- The removal of `build-base`, `libc-dev`, and `cmake` are handled by `apk del build_deps`, the virtual package we created. `linux-headers` can not be deleted, as it is required by `libffi-dev` in the base image.
- Removing `--no-cache` on the second `apk add` because the package caches were already downloaded and retained in the first `apk add`, so there's no need to fetch them again.
- Removing the caches from `/var/cache/apk/*` saves some mega bees 🐝