### PR TITLE
Exclude obsidian.md preferences

### DIFF
--- a/lib/linguist/vendor.yml
+++ b/lib/linguist/vendor.yml
@@ -385,3 +385,6 @@
 
 # GitHub.com
 - (^|/)\.github/
+
+# obsidian.md settings
+- (^|/)\.obsidian/

--- a/test/test_file_blob.rb
+++ b/test/test_file_blob.rb
@@ -580,6 +580,10 @@ class TestFileBlob < Minitest::Test
     # GitHub.com
     assert sample_blob(".github/CODEOWNERS").vendored?
     assert sample_blob(".github/workflows/test.yml").vendored?
+    
+    # obsidian.md settings
+    assert sample_blob(".obsidian/app.json").vendored?
+    assert sample_blob(".obsidian/plugins/templater-obsidian/main.js").vendored?
   end
 
   def test_documentation


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->
Ignore `.obsidian` folder for stats, by adding it as a path exclusion.

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
When using https://obsidian.md/, a `.obsidian` folder is created inside the project (notes in this case) folder. It contains the plugins' source code, which of course, is not the focus of notes.

[Case - where this is happening](https://github.com/sanjar-notes/nodejs-notes/tree/b49a108cbf33207cf73dde3f9868f50bca6c061f)

## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [x] I have added or updated the tests for the new or changed functionality.
