### PR TITLE
Update licensed gem dependency

### DIFF
--- a/github-linguist.gemspec
+++ b/github-linguist.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry', '~> 0.14'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'yajl-ruby', '~> 1.4'
-  s.add_development_dependency 'licensed', '~> 2.0'
+  s.add_development_dependency 'licensed', '~> 4.0'
   s.add_development_dependency 'licensee', '~> 9.15'
   s.add_development_dependency 'bundler', '~> 2.0'
 end


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Updates the licensed gem dependency to ~4.0.

Something has gone awry with licensed on macos with Ruby 3.2.0 which causes `bundle exec licensed cache -c vendor/licenses/config.yml` as run at the end of the `script/add-grammar` script to fail as follows as reported in https://github.com/github/linguist/discussions/6330:

```
bundler: failed to load command: licensed (/Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/bin/licensed)
/Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/licensed-2.9.2/lib/licensed/commands/command.rb:18:in `run': wrong number of arguments (given 1, expected 0) (ArgumentError)
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/licensed-2.9.2/lib/licensed/cli.rb:83:in `run'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/licensed-2.9.2/lib/licensed/cli.rb:14:in `cache'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/gems/licensed-2.9.2/exe/licensed:5:in `<top (required)>'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/bin/licensed:25:in `load'
        from /Users/jessicalin/linguist/vendor/gems/ruby/3.2.0/bin/licensed:25:in `<top (required)>'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:491:in `exec'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/libexec/bundle:45:in `block in <top (required)>'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /Users/jessicalin/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/libexec/bundle:33:in `<top (required)>'
        from /Users/jessicalin/.rbenv/versions/3.2.0/bin/bundle:25:in `load'
        from /Users/jessicalin/.rbenv/versions/3.2.0/bin/bundle:25:in `<main>'
``` 

This doesn't affect Linux from my testing but I have found that we're quite far behind on licensed and updating resolves the issue for me on macos without affecting Linux either.