### PR TITLE
Update link to ace modes

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7,7 +7,7 @@
 # aliases               - An Array of additional aliases (implicitly
 #                         includes name.downcase)
 # ace_mode              - A String name of the Ace Mode used for highlighting whenever
-#                         a file is edited. This must match one of the filenames in http://git.io/3XO_Cg.
+#                         a file is edited. This must match one of the filenames in https://gh.io/acemodes.
 #                         Use "text" if a mode does not exist.
 # codemirror_mode       - A String name of the CodeMirror Mode used for highlighting whenever a file is edited.
 #                         This must match a mode from https://git.io/vi9Fx


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
The directory structure in https://github.com/ajaxorg/ace/ has changed and moved the list of ace modes to https://github.com/ajaxorg/ace/tree/master/src/mode

This PR updates the link in the `languages.yml` to point to this location, and now with a custom shortname.

The current git.io link can't be modified and no new links can be created as that service is now in read-only mode. `gh.io` is the GitHub only replacement.

## Checklist:

N/A
