### PR TITLE
Edit BASIC heuristic to avoid false positives + new sample

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -87,7 +87,7 @@ disambiguations:
   - language: FreeBasic
     pattern: '^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s'
   - language: BASIC
-    pattern: '^\s*\d+'
+    pattern: '^\A\s*\d+'
 - extensions: ['.bb']
   rules:
   - language: BlitzBasic

--- a/samples/BASIC/GPIOGW.BAS
+++ b/samples/BASIC/GPIOGW.BAS
@@ -1,0 +1,59 @@
+1 REM GWBASIC program to control MCP23S17 I/O expander inside PC Emulator
+10 CLS
+20 REM
+30 REM check for I/O available
+40 IF (INP(&HE0) AND 1) = 0 THEN GOTO 1100
+80 REM
+90 REM Setup Port A and B as Outputs
+100 OUT &HE1, &HFF
+110 OUT &HE2, &HFF
+120 REM
+130 PRINT "on/off Port A and B"
+140 FOR I = 1 TO 4
+150   OUT &HE5, 255
+160   OUT &HE6, 255
+170   FOR D = 1 TO 200: NEXT
+180   OUT &HE5, 0
+190   OUT &HE6, 0
+200   FOR D = 1 TO 200: NEXT
+210 NEXT
+220 REM
+230 PRINT "on/off single GPIO A0 to B2"
+240 FOR I = 1 TO 4
+250   FOR GPIO = 0 TO 10
+260     OUT &HE7, GPIO
+270     OUT &HE9, 0
+280     OUT &HE7, GPIO + 1
+290     OUT &HE9, 1
+300     FOR D = 1 TO 50: NEXT
+310   NEXT
+320   FOR GPIO = 10 TO 0 STEP -1
+330     OUT &HE7, GPIO
+340     OUT &HE9, 0
+350     IF GPIO > 0 THEN: OUT &HE7, GPIO - 1
+360     OUT &HE9, 1
+370     FOR D = 1 TO 50: NEXT
+380   NEXT
+390 NEXT
+400 REM
+410 PRINT "Check for B3 to B7 as Inputs..."
+420 PRINT "Press any key to stop"
+430 OUT &HE2, &H7: REM setup GPIO B3 to B7 as inputs (bits 3..7 = 0)
+440 WHILE LEN(INKEY$) = 0
+450   FOR GPIO = 11 TO 15
+460     GOSUB 1000: REM checkGPIO (gpio)
+470   NEXT
+480 WEND
+490 END
+1000 REM SUB checkGPIO (gpio)
+1010 OUT &HE7, GPIO
+1020 IF INP(&HE9) <> 1 THEN RETURN
+1030 PRINT "pressed "; GPIO; "...";
+1040 WHILE INP(&HE9): WEND
+1050 PRINT "released"
+1070 RETURN
+1099 REM
+1100 REM expander not available
+1110 PRINT "Extended I/O not available on this board!"
+1120 END
+


### PR DESCRIPTION
There is currently at least 2 occurences of false positives with the BASIC heuristic (`'^\s*\d+'`) introduced in https://github.com/github/linguist/pull/5166/:

1) If a VBA file contains line numbers, it will automatically be identified as BASIC. It is not that common for VBA code to have line numbers, but some people like to use them to improve error reporting.
eg. https://github.com/Sven-Bo/Integrate-ChatGPT-in-Excel-using-VBA/blob/master/mChatGPT.bas#L34

2) In VBA (or VB6), an underscore can be used as a line continuation character which means that lines can be split and there is the possibility that a number ends up being the first thing on the second line thus matching with the heuristic.
eg. https://github.com/dragokas/hijackthis/blob/7560e67b5e0d14f53ea25bbfb88587cbfadca1c8/src/modPermissions.bas#L905

The good thing is that both of these issues can't happen at the start of the file because you can't have line numbering outside of a procedure in VBA and it can't be a line continuation if it's the start of the file (obviously).

Hence, I'm proposing to add `\A` at the start of the heuristic (which gives `^\A\s*\d+`) and I also added a sample so that we have two samples for BASIC with the `.bas` extension.

<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
- [x] **I am fixing a misclassified language**
  - [x] I have included a new sample for the misclassified language:
    - Sample source(s):
      - [GPIOGW.BAS](https://github.com/fdivitto/FabGL/blob/61eeaf90715fa2070df86c9342ec3c189c3ad1e0/Extras/PC%20Emulator%20BASIC%20Programs/GPIOGW.BAS
) 
    - Sample license(s): [GPL v3](https://github.com/fdivitto/FabGL/blob/master/LICENSE)
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
