### PR TITLE
Fix invalid markup in WebVTT sample

### DIFF
--- a/samples/WebVTT/Godfather-Restaurant-Scene.vtt
+++ b/samples/WebVTT/Godfather-Restaurant-Scene.vtt
@@ -1,5 +1,7 @@
 WEBVTT Language: en-US
 
+NOTE The timecode below needs to start at 01:24:32.732
+
 01:20:37.600 --> 01:20:39.764
 <v McCluskey>How's the Italian food in this restaurant?
 
@@ -28,6 +30,7 @@ a botched translation attempt of this scene: https://youtu.be/AKBcRU5tPco
 <v Sollozzo><lang scn>Mi dispiace—</lang>
 <i.translation>[I'm sorry about—]</i>
 
+01:21:28.000 --> 01:21:29.381
 <v Michael><lang scn>U Sai.</lang>
 <i.translation>[Forget it.]</i>
 

--- a/samples/WebVTT/Russian-Sleep-Experiment.vtt
+++ b/samples/WebVTT/Russian-Sleep-Experiment.vtt
@@ -1,0 +1,564 @@
+WEBVTT
+Kind: captions
+Language: en
+
+NOTE
+The short film from which these subtitles were taken
+can be found on YouTube: http://youtu.be/zr4C_cLgXR0
+
+00:02:38.400 --> 00:02:45.239
+<v Scientist>Good evening, please state your name, age and weight.
+
+00:02:45.239 --> 00:02:50.910
+<v Felix>Felix Nast, age 41 years, 58 kilos.
+
+00:02:50.910 --> 00:02:57.439
+<v Ulrich>Ulrich Shultz, age 29, 71 kilos.
+
+00:02:57.439 --> 00:03:03.260
+<v Hanz>Hanz Berlitz, age 19, 68 kilos.
+
+00:03:03.260 --> 00:03:05.470
+<v Scientist>Very good.
+
+00:03:05.470 --> 00:03:10.900
+<v Scientist>You gentlemen are about to undergo an experiment
+that will benefit the soldiers of the Soviet Union.
+
+00:03:12.480 --> 00:03:17.709
+<v Scientist>You will be given a gas that our nations leading
+scientists have been working on.
+
+00:03:17.709 --> 00:03:22.769
+<v Scientist>All we know is that it is not lethal and you
+will be in no physical harm throughout the
+
+00:03:22.769 --> 00:03:26.760
+<v Scientist>duration of the experiment.
+
+00:03:26.760 --> 00:03:28.819
+<v Scientist>Upon completion of this experiment.
+
+00:03:28.819 --> 00:03:33.129
+<v Scientist>You will be granted your freedom and returned
+to your homeland.
+
+00:03:33.129 --> 00:03:35.860
+<v Scientist>Do you comply?
+
+00:03:35.860 --> 00:03:41.720
+<v Scientist>Reminder, those who do not comply will be
+immediately executed for your crimes against
+
+00:03:41.720 --> 00:03:47.400
+<v Scientist>humanity and the Soviet Union.
+
+00:03:47.400 --> 00:03:50.700
+<v Scientist>I'll ask you once more gentlemen, do you comply?
+
+00:03:52.880 --> 00:03:54.060
+<v Scientist>Very good.
+
+00:03:55.120 --> 00:03:59.180
+<v Scientist>We will administer the gas in a few moments.
+
+00:03:59.190 --> 00:04:03.700
+<v Scientist>Please, get acquainted with your new home.
+
+00:04:13.800 --> 00:04:17.510
+<v Scientist>You will all notice that you have enough food
+for the duration of the experiment.
+
+00:04:18.440 --> 00:04:23.400
+<v Scientist>You will find comfort on the floor as you
+had in your cell.
+
+00:04:23.400 --> 00:04:28.080
+<v Scientist>Books for entertainment, a toilet for the obvious.
+
+00:04:28.740 --> 00:04:34.660
+<v Scientist>Also, no one will be entering the room once
+the gas has been released so it is up to you
+
+00:04:34.660 --> 00:04:38.740
+<v Scientist>to keep your living quarters, liveable.
+
+00:04:40.180 --> 00:04:42.160
+<v Scientist>The gas has been administered.
+
+00:04:53.800 --> 00:04:59.140
+<v Felix>Sure is different on the other side of the gas.
+
+00:04:59.560 --> 00:05:03.100
+<v Scientist>Day one, the first batch of gas has been released.
+
+00:05:03.100 --> 00:05:03.600
+<v Scientist>Normal behaviour resumes.
+
+00:05:33.780 --> 00:05:39.600
+<v Felix>Boy, your name is Hanz?
+
+00:05:39.620 --> 00:05:41.560
+<v Hanz>Yes.
+
+00:05:41.560 --> 00:05:47.760
+<v Felix>Well Hanz, it is so nice to see the face of
+the boy who has been crying in the cell next
+
+00:05:47.800 --> 00:05:51.840
+<v Felix>to me the past three months.
+
+00:05:54.040 --> 00:06:00.800
+<v Felix>Oh come on now, don't you think we should
+all be friends while we are here?
+
+00:06:02.160 --> 00:06:12.000
+<v Felix>Let me guess, your father was a good hard
+working man taken too soon.
+
+00:06:12.000 --> 00:06:17.560
+<v Felix>Your mother was a housekeeper.
+
+00:06:17.560 --> 00:06:24.640
+<v Felix>And you were the youngest of four children,
+the runt of the pack.
+
+00:06:24.640 --> 00:06:30.840
+<v Felix>You joined the war to prove something of yourself
+only to end up a victim of circumstance.
+
+00:06:30.840 --> 00:06:33.680
+<v Felix>Am I right?
+
+00:06:33.680 --> 00:06:37.070
+<v Hanz>I was the youngest of three children.
+
+00:06:37.080 --> 00:06:40.600
+<v Felix>Ah, I was close.
+
+00:06:40.600 --> 00:06:49.600
+<v Felix>What about you, Ulrich is it?
+
+00:06:49.720 --> 00:06:56.000
+<v Felix>Well Hanz, I will tell you my story if you
+tell me yours.
+
+00:06:56.020 --> 00:06:57.980
+<v Hanz>Ok.
+
+00:06:57.980 --> 00:07:10.030
+<v Felix>Well, I was a top SS scientist specialising
+in information extraction and experimentation.
+
+00:07:10.030 --> 00:07:13.170
+<v Felix>I took great pride in my work.
+
+00:07:13.170 --> 00:07:17.880
+<v Felix>It was almost therapeutic.
+
+00:07:17.880 --> 00:07:22.020
+<v Felix>I can still see the faces of the men.
+
+00:07:22.020 --> 00:07:25.280
+<v Felix>I extracted fingernails, teeth.
+
+00:07:26.800 --> 00:07:32.960
+<v Felix>How quickly they would rat out their own families
+to save their lives.
+
+00:07:32.960 --> 00:07:37.920
+<v Felix>Ah, such lowly dogs.
+
+00:07:40.600 --> 00:07:42.840
+<v Felix>Your turn.
+
+00:07:42.840 --> 00:07:48.600
+<v Hanz>I was stationed just outside of Berlin.
+
+00:07:48.600 --> 00:07:55.930
+<v Hanz>I didn't see much of the war, just the end of it.
+
+00:07:55.930 --> 00:07:59.120
+<v Hanz>I was appointed guard duty one night,
+
+00:07:59.120 --> 00:08:15.250
+<v Hanz>and I was supposed to stay awake for the
+duration of the night, but I fell asleep.
+
+00:08:15.250 --> 00:08:26.200
+<v Hanz>When I awoke, everyone was slaughtered.
+
+00:08:26.200 --> 00:08:41.320
+<v Hanz>I ran as fast and as far as I could but they
+caught me. Took me to a prison where I sat
+
+00:08:41.320 --> 00:08:47.160
+<v Hanz>for three months until I ended up here.
+
+00:08:47.160 --> 00:08:51.840
+<v Felix>I thought as much.
+
+00:08:55.240 --> 00:08:59.040
+<v Hanz>Whats your story?
+
+00:09:15.000 --> 00:09:20.680
+<v Scientist>The gas has been active for four days, and
+although none of them have slept for the past
+
+00:09:20.720 --> 00:09:24.320
+<v Scientist>four days, normal behaviour resumes.
+
+00:09:24.320 --> 00:09:27.920
+<v Scientist>The gas seems to be quite effective.
+
+00:09:39.320 --> 00:09:44.280
+<v Felix>These anatomy books are embarrassingly inaccurate.
+
+00:09:44.880 --> 00:09:48.880
+<v Felix>It is no wonder these Russians are so barbaric.
+
+00:09:54.800 --> 00:09:59.520
+<v Felix>They killed your father, didn't they?
+
+00:10:03.000 --> 00:10:03.500
+<v Felix><lang de>Bitte!</lang>
+
+00:10:03.720 --> 00:10:04.220
+<v Scientist><i>Ulrich Shultz!</i>
+
+00:10:04.720 --> 00:10:05.220
+<v Hanz>Ulrich!
+
+00:10:05.560 --> 00:10:09.080
+<v Scientist><i>Put Felix Nast down now or we will end
+the experiment and you will be shot!</i>
+
+00:10:09.700 --> 00:10:10.700
+<v Hanz>Stop this or they will shoot you!
+
+00:10:10.980 --> 00:10:13.320
+<v Ulrich>You talk too much.
+
+00:10:17.920 --> 00:10:18.500
+<v Hanz>Ulrich!
+
+00:10:50.280 --> 00:10:52.920
+<v Scientist>The gas has been active for seven days.
+
+00:10:53.520 --> 00:10:57.360
+<v Scientist>Normal behaviour resumes outside of the
+outburst on day four.
+
+00:10:58.680 --> 00:11:01.100
+<v Scientist>The men have still yet to sleep.
+
+00:11:04.960 --> 00:11:07.640
+<v Scientist>Time for some personal business.
+
+00:11:30.080 --> 00:11:33.840
+<v Hanz>Hey, what happened the other day?
+
+00:11:34.340 --> 00:11:37.000
+<v Ulrich>I almost killed Felix.
+
+00:11:37.000 --> 00:11:38.380
+<v Ulrich>What's happened with you?
+
+00:11:40.620 --> 00:11:43.240
+<v Hanz>You know what I mean.
+
+00:11:44.060 --> 00:11:46.000
+<v Hanz>No one intervened.
+
+00:11:46.000 --> 00:11:48.340
+<v Hanz>No one stopped you.
+
+00:11:48.660 --> 00:11:53.640
+<v Hanz>You just, you just looked at the wall and
+dropped him.
+
+00:11:55.380 --> 00:11:59.620
+<v Hanz>What did you see?
+
+00:12:05.120 --> 00:12:10.920
+<v Hanz>Look, at least tell me your story.
+
+00:12:10.920 --> 00:12:14.660
+<v Hanz>Everyone's got a story.
+
+00:12:25.420 --> 00:12:34.820
+<v Ulrich>I was a soldier, and like you,
+not a very good one.
+
+00:12:35.940 --> 00:12:46.220
+<v Ulrich>I wasn't cruel in what I did but what I
+stood for was damning enough, I suppose.
+
+00:12:47.020 --> 00:12:53.220
+<v Ulrich>What we all stood for was damning enough.
+
+00:12:54.020 --> 00:12:58.140
+<v Ulrich>I was stationed at a camp, a labour camp.
+
+00:12:58.140 --> 00:13:02.240
+<v Ulrich>My father was the commanding officer of the
+camp.
+
+00:13:03.080 --> 00:13:13.940
+<v Ulrich>He was a good man as I remember from my
+childhood, but something… changed in him.
+
+00:13:16.080 --> 00:13:23.880
+<v Ulrich>I went to his office one day to deliver a
+daily report.
+
+00:13:25.300 --> 00:13:32.560
+<v Ulrich>I opened the door and he had his back turned to me.
+
+00:13:32.740 --> 00:13:39.580
+<v Ulrich>I called to him but he didn't answer.
+
+00:13:39.580 --> 00:13:49.640
+<v Ulrich>He just put the barrel of his Luger and he…
+
+00:13:55.100 --> 00:14:02.920
+<v Ulrich>If there was one thing I could have
+asked him it would be why?
+
+00:14:04.500 --> 00:14:12.280
+<v Ulrich>Was it fear, was it remorse, was it grief?
+
+00:14:18.200 --> 00:14:19.320
+<v Ulrich>That's why I tried…
+
+00:14:19.320 --> 00:14:26.680
+<v Hanz>Ulrich, I don't know how much
+more of this I can take.
+
+00:14:28.620 --> 00:14:31.340
+<v Hanz>I haven't slept in days.
+
+00:14:33.220 --> 00:14:34.520
+<v Ulrich>None of us have.
+
+00:14:34.920 --> 00:14:37.060
+<v Ulrich>It must be what the gas does.
+
+00:14:39.440 --> 00:14:41.140
+<v Ulrich>It keeps you awake.
+
+00:14:42.040 --> 00:14:48.060
+<v Ulrich>They're going to use it on their soldiers
+so they don't require sleep.
+
+00:14:49.220 --> 00:14:52.220
+<v Hanz>I can't do this anymore.
+
+00:14:52.230 --> 00:14:56.540
+<v Hanz>I can't breathe in my own skin.
+
+00:14:56.540 --> 00:15:00.639
+<v Hanz>I have to get out of here.
+
+00:15:00.640 --> 00:15:07.360
+<v Ulrich>Just think of your freedom, that's
+what's keeping me going.
+
+00:15:09.420 --> 00:15:17.560
+<v Hanz>You really think we'll be gifted freedom after this?
+
+00:15:30.440 --> 00:15:35.820
+<v Scientist>Day 12, Hanz has been screaming for the past 7 hours.
+
+00:15:38.240 --> 00:15:42.600
+<v Scientist>What seems strange is that the other
+men have not reacted in anyway.
+
+00:15:47.180 --> 00:15:51.000
+<v Scientist>Hanz has been screaming now for the past 12 hours.
+
+00:15:51.480 --> 00:15:56.640
+<v Scientist>His screams have been replaced with a faint
+whimper. It seems he has permanently destroyed
+
+00:15:56.649 --> 00:16:00.170
+<v Scientist>his vocal cords.
+
+00:16:00.170 --> 00:16:10.220
+<v Scientist>Sleep Experiment day 12 June 14th 1945, end log.
+
+00:16:20.160 --> 00:16:21.520
+<v Scientist>Ah, Felix.
+
+00:16:23.800 --> 00:16:25.803
+<v Scientist>You've come to say hello?
+
+00:16:25.803 --> 00:16:27.603
+<v Scientist><i>Felix, Felix, Felix…</i>
+
+00:16:44.240 --> 00:16:47.580
+<v Scientist>What are you thinking Felix?
+
+00:16:50.580 --> 00:16:55.360
+<v Scientist>That's why you're in there, and I'm out here.
+
+00:17:14.600 --> 00:17:17.600
+<v Scientist><i>Felix, Felix, Felix…</i>
+
+00:17:32.640 --> 00:17:36.240
+<v Scientist>Sleep Experiment, day 15.
+
+00:17:40.460 --> 00:17:42.060
+<v Scientist>Day 15…
+
+00:17:49.580 --> 00:17:52.180
+<v Scientist>Sleep Experiment.
+
+00:19:12.000 --> 00:19:15.080
+<v Scientist>Felix! I demand the papers removed from the window!
+
+00:19:18.880 --> 00:19:20.100
+<v Scientist>Felix!
+
+00:19:20.540 --> 00:19:21.680
+<v Scientist>Remove the paper!
+
+00:19:23.020 --> 00:19:24.020
+<v Scientist>Felix!
+
+00:19:26.940 --> 00:19:34.800
+<v Scientist>Day 15, Felix has covered the port window
+with paper from the book in what appears to
+
+00:19:34.800 --> 00:19:37.320
+<v Scientist>be his own excrement.
+
+00:19:37.320 --> 00:19:42.780
+<v Scientist>Strange noises have been coming from inside
+the cell, but the oxygen levels show that the
+
+00:19:42.780 --> 00:19:46.560
+<v Scientist>men are still awake and alive.
+
+00:19:47.060 --> 00:19:50.840
+<v Scientist>I'm not sure how much longer the experiment can go on.
+
+00:19:50.860 --> 00:19:56.960
+<v Scientist>Experiment day 15, June 17th 1945.
+
+00:20:01.940 --> 00:20:05.440
+<v Scientist><i>Gentlemen, the experiment is over.</i>
+
+00:20:05.440 --> 00:20:09.860
+<v Scientist><i>We are turning off the gas and opening the chamber.</i>
+
+00:20:09.860 --> 00:20:13.700
+<v Scientist>Stand back against the wall or you will be shot.
+
+00:20:13.700 --> 00:20:16.760
+<v Scientist>Upon examination you will be freed.
+
+00:20:18.100 --> 00:20:22.860
+<v Felix>We no longer wish to be freed.
+
+00:20:47.400 --> 00:20:52.480
+<v Scientist><i>Day 20 of the Sleep Experiment.</i>
+
+00:20:52.480 --> 00:20:59.540
+<v Scientist><i>Upon opening the chamber it became clear the
+level of mental damage caused by the gas.</i>
+
+00:20:59.540 --> 00:21:03.820
+<v Scientist><i>The men have ripped into their own flesh.</i>
+
+00:21:03.820 --> 00:21:10.540
+<v Scientist><i>The amount of blood lost by the three
+men should have killed them all.</i>
+
+00:21:11.500 --> 00:21:14.060
+<v Scientist><i>Hanz was rushed to the emergency room.</i>
+
+00:21:15.280 --> 00:21:19.900
+<v Scientist><i>He tried to utter words but his torn vocal
+cords allowed only a weak whisper.</i>
+
+00:21:21.520 --> 00:21:27.840
+<v Scientist><i>After fighting to stay awake under the anaesthesia,
+he died on the operating table,</i>
+
+00:21:27.840 --> 00:21:29.720
+<v Scientist><i>11:45 PM.</i>
+
+00:21:31.580 --> 00:21:37.400
+<v Scientist><i>Felix was sent to the emergency room. He begged
+to be put back on the gas and screamed in</i>
+
+00:21:37.400 --> 00:21:43.620
+<v Scientist><i>agonising pain when we brought the anaesthesia
+anywhere near him.</i>
+
+00:21:43.620 --> 00:21:47.520
+<v Scientist><i>We then attempted the surgery without it.</i>
+
+00:21:47.520 --> 00:21:50.400
+<v Scientist><i>He died the second his eyes closed from fatigue,</i>
+
+00:21:51.300 --> 00:21:52.700
+<v Scientist><i>12:14 AM.</i>
+
+00:21:55.220 --> 00:21:59.020
+<v Scientist><i>I left Ulrich in the chamber to be alone with me.</i>
+
+00:22:00.640 --> 00:22:02.420
+<v Scientist><i>I needed answers.</i>
+
+00:22:06.080 --> 00:22:10.040
+<v Scientist>Ulrich, what happened?
+
+00:22:11.540 --> 00:22:12.980
+<v Scientist>What did you do?
+
+00:22:21.040 --> 00:22:23.800
+<v Ulrich>Hell could not wait for these men.
+
+00:22:26.240 --> 00:22:28.700
+<v Ulrich>The doctor sicker than his patients.
+
+00:22:29.700 --> 00:22:34.800
+<v Ulrich>The boy allowing his own kind to perish
+on account of his own negligence.
+
+00:22:35.280 --> 00:22:39.420
+<v Ulrich>The man who blindly follows evil
+for the sake of convenience.
+
+00:22:45.180 --> 00:22:51.800
+<v Ulrich>Without the fortitude of unconsciousness,
+all men will share this fate.
+
+00:22:54.180 --> 00:22:57.480
+<v Scientist>What are you?
+
+00:23:05.180 --> 00:23:06.340
+<v Ulrich>I'm awake.
+
+00:23:11.160 --> 00:23:12.960
+<v Ulrich>I'm awake.
+
+00:23:54.520 --> 00:24:03.440
+<v Scientist>Whether or not you believe these men
+deserve this fate is irrelevant.
+
+00:24:03.440 --> 00:24:07.220
+<v Scientist>No man can decide this.
+
+00:24:07.220 --> 00:24:13.420
+<v Scientist>I only hope the world will forgive
+my part in this experiment.
+
+00:24:16.820 --> 00:24:27.920
+<v Scientist>What these men did will be forever written in
+history but I can still erase what I've done.
+
+00:24:27.920 --> 00:24:34.720
+<v Scientist>End log, June 22nd 1945.


### PR DESCRIPTION
## Description
I erroneously omitted a timecode from the `.vtt` sample I added in [`#4536`](https://github.com/github/linguist/pull/4536). This wasn't a valid WebVTT file (according to an [online validator](https://w3c.github.io/webvtt.js/parser.html)), so in the interests of being correct and complete, I've fixed my silly oversight.

Also included is a second `.vtt` sample, which was transcribed by yours truly from the dialogue of a [YouTube video](http://youtu.be/zr4C_cLgXR0).

## Checklist
*(Template removed as it doesn't apply).*