### PR TITLE
Add support for `.editorconfig` file extension

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1673,6 +1673,8 @@ EditorConfig:
   type: data
   color: "#fff1f2"
   group: INI
+  extensions:
+  - ".editorconfig"
   filenames:
   - ".editorconfig"
   aliases:

--- a/samples/EditorConfig/ASP.NET.EditorConfig
+++ b/samples/EditorConfig/ASP.NET.EditorConfig
@@ -1,0 +1,94 @@
+# ASP.NET Core EditorConfig file
+
+# NOTE: This file focuses on settings Visual Studio 2017 supports natively. For example, VS does not support insert_final_newline.
+# We do use it, but it's harder to enforce without a separate VS extension or an editor that supports it.
+# See https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options for more
+
+# Mark this file as the "root" for everything below this point. This means that editor config files above
+# this file will be ignored
+root = true
+
+# Default settings
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+insert_final_newline = true
+
+# Unix-only files
+[*.sh]
+end_of_line = lf
+
+# 2-space files
+[{*.json,*.yml}]
+indent_size = 2
+
+# .NET Code Style Settings
+# See https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+# REVIEW: Should these be errors? warnings? suggestions?
+[{*.cs,*.vb}]
+dotnet_sort_system_directives_first = true
+
+# Don't use 'this.'/'Me.' prefix for anything
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error
+
+# Use language keywords over framework type names for type references
+# i.e. prefer 'string' over 'String'
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
+
+# Prefer object/collection initializers
+# This is a suggestion because there are cases where this is necessary
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+
+# C# 7: Prefer using named tuple names over '.Item1', '.Item2', etc.
+dotnet_style_explicit_tuple_names = true:error
+
+# Prefer using 'foo ?? bar' over 'foo != null ? foo : bar'
+dotnet_style_coalesce_expression = true:error
+
+# Prefer using '?.' over ternary null checking where possible
+dotnet_style_null_propagation = true:error
+
+# Use 'var' in all cases where it can be used
+csharp_style_var_for_built_in_types = true:error
+csharp_style_var_when_type_is_apparent = true:error
+csharp_style_var_elsewhere = true:error
+
+# C# 7: Prefer using pattern matching over "if(x is T) { var t = (T)x; }" and "var t = x as T; if(t != null) { ... }"
+# REVIEW: Since this is a new C# 7 feature that replaces an existing pattern, I'm making it a suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+
+# C# 7: Prefer using 'out var' where possible
+# REVIEW: Since this is a new C# 7 feature that replaces an existing pattern, I'm making it a suggestion
+csharp_style_inlined_variable_declaration = true:error
+
+# C# 7: Use throw expressions when null-checking
+# @davidfowl hates them :)
+csharp_style_throw_expression = false:error
+
+# Prefer using "func?.Invoke(args)" over "if(func != null) { func(args); }"
+# REVIEW: Maybe an error?
+csharp_style_conditional_delegate_call = true:error
+
+# Newline settings
+# Unsure where docs are. Got these from https://github.com/dotnet/roslyn/blob/master/.editorconfig
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+
+# Prefer expression-bodied methods, constructors, operators, etc.
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = true:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion

--- a/samples/EditorConfig/IntelliJ.editorconfig
+++ b/samples/EditorConfig/IntelliJ.editorconfig
@@ -1,0 +1,39 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+ij_continuation_indent_size = 4
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = false
+ij_smart_tabs = false
+ij_wrap_on_typing = false
+
+[{*.cjs, *.js, *.karma}]
+ij_continuation_indent_size = 1
+ij_javascript_align_imports = false
+ij_javascript_align_multiline_for = true
+ij_javascript_align_multiline_parameters = true
+ij_javascript_align_multiline_parameters_in_calls = false
+ij_javascript_align_multiline_ternary_operation = false
+ij_javascript_align_object_properties = 0
+ij_javascript_align_union_types = false
+ij_javascript_align_var_statements = 1
+ij_javascript_assignment_wrap = on_every_item
+ij_javascript_binary_operation_sign_on_next_line = false
+ij_javascript_binary_operation_wrap = off
+ij_javascript_blacklist_imports = rxjs/Rx, node_modules/**, **/node_modules/**, @angular/material, @angular/material/typings/**
+
+[{*.yaml, *.yml, _algolia_api_key}]
+indent_size = 2
+ij_yaml_keep_indents_on_empty_lines = false
+ij_yaml_keep_line_breaks = true
+
+[{*.htm, *.html, *.sht, *.shtm, *.shtml}]
+ij_html_do_not_break_if_inline_tags = title, h1, h2, h3, h4, h5, h6, p
+ij_html_do_not_indent_children_of_tags = html, body, thead, tbody, tfoot


### PR DESCRIPTION
## Description
There appears to be [ample usage][1] of `.editorconfig` as a legitimate file extension, rather than a complete filename. This PR adds it as an extension to EditorConfig's language entry.

### Sidenotes
My initial approach was this…

~~~diff
diff --git a/lib/linguist/languages.yml b/lib/linguist/languages.yml
index ac5fe47d..5e7d9ea1 100644
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1675,8 +1675,6 @@ EditorConfig:
   group: INI
-  filenames:
+  extensions:
   - ".editorconfig"
   aliases:
   - editor-config
   ace_mode: ini
~~~

… however, [`test_samples.rb`](https://github.com/github/linguist/blob/16a7a528ab840dd24188edda671d31881a67e527/test/test_samples.rb#L40) got confused by the EditorConfig sample named `.editorconfig` (which ostensibly doesn't equate to a filename containing only an extension):
~~~
  1) Failure:
TestSamples#test_ext_or_shebang [/Users/Alhadis/Forks/GitHub-Linguist/test/test_samples.rb:40]:
/Users/Alhadis/Forks/GitHub-Linguist/samples/EditorConfig/.editorconfig should have a file extension or a shebang, maybe it belongs in filenames/ subdir

1654 runs, 33562 assertions, 1 failures, 0 errors, 0 skips
~~~

@lildude, please let me know if this is correct behaviour; if so, I'll stick with the less-than-D.R.Y approach I resorted to for this PR. :wink:


## Checklist
-	[x] **I am associating a language with a new file extension.**
	-	[x] **The new extension is used in hundreds of repositories:**  
		Code Search yields [~39,000 results][1] for `path:**/?*.editorconfig`.
	-	[x] **I have included real-world usage samples:**  
		**NB:** The latter sample was edited to eliminate a lot of repetitive and excessive data.
		- [[`ASP.NET.EditorConfig`](https://github.com/github/linguist/blob/b3b10c4d5feb6853a2d573bad6c445a8ce872319/samples/EditorConfig/ASP.NET.EditorConfig)]: [Source](https://github.com/Drawaes/Leto/blob/307a111cc1254e7d3435d10921a8550d2f146903/.EditorConfig) | [MIT-licensed](https://github.com/Drawaes/Leto/blob/47c3ff0216ee5929902b40111b3ce4bf9e8a123f/LICENSE)
		* [[`IntelliJ.editorconfig`](https://github.com/github/linguist/blob/b3b10c4d5feb6853a2d573bad6c445a8ce872319/samples/EditorConfig/IntelliJ.editorconfig)]: [Source](https://github.com/mallowigi/iconGenerator/blob/f5af5365520fa99e9551716439c95468c861177b/.editorconfig) | [Apache-2.0](https://github.com/mallowigi/iconGenerator/blob/30fdf5a550b8207aa88b82f452b9649362ec1f6d/LICENSE)
	-	[ ] ~~I have included a change to the heuristics~~

[1]: https://cs.github.com/?scopeName=All+repos&scope=&q=path%3A**%2F%3F*.editorconfig
