### PR TITLE
Add ".plt" to Prolog extensions along with sample

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5127,6 +5127,7 @@ Prolog:
   color: "#74283c"
   extensions:
   - ".pl"
+  - ".plt"
   - ".pro"
   - ".prolog"
   - ".yap"

--- a/samples/Prolog/plunit_test_example.plt
+++ b/samples/Prolog/plunit_test_example.plt
@@ -1,0 +1,11 @@
+:- use_module(library(plunit)).
+
+:- begin_tests(plunit_test_example).
+
+test(true_succeeds) :-
+  true.
+
+test(fail_fails, [fail]) :-
+  fail.  % Interchangeable with false/0.
+
+:- end_tests(plunit_test_example).


### PR DESCRIPTION
.plt files are used by Gnuplot for saved plots, and by SWI-Prolog (and probably SICSTUS Prolog) for PlUnit tests. Most seem to be misclassified as Gnuplot.

I can add a simple ":-\s?begin_tests" heuristic, but hopefully the classifier will pick up on the vastly different syntax.