### PR TITLE
Generate samples during bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ Additionally, if this extension is already listed in [`languages.yml`][languages
    This ensures we're not misclassifying files.
 1. If the Bayesian classifier does a bad job with the sample `.yourextension` files then a [heuristic][] may need to be written to help.
 
+
 ## Adding a language
 
 We try only to add languages once they have some usage on GitHub.
@@ -173,12 +174,6 @@ You can run the tests locally with:
 
 ```bash
 bundle exec rake test
-```
-
-If the tests indicate the samples are out of date, you can update them with:
-
-```bash
-bundle exec rake samples
 ```
 
 Sometimes getting the tests running can be too much work, especially if you don't have much Ruby experience.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,14 +42,6 @@ cd linguist/
 script/bootstrap
 ```
 
-To run Linguist from the cloned repository, you will need to generate the code samples first:
-
-```bash
-bundle exec rake samples
-```
-
-Run this command each time a [sample][samples] has been modified.
-
 To run Linguist from the cloned repository:
 
 ```bash
@@ -80,7 +72,6 @@ Additionally, if this extension is already listed in [`languages.yml`][languages
 1. Test the performance of the Bayesian classifier with a relatively large number (1000s) of sample `.yourextension` files (ping **@lildude** to help with this).
    This ensures we're not misclassifying files.
 1. If the Bayesian classifier does a bad job with the sample `.yourextension` files then a [heuristic][] may need to be written to help.
-
 
 ## Adding a language
 
@@ -182,6 +173,12 @@ You can run the tests locally with:
 
 ```bash
 bundle exec rake test
+```
+
+If the tests indicate the samples are out of date, you can update them with:
+
+```bash
+bundle exec rake samples
 ```
 
 Sometimes getting the tests running can be too much work, especially if you don't have much Ruby experience.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -15,6 +15,10 @@ bundle config --local path vendor/gems
 
 bundle check > /dev/null 2>&1 || bundle install
 
+echo "==> Initialising submodules…"
 git submodule init
 git submodule sync --quiet
 script/fast-submodule-update
+
+echo "==> Generating samples…"
+bundle exec rake samples > /dev/null 2>&1


### PR DESCRIPTION
I create a new Codespace whenever I work on Linguist and continually forget the samples step.

There's no reason not to include this in `script/bootstrap` so that's what this PR does. As this isn't a required step anymore, I've removed that section from the CONTRIBUTING.md file too.

I've also tweaked the output slightly so you know what is being done.