### PR TITLE
Add repo "language used support" for INI/CFG.

### DIFF
--- a/samples/INI/serv.cfg
+++ b/samples/INI/serv.cfg
@@ -1,0 +1,6 @@
+version=0.1
+url=localhost
+port=27043
+ascii=0
+host=1
+allowed_ips=10


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
Hello, I have been seen by someone called "lildude", Since i did 2 pull requests about my language, This time I'm trying to add something for some projects I'm trying to do, The reviewer of this pr maybe will not understand "language used support" but here's an example:

![something](https://user-images.githubusercontent.com/68444929/195950021-599e85b6-55aa-4104-a4dc-c9a6fe8a74b0.png)

You can notice a brown color and next to it a text "Assembly" under the description of the repo, this indicates which language is used the most OR if it's the only used language.

I want to add the exact same thing but with INI/CFG. It will look like this:

![INI](https://user-images.githubusercontent.com/68444929/195950211-8541f7f5-5024-4e88-8634-f97076602955.png)

If you think this is some joke or some stupid idea, you're right, But I get insecure when I don't get the "language used" below my repo (probably won't make sense at all). Thanks!

- Waled Ali / yoidog
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **Adding "language used" support**