### PR TITLE
register .vscode/{extensions.json,settings.json,launch.json} as `JSON with Comments`

### DIFF
--- a/lib/linguist/language.rb
+++ b/lib/linguist/language.rb
@@ -144,7 +144,13 @@ module Linguist
     # Returns all matching Languages or [] if none were found.
     def self.find_by_filename(filename)
       basename = File.basename(filename)
-      @filename_index[basename]
+      languages = @filename_index[basename]
+
+      if languages.empty? && @filename_index.key?(filename)
+        @filename_index[filename]
+      else
+        languages
+      end
     end
 
     # Public: Look up Languages by file extension.

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3072,6 +3072,9 @@ JSON with Comments:
   - ".jscsrc"
   - ".jshintrc"
   - ".jslintrc"
+  - ".vscode/extensions.json"
+  - ".vscode/launch.json"
+  - ".vscode/settings.json"
   - api-extractor.json
   - devcontainer.json
   - jsconfig.json

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -198,6 +198,8 @@ class TestLanguage < Minitest::Test
     assert_equal [Language['Shell']], Language.find_by_filename('bash_profile')
     assert_equal [Language['Shell']], Language.find_by_filename('.zshrc')
     assert_equal [Language['Clojure']], Language.find_by_filename('riemann.config')
+    assert_equal [Language['JSON with Comments']], Language.find_by_filename('tsconfig.json')
+    assert_equal [Language['JSON with Comments']], Language.find_by_filename('.vscode/settings.json')
   end
 
   def test_find_by_interpreter


### PR DESCRIPTION
As you folks may know, `.vscode/*.json` are JSON with Comments (jsonc), not JSON. That is, when I open, e.g., `.vscode/settings.json` on GitHub Web, I'd expect it is rendered as jsonc. 

If I add a git attribute to these files, I can see those files are rendered as jsonc (like `.vscode/*.json linguist-language=jsonc` => https://github.com/msgpack/msgpack-javascript/blob/main/.vscode/launch.json), but I believe it should be the default.

## Description

I'm adding a new lookup path to `Language.find_by_filename` to see the entire given filename, as well as its basename. I'm not sure this is an ideal implementation. The implementation might be arguable.  It's still O(1) but sounds too ad-hoc and it cannot handle deep paths such as `some/other/dir/.vscode/settings.json`. Another algorithm (e.g. fnmatch(3)-like behavior + cache) would be better but I'd like to discuss the new functionality before implementing such a smart algorithm. 

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
