### PR TITLE
Add color for PlantUML.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5015,6 +5015,7 @@ Pike:
   language_id: 287
 PlantUML:
   type: data
+  color: "#fbbd16"
   extensions:
   - ".puml"
   - ".iuml"


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

This MR adds a color for PlantUML.

The color is the yellow from the official UML "cube" logo ![](https://upload.wikimedia.org/wikipedia/commons/d/d5/UML_logo.svg)

Althought _Unified Modeling Language_, _UML_, and the _UML Cube Logo_ are registered trademarks ® of the Object Management Group, Inc., the color bears no copyright.

The community at large was asked for their opinion through the normal channels of communication in July 2021 (both in a GitHub issue and on the user forum). There was little response.

The creator of PlantUML and a few contributors _did_ respond, all opting for the "official" yellow (the yellow used in the PlantUML logo is 2% off, the consensus was to go with the "correct" color instead).

## Checklist:

- [x] **I am changing the color associated with a language**
  <!-- Please ensure you have gathered agreement from the wider language community _before_ opening this PR -->
  - [x] I have obtained agreement from the wider language community on this color change.
    - URLs to public discussion:
      - https://github.com/plantuml/plantuml/issues/596)
      - https://forum.plantuml.net/14298 