### PR TITLE
Add md as an alias for Markdown

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -3967,6 +3967,7 @@ Markdown:
   type: prose
   color: "#083fa1"
   aliases:
+  - md
   - pandoc
   ace_mode: markdown
   codemirror_mode: gfm


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Many people use ` ```md ` for Markdown codeblocks within Markdown files. This is currently only declared as an extension which is shared with "GCC Machine Description". When [markup](https://github.com/github/markup) sees `md` it searches for the language name, aliases and then extensions in order, and as "GCC Machine Description" comes first alphabetically, Lisp syntax highlighting is applied and not Markdown.

This resolves that by adding `md` as an alias to Markdown.

🎩 to @wooorm in https://github.com/github/linguist/discussions/6335 for bringing this to my attention and making me realise this could be resolved from Linguist 🙇 

## Checklist:

- [x] **I am fixing a misclassified language**
  - [ ] I have included a new sample for the misclassified language:
    - Sample source(s): N/A
    - Sample license(s): N/A
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension. N/A

The final checkboxes aren't applicable as this is "fixing" a misclassification in markup, not Linguist.
