### PR TITLE
Add clarification for override using alias + case-insensitive

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -19,6 +19,9 @@ File and folder paths inside `.gitattributes` are calculated relative to the pos
 # Replace any whitespace in the language name with hyphens:
 *.glyphs linguist-language=OpenStep-Property-List
 
+# Language names are case-insensitive. Hence, the line above is equivalent to:
+*.glyphs linguist-language=openstep-property-list
+
 # You can also use an alias of the language (eg. js instead of JavaScript)
 *.cshtml linguist-language=js
 ```

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -18,6 +18,9 @@ File and folder paths inside `.gitattributes` are calculated relative to the pos
 
 # Replace any whitespace in the language name with hyphens:
 *.glyphs linguist-language=OpenStep-Property-List
+
+# You can also use an alias of the language (eg. js instead of JavaScript)
+*.cshtml linguist-language=js
 ```
 
 ### Summary

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -19,11 +19,11 @@ File and folder paths inside `.gitattributes` are calculated relative to the pos
 # Replace any whitespace in the language name with hyphens:
 *.glyphs linguist-language=OpenStep-Property-List
 
-# Language names are case-insensitive. Hence, the line above is equivalent to:
-*.glyphs linguist-language=openstep-property-list
-
-# You can also use an alias of the language (eg. js instead of JavaScript)
-*.cshtml linguist-language=js
+# Language names are case-insensitive and may be specified using an alias.
+# So, the following three lines are all functionally equivalent:
+*.es linguist-language=js
+*.es linguist-language=JS
+*.es linguist-language=JAVASCRIPT
 ```
 
 ### Summary


### PR DESCRIPTION
I noticed that it was possible to use an alias of the language for overrides [here](https://github.com/fafalone/LongLongHelper/commit/0e91ab04833e3d8236ea53eef94174b0363c8b1a), so thought it would be good to mention it in the docs.