### PR TITLE
Fix `trim_trailing_whitespace` typo in `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,4 +26,4 @@ end_of_line = unset
 indent_size = unset
 indent_style = unset
 insert_final_newline = unset
-trim_trailing_spaces = unset
+trim_trailing_whitespace = unset


### PR DESCRIPTION
## Description

`trim_trailing_spaces` seems to have been an older proposal for the name of this property but `trim_trailing_whitespace` is what was finally settled on. `trim_trailing_whitespace` already appears twice in this file.

https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#trim_trailing_whitespace

Cc: @Alhadis who added this file originally