### PR TITLE
Add language support for Mermaid diagrams

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -689,6 +689,9 @@
 [submodule "vendor/grammars/language-mcfunction"]
 	path = vendor/grammars/language-mcfunction
 	url = https://github.com/Arcensoth/language-mcfunction
+[submodule "vendor/grammars/language-mermaid"]
+	path = vendor/grammars/language-mermaid
+	url = https://github.com/Alhadis/language-mermaid.git
 [submodule "vendor/grammars/language-meson"]
 	path = vendor/grammars/language-meson
 	url = https://github.com/TingPing/language-meson

--- a/grammars.yml
+++ b/grammars.yml
@@ -649,6 +649,19 @@ vendor/grammars/language-maxscript:
 vendor/grammars/language-mcfunction:
 - markdown.mcfunction.codeblock
 - source.mcfunction
+vendor/grammars/language-mermaid:
+- source.mermaid
+- source.mermaid.c4c-diagram
+- source.mermaid.class-diagram
+- source.mermaid.er-diagram
+- source.mermaid.flowchart
+- source.mermaid.gantt
+- source.mermaid.gitgraph
+- source.mermaid.pie-chart
+- source.mermaid.requirement-diagram
+- source.mermaid.sequence-diagram
+- source.mermaid.state-diagram
+- source.mermaid.user-journey
 vendor/grammars/language-meson:
 - source.meson
 vendor/grammars/language-msl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3958,6 +3958,17 @@ Mercury:
   - ".moo"
   tm_scope: source.mercury
   language_id: 229
+Mermaid:
+  type: markup
+  color: "#ff3670"
+  aliases:
+  - mermaid example
+  extensions:
+  - ".mmd"
+  - ".mermaid"
+  tm_scope: source.mermaid
+  ace_mode: text
+  language_id: 385992043
 Meson:
   type: programming
   color: "#007800"
@@ -4574,7 +4585,7 @@ Open Policy Agent:
   tm_scope: source.rego
 OpenAPI Specification v2:
   aliases:
-    - oasv2
+  - oasv2
   type: data
   color: "#85ea2d"
   tm_scope: none
@@ -4582,7 +4593,7 @@ OpenAPI Specification v2:
   language_id: 848295328
 OpenAPI Specification v3:
   aliases:
-    - oasv3
+  - oasv3
   type: data
   color: "#85ea2d"
   tm_scope: none
@@ -4667,7 +4678,7 @@ Option List:
   - ackrc
   filenames:
   - ".ackrc"
-  - "ackrc"
+  - ackrc
   tm_scope: source.opts
   ace_mode: sh
   codemirror_mode: shell
@@ -4917,7 +4928,7 @@ Perl:
   - ".psgi"
   - ".t"
   filenames:
-  - .latexmkrc
+  - ".latexmkrc"
   - Makefile.PL
   - Rexfile
   - ack

--- a/samples/Mermaid/c4c-diagram.mermaid
+++ b/samples/Mermaid/c4c-diagram.mermaid
@@ -1,0 +1,42 @@
+C4Context
+	title System Context diagram for Internet Banking System
+	Enterprise_Boundary(b0, "BankBoundary0") {
+		Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")
+		Person(customerB, "Banking Customer B")
+		Person_Ext(customerC, "Banking Customer C", "desc")
+
+		Person(customerD, "Banking Customer D", "A customer of the bank, <br/> with personal bank accounts.")
+
+		System(SystemAA, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")
+
+		Enterprise_Boundary(b1, "BankBoundary") {
+
+			SystemDb_Ext(SystemE, "Mainframe Banking System", "Stores all of the core banking information about customers, accounts, transactions, etc.")
+
+			System_Boundary(b2, "BankBoundary2") {
+				System(SystemA, "Banking System A")
+				System(SystemB, "Banking System B", "A system of the bank, with personal bank accounts. next line.")
+			}
+
+			System_Ext(SystemC, "E-mail system", "The internal Microsoft Exchange e-mail system.")
+			SystemDb(SystemD, "Banking System D Database", "A system of the bank, with personal bank accounts.")
+
+			Boundary(b3, "BankBoundary3", "boundary") {
+				SystemQueue(SystemF, "Banking System F Queue", "A system of the bank.")
+				SystemQueue_Ext(SystemG, "Banking System G Queue", "A system of the bank, with personal bank accounts.")
+			}
+		}
+	}
+
+	BiRel(customerA, SystemAA, "Uses")
+	BiRel(SystemAA, SystemE, "Uses")
+	Rel(SystemAA, SystemC, "Sends e-mails", "SMTP")
+	Rel(SystemC, customerA, "Sends e-mails to")
+
+	UpdateElementStyle(customerA, $fontColor="red", $bgColor="grey", $borderColor="red")
+	UpdateRelStyle(customerA, SystemAA, $textColor="blue", $lineColor="blue", $offsetX="5")
+	UpdateRelStyle(SystemAA, SystemE, $textColor="blue", $lineColor="blue", $offsetY="-10")
+	UpdateRelStyle(SystemAA, SystemC, $textColor="blue", $lineColor="blue", $offsetY="-40", $offsetX="-50")
+	UpdateRelStyle(SystemC, customerA, $textColor="red", $lineColor="red", $offsetX="-50", $offsetY="20")
+
+	UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")

--- a/samples/Mermaid/class-diagram.mermaid
+++ b/samples/Mermaid/class-diagram.mermaid
@@ -1,0 +1,24 @@
+classDiagram
+	Animal <|-- Duck
+	Animal <|-- Fish
+	Animal <|-- Zebra
+	Animal : +int age
+	Animal : +String gender
+	Animal: +isMammal()
+	Animal: +mate()
+	class Duck{
+		+String beakColor
+		+swim()
+		+quack()
+	}
+	class Fish {
+		-int sizeInFeet
+		-canEat()
+	}
+	class Zebra{
+		+bool is_wild
+		+run()
+	}
+
+	callback Duck callback "Tooltip"
+	link Zebra "https://www.github.com" "This is a link"

--- a/samples/Mermaid/er-diagram.mmd
+++ b/samples/Mermaid/er-diagram.mmd
@@ -1,0 +1,15 @@
+erDiagram
+	CAR ||--o{ NAMED-DRIVER : allows
+	CAR {
+		string allowedDriver FK "The license of the allowed driver"
+		string registrationNumber
+		string make
+		string model
+	}
+	PERSON ||--o{ NAMED-DRIVER : is
+	PERSON {
+		string driversLicense PK "The license #"
+		string firstName
+		string lastName
+		int age
+	}

--- a/samples/Mermaid/flowchart.mmd
+++ b/samples/Mermaid/flowchart.mmd
@@ -1,0 +1,5 @@
+flowchart LR
+	A[Hard edge] -->|Link text| B(Round edge)
+	B --> C{Decision}
+	C -->|One| D[Result one]
+	C -->|Two| E[Result two]

--- a/samples/Mermaid/gantt.mmd
+++ b/samples/Mermaid/gantt.mmd
@@ -1,0 +1,37 @@
+gantt
+	dateFormat  YYYY-MM-DD %% Comment
+	title       Adding Gantt diagram functionality to Mermaid
+	
+	%% `excludes` accepts specific dates in YYYY-MM-DD format, days of
+	%% the week ("sunday") or "weekends", but not the word "weekdays".
+	excludes    weekends
+
+	todayMarker stroke-width:5px,stroke:#0f0,opacity:0.5
+	todayMarker off
+	inclusiveEndDates
+	topAxis
+	
+	section A section
+	Completed task            :done,    des1, 2014-01-06,2014-01-08
+	Active task               :active,  des2, 2014-01-09, 3d
+	Future task               :         des3, after des2, 5d
+	Future task2              :         des4, after des3, 5d
+
+	section Critical tasks
+	Completed task in the critical line :crit, done, 2014-01-06,24h
+	Implement parser and jison          :crit, done, after des1, 2d
+	Create tests for parser             :crit, active, 3d
+	Future task in critical line        :crit, 5d
+	Create tests for renderer           :2d
+	Add to mermaid                      :1d
+	Functionality added                 :milestone, 2014-01-25, 0d
+
+	section Documentation
+	Describe Gantt syntax               :active, a1, after des1, 3d
+	Add gantt diagram to demo page      :after a1  , 20h
+	Add another diagram to demo page    :doc1, after a1  , 48h
+
+	section Last section
+	Describe Gantt syntax               :after doc1, 3d
+	Add gantt diagram to demo page      :20h
+	Add another diagram to demo page    :48h

--- a/samples/Mermaid/gitgraph.mmd
+++ b/samples/Mermaid/gitgraph.mmd
@@ -1,0 +1,17 @@
+%%{init: { 'logLevel': 'debug', 'theme': 'default' , 'themeVariables': {
+	'tagLabelColor': '#ff0000',
+	'tagLabelBackground': '#00ff00',
+	'tagLabelBorder': '#0000ff'
+}}}%%
+gitGraph
+	commit
+	branch develop
+	commit tag:"v1.0.0"
+	commit
+	checkout main
+	commit type: HIGHLIGHT
+	commit
+	merge develop
+	commit
+	branch featureA
+	commit

--- a/samples/Mermaid/pie-chart.mermaid
+++ b/samples/Mermaid/pie-chart.mermaid
@@ -1,0 +1,13 @@
+pie showData
+	title Alhadis's ancestry composition, according to 23andme.com
+
+	%% NB: Values are expressed as percentages
+	"British & Irish" : 44.8
+	"French & German" : 7.3
+	"Scandinavian" : 1.8
+	"Broadly Northwestern European" : 12.5
+	"Eastern European" : 16.2
+	"Greek & Balkan": 8.0
+	"Italian" : 2.0
+	"Broadly Southern European": 2.2
+	"Broadly European": 5.2

--- a/samples/Mermaid/requirement-diagram.mermaid
+++ b/samples/Mermaid/requirement-diagram.mermaid
@@ -1,0 +1,71 @@
+requirementDiagram
+	%% Obligatory comment
+
+	requirement test_req {
+		%% Comment
+		id: 1
+		text: the test text.
+		risk: high
+		verifymethod: test
+	}
+
+	functionalRequirement test_req2 {
+		id: 1.1
+		text: the second test text.
+		risk: low
+		verifymethod: inspection
+	}
+
+	performanceRequirement test_req3 {
+		id: 1.2
+		text: the third test text.
+		risk: medium
+		verifymethod: demonstration
+	}
+
+	interfaceRequirement test_req4 {
+		id: 1.2.1
+		text: the fourth test text.
+		risk: medium
+		verifymethod: analysis
+	}
+
+	physicalRequirement test_req5 {
+		id: 1.2.2
+		text: the fifth test text.
+		risk: medium
+		verifyMethod: analysis
+	}
+
+	designConstraint test_req6 {
+		id: 1.2.3
+		text: the sixth test text.
+		risk: medium
+		verifymethod: analysis
+	}
+
+	element test_entity {
+		%% Another comment
+		type: simulation
+	}
+
+	element test_entity2 {
+		type: word doc
+		docRef: reqs/test_entity
+	}
+
+	element test_entity3 {
+		type: "test suite"
+		docRef: github.com/all_the_tests
+	}
+
+
+	test_entity - satisfies -> test_req2
+	test_req - traces -> test_req2
+	test_req - contains -> test_req3
+	test_req3 - contains -> test_req4
+	test_req4 - derives -> test_req5
+	test_req5 - refines -> test_req6
+	test_entity3 - verifies -> test_req5
+	test_req <- copies - test_entity2
+	not - traumatises -> valid

--- a/samples/Mermaid/sequence-diagram.mmd
+++ b/samples/Mermaid/sequence-diagram.mmd
@@ -1,0 +1,8 @@
+sequenceDiagram
+	participant Alice
+	participant John
+	links Alice: {"Dashboard": "https://dashboard.contoso.com/alice", "Wiki": "https://wiki.contoso.com/alice"}
+	links John: {"Dashboard": "https://dashboard.contoso.com/john", "Wiki": "https://wiki.contoso.com/john"}
+	Alice->>John: Hello John, how are you?
+	John-->>Alice: Great!
+	Alice-)John: See you later!

--- a/samples/Mermaid/state-diagram.mmd
+++ b/samples/Mermaid/state-diagram.mmd
@@ -1,0 +1,17 @@
+stateDiagram-v2
+	direction LR
+	[*] --> Active
+
+	state Active {
+		[*] --> NumLockOff
+		NumLockOff --> NumLockOn : EvNumLockPressed
+		NumLockOn --> NumLockOff : EvNumLockPressed
+		--
+		[*] --> CapsLockOff
+		CapsLockOff --> CapsLockOn : EvCapsLockPressed
+		CapsLockOn --> CapsLockOff : EvCapsLockPressed
+		--
+		[*] --> ScrollLockOff
+		ScrollLockOff --> ScrollLockOn : EvScrollLockPressed
+		ScrollLockOn --> ScrollLockOff : EvScrollLockPressed
+	}

--- a/samples/Mermaid/user-journey.mmd
+++ b/samples/Mermaid/user-journey.mmd
@@ -1,0 +1,9 @@
+journey
+	title My working day
+	section Go to work
+		Make tea: 5: Me
+		Go upstairs: 3: Me
+		Do work: 1: Me, Cat
+	section Go home
+		Go downstairs: 5: Me
+		Sit down: 5: Me

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -315,6 +315,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Maven POM:** [textmate/maven.tmbundle](https://github.com/textmate/maven.tmbundle)
 - **Max:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)
 - **Mercury:** [sebgod/mercury-tmlanguage](https://github.com/sebgod/mercury-tmlanguage)
+- **Mermaid:** [Alhadis/language-mermaid](https://github.com/Alhadis/language-mermaid)
 - **Meson:** [TingPing/language-meson](https://github.com/TingPing/language-meson)
 - **Metal:** [textmate/c.tmbundle](https://github.com/textmate/c.tmbundle)
 - **Microsoft Visual Studio Solution:** [Nixinova/NovaGrammars](https://github.com/Nixinova/NovaGrammars)

--- a/vendor/licenses/git_submodule/language-mermaid.dep.yml
+++ b/vendor/licenses/git_submodule/language-mermaid.dep.yml
@@ -1,0 +1,23 @@
+---
+name: language-mermaid
+version: 1cd1997642b11a551bc415e8833f33c55850158f
+type: git_submodule
+homepage: https://github.com/Alhadis/language-mermaid.git
+license: isc
+licenses:
+- sources: LICENSE.md
+  text: |
+    Copyright (c) 2022, John Gardner
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+notices: []


### PR DESCRIPTION
## Description
This PR adds formal support for Mermaid diagrams, which are already recognised by GitHub's markup processor:

~~~html
<pre lang="mermaid"><code>flowchart LR
	A[Hard edge] -->|Link text| B(Round edge)
	B --> C{Decision}
	C -->|One| D[Result one]
	C -->|Two| E[Result two]</code></pre>
~~~

<pre lang="mermaid"><code>flowchart LR
	A[Hard edge] -->|Link text| B(Round edge)
	B --> C{Decision}
	C -->|One| D[Result one]
	C -->|Two| E[Result two]</code></pre>

I've included `mermaid example` as an alias so that snippets of Mermaid source can be embeddedand highlighted without being physically rendered. It's already in-use by Mermaid's [docs][2].

@lildude I'm gauchely assuming that both the `.mmd` and `.mermaid` extensions satisfy our popularity requirements. Correct me if I'm wrong. :wink:

## Checklist:
-	[x] **I am adding a new language.**
	-	[x] **The extension of the new language is used in hundreds of repositories**  
		Probably. See the \@mention above.
		- **Search results for each extension:**
			- `.mmd`:    [~10,572 results](https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Ammd+NOT+nothack)
			- `.mermaid` [~810 results](https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Amermaid+NOT+nothack)
	-	[x] **I have included a real-world usage sample for all extensions added in this PR**  
		Each sample was either taken from Mermaid's [documentation](https://github.com/mermaid-js/mermaid/tree/f4bb978a8742f7ffca1bd7e65b4ad5ea1825ba4b/docs) (which is [MIT-licensed][2]), or written by yours truly during development of [`Alhadis/language-mermaid`][1].
	-	[x] **I have included a [syntax highlighting grammar][1]**
	-	[ ] ~~I have updated the heuristics to distinguish my language from others using the same extension.~~

[1]: https://github.com/Alhadis/language-mermaid
[2]: https://github.com/mermaid-js/mermaid/blob/93fa3f018f998d7646a5fd3788b9f9f53421eacf/LICENSE
