### PR TITLE
Add `mocha.opts` to option-list filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4668,6 +4668,7 @@ Option List:
   filenames:
   - ".ackrc"
   - "ackrc"
+  - "mocha.opts"
   tm_scope: source.opts
   ace_mode: sh
   codemirror_mode: shell

--- a/samples/Option List/filenames/mocha.opts
+++ b/samples/Option List/filenames/mocha.opts
@@ -1,0 +1,6 @@
+--colors
+--recursive
+--reporter mochawesome
+--reporter-options reportDir=reports/mochawesome
+--require ./tools/testSetup
+--ui bdd


### PR DESCRIPTION
## Description
This PR adds `mocha.opts` to the list of filenames recognised as [generic option-lists][0].

Ideally, this really should've been included in [`#6088`][0], but because `mocha.opts` files have been deprecated by [Mocha][] for some time, I blindly assumed they wouldn't meet the usage requirements (hence, I didn't think to check). However, a code search for [`path:**/mocha.opts`][1] yields ~9,200 results, which likely spans 200 unique users.

## Checklist:
-	[x] **I am associating a language with a new filename**
	-	[x] **The new filename is used in hundreds of repositories**  
		[~9,200 repositories][1]
	-	[x] **I have included a real-world usage sample:**  
		- **Source:** [`hackoregon/civic/packages/2018/mocha.opts`](https://github.com/hackoregon/civic/blob/ce1dc98fff88b6ec63dc41714b6b0d4a50537a1b/packages/2018/mocha.opts)  
		- **License:** [MIT](https://github.com/hackoregon/civic/blob/1ed14caad0e901804fe60712d6352b91a7f3d7e8/LICENSE)
	- [ ] ~~I have included a change to the heuristics~~

[0]: https://github.com/github/linguist/pull/6088
[1]: https://cs.github.com/?scopeName=All+repos&scope=&q=path%3A**%2Fmocha.opts+NOT+nothack
[Mocha]: https://mochajs.org
