### PR TITLE
Update Ruby versions for CI: drop 2.5 & add 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.0', '2.7', '2.6' ]
+        ruby: [ '3.1', '3.0', '2.7', '2.6' ]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.0', '2.7', '2.6', '2.5' ]
+        ruby: [ '3.0', '2.7', '2.6' ]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby

--- a/test/test_samples.rb
+++ b/test/test_samples.rb
@@ -83,8 +83,8 @@ class TestSamples < Minitest::Test
         if language_matches.length > 1
           language_matches.each do |match|
             generic = Strategy::Extension.generic? extension
-            samples = generic ? "test/fixtures/Generic/#{extension.sub(/^\./, "")}/#{match.name}/*" : "samples/#{match.name}/*#{extension}"
-            assert Dir.glob(samples, File::FNM_CASEFOLD).any?, "Missing samples in #{samples.inspect}. See https://github.com/github/linguist/blob/master/CONTRIBUTING.md"
+            samples = generic ? "test/fixtures/Generic/#{extension.sub(/^\./, "")}/#{match.name}/*" : "samples/#{match.name}/*#{case_insensitive_glob(extension)}"
+            assert Dir.glob(samples).any?, "Missing samples in #{samples.inspect}. See https://github.com/github/linguist/blob/master/CONTRIBUTING.md"
           end
         end
       end
@@ -98,5 +98,13 @@ class TestSamples < Minitest::Test
         end
       end
     end
+  end
+  
+  def case_insensitive_glob(extension)
+    glob = ""
+    extension.each_char do |c|
+      glob += c.downcase != c.upcase ? "[#{c.downcase}#{c.upcase}]" : c
+    end
+    glob
   end
 end


### PR DESCRIPTION
## Description
Ruby 2.5 is already EOL, https://endoflife.software/programming-languages/server-side-scripting/ruby

Ruby 3.1 is now available too.

## Checklist:
N/A