### PR TITLE
Accept branch name as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ $ github-linguist
 
 #### Additional options
 
+##### `--rev REV`
+The `--rev REV` flag will change the git revision being analyzed to any [gitrevisions(1)](https://git-scm.com/docs/gitrevisions#_specifying_revisions) compatible revision you specify.
+
+This is useful to analyze the makeup of a repo as of a certain tag, or in a certain branch.
+
+For example, here is the popular [Jekyll open source project](https://github.com/jekyll/jekyll).
+
+```console
+$ github-linguist jekyll
+
+70.64%  709959     Ruby
+23.04%  231555     Gherkin
+3.80%   38178      JavaScript
+1.19%   11943      HTML
+0.79%   7900       Shell
+0.23%   2279       Dockerfile
+0.13%   1344       Earthly
+0.10%   1019       CSS
+0.06%   606        SCSS
+0.02%   234        CoffeeScript
+0.01%   90         Hack
+```
+
+And here is Jekyll's published website, from the gh-pages branch inside their repository.
+```console
+$ github-linguist jekyll --rev origin/gh-pages
+100.00% 2568354    HTML
+```
+
 ##### `--breakdown`
 The `--breakdown` or `-b` flag will additionally show the breakdown of files by language.
 

--- a/bin/github-linguist
+++ b/bin/github-linguist
@@ -13,13 +13,14 @@ Linguist v#{Linguist::VERSION}
 Detect language type and determine language breakdown for a given Git repository.
 
 Usage: linguist <path>
-       linguist <path> [--breakdown] [--json]
-       linguist [--breakdown] [--json]
+       linguist <path> [--rev REV] [--breakdown] [--json]
+       linguist [--rev REV] [--breakdown] [--json]
 HELP
 
 def github_linguist(args)
   breakdown = false
   json_output = false
+  rev = 'HEAD'
   path = Dir.pwd
 
   parser = OptionParser.new do |opts|
@@ -28,6 +29,9 @@ def github_linguist(args)
 
     opts.on("-b", "--breakdown", "Analyze entire repository and display detailed usage statistics") { breakdown = true }
     opts.on("-j", "--json", "Output results as JSON") { json_output = true }
+    opts.on("-r", "--rev REV", String,
+            "Analyze specific git revision",
+            "defaults to HEAD, see gitrevisions(1) for alternatives") { |r| rev = r }
     opts.on("-h", "--help", "Display a short usage summary, then exit") do
       puts opts
       exit
@@ -46,7 +50,13 @@ def github_linguist(args)
 
   if File.directory?(path)
     rugged = Rugged::Repository.new(path)
-    repo = Linguist::Repository.new(rugged, rugged.head.target_id)
+    begin
+      target_oid = rugged.rev_parse_oid(rev)
+    rescue
+      puts "invalid revision '#{rev}' for repo '#{path}'"
+      exit 1
+    end
+    repo = Linguist::Repository.new(rugged, target_oid)
 
     full_results = {}
     repo.languages.each do |language, size|


### PR DESCRIPTION
Modify the github-linguist CLI to accept a new, optional argument specifying a git revision other than HEAD to analyze.

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
While working with a GitHub customer it came to my attention that linguist as a command line tool will only analyze HEAD in the current repo, which is typically the default branch in a newly cloned repo. I have added an optional command line flag to accept any [gitrevisions(1)](https://git-scm.com/docs/gitrevisions#_specifying_revisions) compatible ref so that other branches, tags, or individual SHAs can be analyzed provided they are reachable.

This does not regress any current functionality, and I also rescue the potential exception should the user provide a revision that is not reachable.

I have investigated adding a test but there appear to be none in the current suite related to the CLI at all, and this change should be safe to introduce without one.

This makes the tool useful for example in CI pipelines where the languages present may be an input to a later step, where certain build tools, linters, or scanning tools may be needed based on the results.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] **I am associating a language with a new file extension.**
  - [ ] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3AFOOBAR+KEYWORDS+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.

- [ ] **I am changing the source of a syntax highlighting grammar**
  - Old: [URL to grammar repo]
  - New: [URL to grammar repo]

- [ ] **I am updating a grammar submodule**
  <!-- That's not necessary, grammar submodules are updated automatically with each new release. -->

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.

- [ ] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [ ] I have obtained agreement from the wider language community on this color change.
    - [URL to public discussion]
    - [Optional: URL to official branding guidelines for the language]
