### PR TITLE
Add .cnf to INI

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2850,6 +2850,7 @@ INI:
   extensions:
   - ".ini"
   - ".cfg"
+  - ".cnf"
   - ".dof"
   - ".lektorproject"
   - ".prefs"

--- a/samples/INI/my.cnf
+++ b/samples/INI/my.cnf
@@ -1,0 +1,107 @@
+# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is also distributed with certain software (including
+# but not limited to OpenSSL) that is licensed under separate terms, as
+# designated in a particular file or component or in included license
+# documentation.  The authors of MySQL hereby grant you an additional
+# permission to link the program and your derivative works with the
+# separately licensed software that they have included with MySQL.
+# This program is distributed in the hope that it will be useful,  but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+#
+# Regular comments
+
+# Make sure default section is handled properly
+# Not a special section according to MySQL documentation (no precedence, etc.)
+[DEFAULT]
+password=54321
+repeated_value
+repeated-value = "what"
+
+# Group names are not case sensitive, unlike opt_name.
+[cLieNt] # inline section comment
+password=12345
+port=1000
+socket=/var/run/mysqld/mysqld.sock
+ssl-ca=dummyCA
+ssl-cert=dummyCert
+ssl-key=dummyKey
+ssl-cipher=AES256-SHA:CAMELLIA256-SHA
+CaseSensitiveOptions=Yes
+option_to_delete_with_value = 20
+option_to_delete_without_value
+
+; Another comment
+
+[mysqld_safe]
+socket=/var/run/mysqld/mysqld1.sock
+
+# spaces can be used around '='
+nice =   0
+# values can include '#' if enclose with single or double quotes
+valid_v1 = 'include comment ( #) symbol' # comment
+valid_v2 = "include comment ( #) symbol" # comment
+
+[mysqld]
+option_to_delete_with_value = 20 # delete this
+option_to_delete_without_value  # this as well
+master-info-repository = TABLE
+master-info_repository = FILE
+user=mysql  # inline coments
+pid-file=/var/run/mysqld/mysqld.pid
+socket=/var/run/mysqld/mysqld2.sock
+port=1001
+basedir=/usr
+datadir=/var/lib/mysql
+tmpdir = /tmp # other inline comment and spaces
+to_override # this option is going to be overridden
+to_override_with_value = old_val  # this is also to be overridden
+no_comment_no_value
+lc-messages-dir=/usr/share/mysql
+skip-external-locking  # another inline comment
+binlog=True # ignore this comment
+   multivalue =   Noooooooooooooooo #; Ignore this one as well
+semi-colon=;
+
+# leading and training spaces are ignored
+   bind-address =   127.0.0.1  
+
+log_error=/var/log/mysql/error.log # value to be removed
+
+[delete_section]
+option_to_drop_with_no_value  # comments are
+option_to_drop_with_value = "value"   # also to be
+option_to_drop_with_value2 = "value"  ## deleted #
+
+[escape_sequences]
+backspace=\b
+tab=\t
+newline=\n
+carriage-return=\r
+backslash=\\
+space=\s
+not_esc_seq_char=\S
+
+[path_options]
+win_path_no_esc_seq_char1="C:\Program Files\MySQL\MySQL Server 5.7"
+win_path_no_esc_seq_char2="C:\\Program Files\\MySQL\\MySQL Server 5.7"
+win_path_esc_seq_char=C:\\Program\sFiles\\MySQL\\MySQL\sServer\s5.7
+win_path_with_posix_sep="C:/Program Files/MySQL/MySQL Server 5.7"
+
+[delete_section2]
+option_to_drop_with_no_value  # comments are
+option_to_drop_with_value = "value"   # also to be
+option_to_drop_with_value2 = "value"  # delete
+
+[empty section]

--- a/samples/INI/openssl.cnf
+++ b/samples/INI/openssl.cnf
@@ -1,0 +1,244 @@
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+
+# This sets a mask for permitted string types. There are several options.
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+# req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= AU
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= Some-State
+
+localityName			= Locality Name (eg, city)
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= Internet Widgits Pty Ltd
+
+# we can do this but it is not needed normally :-)
+#1.organizationName		= Second Organization Name (eg, company)
+#1.organizationName_default	= World Wide Web Pty Ltd
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (e.g. server FQDN or YOUR name)
+commonName_max			= 64
+
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+# SET-ex3			= SET extension number 3
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+basicConstraints = critical,CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+# keyUsage = cRLSign, keyCertSign
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF
+
+[ crl_ext ]
+
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+
+[ proxy_cert_ext ]
+# These extensions should be added when creating a proxy certificate
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+# This really needs to be in place for it to be a proxy certificate.
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+####################################################################
+[ tsa ]
+
+default_tsa = tsa_config1	# the default TSA section
+
+[ tsa_config1 ]
+
+# These are used by the TSA reply generation only.
+dir		= ./demoCA		# TSA root directory
+serial		= $dir/tsaserial	# The current serial number (mandatory)
+crypto_device	= builtin		# OpenSSL engine to use for signing
+signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
+					# (optional)
+certs		= $dir/cacert.pem	# Certificate chain to include in reply
+					# (optional)
+signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
+signer_digest  = sha256			# Signing digest to use. (Optional)
+default_policy	= tsa_policy1		# Policy if request did not specify it
+					# (optional)
+other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
+digests     = sha1, sha256, sha384, sha512  # Acceptable message digests (mandatory)
+accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
+clock_precision_digits  = 0	# number of digits after dot. (optional)
+ordering		= yes	# Is ordering defined for timestamps?
+				# (optional, default: no)
+tsa_name		= yes	# Must the TSA name be included in the reply?
+				# (optional, default: no)
+ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
+				# (optional, default: no)
+ess_cert_id_alg		= sha1	# algorithm to compute certificate
+				# identifier (optional, default: sha1)
+
+[insta] # CMP using Insta Demo CA
+# Message transfer
+server = pki.certificate.fi:8700
+# proxy = # set this as far as needed, e.g., http://192.168.1.1:8080
+# tls_use = 0
+path = pkix/
+
+# Server authentication
+recipient = "/C=FI/O=Insta Demo/CN=Insta Demo CA" # or set srvcert or issuer
+ignore_keyusage = 1 # potentially needed quirk
+unprotected_errors = 1 # potentially needed quirk
+extracertsout = insta.extracerts.pem
+
+# Client authentication
+ref = 3078 # user identification
+secret = pass:insta # can be used for both client and server side
+
+# Generic message options
+cmd = ir # default operation, can be overridden on cmd line with, e.g., kur
+
+# Certificate enrollment
+subject = "/CN=openssl-cmp-test"
+newkey = insta.priv.pem
+out_trusted = insta.ca.crt
+certout = insta.cert.pem
+
+[pbm] # Password-based protection for Insta CA
+# Server and client authentication
+ref = $insta::ref # 3078
+secret = $insta::secret # pass:insta
+
+[signature] # Signature-based protection for Insta CA
+# Server authentication
+trusted = insta.ca.crt # does not include keyUsage digitalSignature
+
+# Client authentication
+secret = # disable PBM
+key = $insta::newkey # insta.priv.pem
+cert = $insta::certout # insta.cert.pem
+
+[ir]
+cmd = ir
+
+[cr]
+cmd = cr
+
+[kur]
+# Certificate update
+cmd = kur
+oldcert = $insta::certout # insta.cert.pem
+
+[rr]
+# Certificate revocation
+cmd = rr
+oldcert = $insta::certout # insta.cert.pem

--- a/script/cross-validation
+++ b/script/cross-validation
@@ -2,7 +2,7 @@
 
 # Number of acceptable classification errors.
 # It should only be decreased.
-ACCEPTABLE_ERRORS = 38
+ACCEPTABLE_ERRORS = 39
 
 # Number of acceptable classification errors when using --all.
 # It should only be decreased.


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

I would like to add `.cnf` extension as INI.

`.cnf` is used for [MySQL Option File](https://dev.mysql.com/doc/refman/8.0/en/option-files.html#option-file-syntax) and [OpenSSL CONF library configuration file](https://www.openssl.org/docs/manmaster/man5/config.html).

## Checklist:
- [x] **I am associating a language with a new file extension.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?q=path%3A*.cnf+mysqld+NOT+nothack&type=code
    - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - <https://github.com/mysql/mysql-shell/blob/037114f/unittest/data/config/my.cnf>
        - `GNU General Public License, version 2.0`
      - <https://github.com/nodejs/node/blob/66da32c/deps/openssl/openssl/apps/openssl.cnf>
        - `MIT License` 
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.