### PR TITLE
Update grammar compiler to use Go 1.20

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,3 @@
+go 1.20
+
+use ./tools/grammars

--- a/tools/grammars/Dockerfile
+++ b/tools/grammars/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.20
 
 WORKDIR /go/src/github.com/github/linguist/tools/grammars
 

--- a/tools/grammars/go.mod
+++ b/tools/grammars/go.mod
@@ -1,16 +1,23 @@
 module github.com/github/linguist/tools/grammars
 
-go 1.16
+go 1.20
 
 require (
-	github.com/fatih/color v1.12.0 // indirect
 	github.com/golang/protobuf v0.0.0-20171113180720-1e59b77b52bf
 	github.com/groob/plist v0.0.0-20171013152701-7b367e0aa692
-	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20171017171808-06020f85339e
 	github.com/urfave/cli/v2 v2.3.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.18
 	gopkg.in/yaml.v2 v2.2.8
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/fatih/color v1.12.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-runewidth v0.0.2 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Small PR to bump the version of Go used by the grammar compiler to 1.20 as Go 1.16 is now EoL.

Whilst I'm at it, I'm also adding a [Go workspace file](https://github.com/golang/tools/blob/193023cca0b707b4d668e5d332649cba285e99f7/gopls/doc/workspace.md) to make it easier to work with the compiler code in VSCode directly from the repo's root directory.

## Checklist:

N/A