### PR TITLE
Classify `.bash_functions` as Shell

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6195,8 +6195,7 @@ Self:
   language_id: 345
 ShaderLab:
   type: programming
-  color: "#2
-  22c37"
+  color: "#222c37"
   extensions:
   - ".shader"
   ace_mode: text

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6195,7 +6195,8 @@ Self:
   language_id: 345
 ShaderLab:
   type: programming
-  color: "#222c37"
+  color: "#2
+  22c37"
   extensions:
   - ".shader"
   ace_mode: text
@@ -6225,6 +6226,7 @@ Shell:
   - ".zsh-theme"
   filenames:
   - ".bash_aliases"
+  - ".bash_functions"
   - ".bash_history"
   - ".bash_logout"
   - ".bash_profile"

--- a/samples/Shell/filenames/.bash_functions
+++ b/samples/Shell/filenames/.bash_functions
@@ -1,0 +1,21 @@
+make_graph() {
+    if [ -f dbschema.dot ]; then
+        rm -f dbschema.dot
+    fi
+
+    # NB graph_models is one of the additions from django-extensions
+    python manage.py graph_models -a -X CaptchaStore,ContentType,Group,Permission,Site,Session,AbstractBaseSession,LogEntry,FileBrowser,PermissionsMixin,AbstractBaseUser,TaskResult,PeriodicTask,IntervalSchedule,PeriodicTasks,ClockedSchedule,CrontabSchedule,SolarSchedule, -x last_updated_by -g > dbschema.dot
+
+    # Swap the direction of the arrow
+    sed -i -e 's/arrowhead=none, arrowtail=dot/arrowhead=vee, arrowtail=none/g' dbschema.dot
+    sed -i -e 's/arrowhead=dot, arrowtail=none/arrowhead=none, arrowtail=vee/g' dbschema.dot
+    sed -i -e 's/arrowhead=dot arrowtail=dot/arrowhead=vee arrowtail=vee/g' dbschema.dot
+
+    # https://www.graphviz.org/doc/info/attrs.html
+    for layout in dot fdp sfdp osage; do  # neato  twopi  circo  patchwork
+        if [ -f dbschema_$layout.pdf ]; then
+            rm -f dbschema_$layout.pdf
+        fi
+        dot -K$layout -Tpdf dbschema.dot -x > dbschema_$layout.pdf
+    done
+}


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
- Resolves #6234

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Adds `.bash_functions` as a Shell filename.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub:
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - [path:**/.bash_functions](https://github.com/search?q=path%3A**%2F.bash_functions) - 281 files. Assuming 1 per repo.
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - [x] Sample source(s):
      - [tlrh314/atlas-web](https://github.com/tlrh314/atlas-web/blob/9e508a3c15184e393e55eb2771f5f412b21d5e3b/.bash_functions)
    - [x] Sample license(s):
      - [GNU 3](https://github.com/tlrh314/atlas-web/blob/master/LICENSE)
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
