### PR TITLE
Revert "Change grammar source for Svelte"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1108,7 +1108,7 @@
 	url = https://github.com/tenable/sublimetext-nasl
 [submodule "vendor/grammars/svelte-atom"]
 	path = vendor/grammars/svelte-atom
-	url = https://github.com/sveltejs/svelte-atom.git
+	url = https://github.com/umanghome/svelte-atom
 [submodule "vendor/grammars/swift.tmbundle"]
 	path = vendor/grammars/swift.tmbundle
 	url = https://github.com/textmate/swift.tmbundle

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -510,7 +510,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **SubRip Text:** [Alhadis/language-subtitles](https://github.com/Alhadis/language-subtitles)
 - **SugarSS:** [hudochenkov/Syntax-highlighting-for-PostCSS](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS)
 - **SuperCollider:** [supercollider/language-supercollider](https://github.com/supercollider/language-supercollider)
-- **Svelte:** [sveltejs/svelte-atom](https://github.com/sveltejs/svelte-atom)
+- **Svelte:** [umanghome/svelte-atom](https://github.com/umanghome/svelte-atom)
 - **Swift:** [textmate/swift.tmbundle](https://github.com/textmate/swift.tmbundle)
 - **SystemVerilog:** [TheClams/SystemVerilog](https://github.com/TheClams/SystemVerilog)
 - **TLA:** [tlaplus-community/tree-sitter-tlaplus](https://github.com/tlaplus-community/tree-sitter-tlaplus) 🐌


### PR DESCRIPTION
Reverts github/linguist#5963

This broke the syntax highlighting between `<(script|style|template)>` tags due to a really old limitation in the old prettylights highlighting engine which won't be fixed.

See https://github.com/github/linguist/discussions/6164 for more details.

This can be reverted back to the sveltejs/svelte-atom grammar once it has been updated to address this limitation or a production-ready tree-sitter grammar becomes available.

This PR will be merged early next week (w/c 28 Nov 2022) and a patch release made, unless the sveltejs/svelte-atom grammar is updated by then, in which case I'll pull the latest version of that grammar.

Fixes https://github.com/github/linguist/issues/6180