### PR TITLE
Make use of additional editor modes

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -156,7 +156,7 @@ APL:
   language_id: 6
 ASL:
   type: programming
-  ace_mode: text
+  ace_mode: asl
   extensions:
   - ".asl"
   - ".dsl"
@@ -370,7 +370,7 @@ Apex:
   - ".apex"
   - ".trigger"
   tm_scope: source.apex
-  ace_mode: java
+  ace_mode: apex
   codemirror_mode: clike
   codemirror_mime_type: text/x-java
   language_id: 17
@@ -446,7 +446,7 @@ Astro:
   extensions:
   - ".astro"
   tm_scope: source.astro
-  ace_mode: html
+  ace_mode: astro
   codemirror_mode: jsx
   codemirror_mime_type: text/jsx
   language_id: 578209015
@@ -535,7 +535,7 @@ BASIC:
   extensions:
   - ".bas"
   tm_scope: source.basic
-  ace_mode: text
+  ace_mode: basic
   color: "#ff0000"
   language_id: 28923963
 BQN:
@@ -604,7 +604,7 @@ BibTeX:
   - ".bib"
   - ".bibtex"
   tm_scope: text.bibtex
-  ace_mode: tex
+  ace_mode: bibtex
   codemirror_mode: stex
   codemirror_mime_type: text/x-stex
   language_id: 982188347
@@ -661,7 +661,7 @@ Blade:
   - ".blade"
   - ".blade.php"
   tm_scope: text.html.php.blade
-  ace_mode: text
+  ace_mode: php_laravel_blade
   language_id: 33
 BlitzBasic:
   type: programming
@@ -951,7 +951,7 @@ CSS:
 CSV:
   type: data
   color: "#237346"
-  ace_mode: text
+  ace_mode: csv
   tm_scope: none
   extensions:
   - ".csv"
@@ -982,7 +982,7 @@ Cabal Config:
   filenames:
   - cabal.config
   - cabal.project
-  ace_mode: haskell
+  ace_mode: haskell_cabal
   codemirror_mode: haskell
   codemirror_mime_type: text/x-haskell
   tm_scope: source.cabal
@@ -1393,7 +1393,7 @@ Crystal:
   color: "#000100"
   extensions:
   - ".cr"
-  ace_mode: ruby
+  ace_mode: crystal
   codemirror_mode: crystal
   codemirror_mime_type: text/x-crystal
   tm_scope: source.crystal
@@ -2044,7 +2044,7 @@ F#:
   - ".fsi"
   - ".fsx"
   tm_scope: source.fsharp
-  ace_mode: text
+  ace_mode: fsharp
   codemirror_mode: mllike
   codemirror_mime_type: text/x-fsharp
   language_id: 105
@@ -2196,7 +2196,7 @@ Fortran:
   - ".for"
   - ".fpp"
   tm_scope: source.fortran
-  ace_mode: text
+  ace_mode: fortran
   codemirror_mode: fortran
   codemirror_mime_type: text/x-fortran
   language_id: 107
@@ -2210,7 +2210,7 @@ Fortran Free Form:
   - ".f08"
   - ".f95"
   tm_scope: source.fortran.modern
-  ace_mode: text
+  ace_mode: fortran
   codemirror_mode: fortran
   codemirror_mime_type: text/x-fortran
   language_id: 761352333
@@ -2528,7 +2528,7 @@ Gherkin:
   codemirror_mime_type: text/x-feature
   aliases:
   - cucumber
-  ace_mode: text
+  ace_mode: gherkin
   color: "#5B2063"
   language_id: 76
 Git Attributes:
@@ -2760,7 +2760,7 @@ GraphQL:
   - ".gql"
   - ".graphqls"
   tm_scope: source.graphql
-  ace_mode: text
+  ace_mode: graphqlschema
   language_id: 139
 Graphviz (DOT):
   type: data
@@ -2769,7 +2769,7 @@ Graphviz (DOT):
   extensions:
   - ".dot"
   - ".gv"
-  ace_mode: text
+  ace_mode: dot
   language_id: 140
 Groovy:
   type: programming
@@ -2824,7 +2824,7 @@ HCL:
   aliases:
   - HashiCorp Configuration Language
   - terraform
-  ace_mode: ruby
+  ace_mode: terraform
   codemirror_mode: ruby
   codemirror_mime_type: text/x-ruby
   tm_scope: source.hcl
@@ -2889,7 +2889,7 @@ HTML+ECR:
   - ecr
   extensions:
   - ".ecr"
-  ace_mode: text
+  ace_mode: html_ruby
   codemirror_mode: htmlmixed
   codemirror_mime_type: text/html
   language_id: 148
@@ -2906,7 +2906,7 @@ HTML+EEX:
   - ".html.eex"
   - ".heex"
   - ".leex"
-  ace_mode: text
+  ace_mode: html_elixir
   codemirror_mode: htmlmixed
   codemirror_mime_type: text/html
   language_id: 149
@@ -2923,7 +2923,7 @@ HTML+ERB:
   - ".erb"
   - ".erb.deface"
   - ".rhtml"
-  ace_mode: text
+  ace_mode: html_ruby
   codemirror_mode: htmlembedded
   codemirror_mime_type: application/x-erb
   language_id: 150
@@ -3444,7 +3444,7 @@ JSON5:
   extensions:
   - ".json5"
   tm_scope: source.js
-  ace_mode: javascript
+  ace_mode: json5
   codemirror_mode: javascript
   codemirror_mime_type: application/json
   language_id: 175
@@ -3854,7 +3854,7 @@ Kotlin:
   - ".ktm"
   - ".kts"
   tm_scope: source.kotlin
-  ace_mode: text
+  ace_mode: kotlin
   codemirror_mode: clike
   codemirror_mime_type: text/x-kotlin
   language_id: 189
@@ -3953,7 +3953,7 @@ Latte:
   extensions:
   - ".latte"
   tm_scope: text.html.smarty
-  ace_mode: smarty
+  ace_mode: latte
   codemirror_mode: smarty
   codemirror_mime_type: text/x-smarty
   language_id: 196
@@ -4145,7 +4145,7 @@ Logtalk:
   - ".lgt"
   - ".logtalk"
   tm_scope: source.logtalk
-  ace_mode: text
+  ace_mode: logtalk
   language_id: 210
 LookML:
   type: programming
@@ -4793,7 +4793,7 @@ NSIS:
   - ".nsi"
   - ".nsh"
   tm_scope: source.nsis
-  ace_mode: text
+  ace_mode: nsis
   codemirror_mode: nsis
   codemirror_mime_type: text/x-nsis
   language_id: 242
@@ -4898,7 +4898,7 @@ Nginx:
   tm_scope: source.nginx
   aliases:
   - nginx configuration file
-  ace_mode: text
+  ace_mode: nginx
   codemirror_mode: nginx
   codemirror_mime_type: text/x-nginx-conf
   language_id: 248
@@ -4921,7 +4921,7 @@ Nim:
   - ".nims"
   filenames:
   - nim.cfg
-  ace_mode: text
+  ace_mode: nim
   tm_scope: source.nim
   language_id: 249
 Ninja:
@@ -5181,7 +5181,7 @@ Odin:
   extensions:
   - ".odin"
   tm_scope: source.odin
-  ace_mode: text
+  ace_mode: odin
   language_id: 889244082
 Omgrofl:
   type: programming
@@ -5420,7 +5420,7 @@ PHP:
   language_id: 272
 PLSQL:
   type: programming
-  ace_mode: sql
+  ace_mode: plsql
   codemirror_mode: sql
   codemirror_mime_type: text/x-plsql
   tm_scope: none
@@ -5629,7 +5629,7 @@ PigLatin:
   extensions:
   - ".pig"
   tm_scope: source.pig_latin
-  ace_mode: text
+  ace_mode: pig
   codemirror_mode: pig
   codemirror_mime_type: text/x-pig
   language_id: 286
@@ -5792,7 +5792,7 @@ Prisma:
   extensions:
   - ".prisma"
   tm_scope: source.prisma
-  ace_mode: text
+  ace_mode: prisma
   language_id: 499933428
 Processing:
   type: programming
@@ -5901,7 +5901,7 @@ Puppet:
   - ".pp"
   filenames:
   - Modulefile
-  ace_mode: text
+  ace_mode: puppet
   codemirror_mode: puppet
   codemirror_mime_type: text/x-puppet
   tm_scope: source.puppet
@@ -6018,7 +6018,7 @@ QML:
   - ".qml"
   - ".qbs"
   tm_scope: source.qml
-  ace_mode: text
+  ace_mode: qml
   language_id: 305
 QMake:
   type: programming
@@ -6258,7 +6258,7 @@ Raku:
   - perl6
   - perl-6
   tm_scope: source.raku
-  ace_mode: perl
+  ace_mode: raku
   codemirror_mode: perl
   codemirror_mime_type: text/x-perl
   language_id: 283
@@ -6357,7 +6357,7 @@ Red:
   aliases:
   - red/system
   tm_scope: source.red
-  ace_mode: text
+  ace_mode: red
   language_id: 320
 Redcode:
   type: programming
@@ -6443,7 +6443,7 @@ RobotFramework:
   - ".robot"
   - ".resource"
   tm_scope: text.robot
-  ace_mode: text
+  ace_mode: robot
   language_id: 324
 Roc:
   type: programming
@@ -6711,7 +6711,7 @@ SPARQL:
   type: data
   color: "#0C4597"
   tm_scope: source.sparql
-  ace_mode: text
+  ace_mode: sparql
   codemirror_mode: sparql
   codemirror_mime_type: application/sparql-query
   extensions:
@@ -6816,7 +6816,7 @@ SVG:
   extensions:
   - ".svg"
   tm_scope: text.xml.svg
-  ace_mode: xml
+  ace_mode: svg
   codemirror_mode: xml
   codemirror_mime_type: text/xml
   language_id: 337
@@ -7121,7 +7121,7 @@ Slim:
   extensions:
   - ".slim"
   tm_scope: text.slim
-  ace_mode: text
+  ace_mode: slim
   codemirror_mode: slim
   codemirror_mime_type: text/x-slim
   language_id: 350
@@ -7175,7 +7175,7 @@ Smarty:
   language_id: 353
 Smithy:
   type: programming
-  ace_mode: text
+  ace_mode: smithy
   codemirror_mode: clike
   codemirror_mime_type: text/x-csrc
   tm_scope: source.smithy
@@ -7392,7 +7392,7 @@ Swift:
   extensions:
   - ".swift"
   tm_scope: source.swift
-  ace_mode: text
+  ace_mode: swift
   codemirror_mode: swift
   codemirror_mime_type: text/x-swift
   language_id: 362
@@ -7472,7 +7472,7 @@ TSQL:
 TSV:
   type: data
   color: "#237346"
-  ace_mode: text
+  ace_mode: tsv
   tm_scope: source.generic-db
   extensions:
   - ".tsv"
@@ -7487,7 +7487,7 @@ TSX:
   extensions:
   - ".tsx"
   tm_scope: source.tsx
-  ace_mode: javascript
+  ace_mode: tsx
   codemirror_mode: jsx
   codemirror_mime_type: text/typescript-jsx
   language_id: 94901924
@@ -7743,7 +7743,7 @@ Turtle:
   extensions:
   - ".ttl"
   tm_scope: source.turtle
-  ace_mode: text
+  ace_mode: turtle
   codemirror_mode: turtle
   codemirror_mime_type: text/turtle
   language_id: 376
@@ -7918,7 +7918,7 @@ VBScript:
   extensions:
   - ".vbs"
   tm_scope: source.vbnet
-  ace_mode: text
+  ace_mode: vbscript
   codemirror_mode: vbscript
   codemirror_mime_type: text/vbscript
   language_id: 408016005
@@ -8102,7 +8102,7 @@ Vue:
   extensions:
   - ".vue"
   tm_scope: source.vue
-  ace_mode: html
+  ace_mode: vue
   codemirror_mode: vue
   codemirror_mime_type: text/x-vue
   language_id: 391
@@ -8229,7 +8229,7 @@ Wikitext:
   - ".wiki"
   - ".wikitext"
   tm_scope: text.html.mediawiki
-  ace_mode: text
+  ace_mode: mediawiki
   language_id: 228
 Win32 Message File:
   type: data
@@ -8263,7 +8263,7 @@ Wollok:
   color: "#a23738"
   extensions:
   - ".wlk"
-  ace_mode: text
+  ace_mode: wollok
   tm_scope: source.wollok
   language_id: 632745969
 World of Warcraft Addon Data:
@@ -8693,7 +8693,7 @@ Zeek:
   - ".zeek"
   - ".bro"
   tm_scope: source.zeek
-  ace_mode: text
+  ace_mode: zeek
   language_id: 40
 ZenScript:
   type: programming
@@ -8718,7 +8718,7 @@ Zig:
   - ".zig"
   - ".zig.zon"
   tm_scope: source.zig
-  ace_mode: text
+  ace_mode: zig
   language_id: 646424281
 Zimpl:
   type: programming
@@ -8941,7 +8941,7 @@ reStructuredText:
   - ".rest.txt"
   - ".rst.txt"
   tm_scope: text.restructuredtext
-  ace_mode: text
+  ace_mode: rst
   codemirror_mode: rst
   codemirror_mime_type: text/x-rst
   language_id: 419

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -312,7 +312,7 @@ class TestLanguage < Minitest::Test
     assert_equal 'css', Language['CSS'].ace_mode
     assert_equal 'lsl', Language['LSL'].ace_mode
     assert_equal 'javascript', Language['JavaScript'].ace_mode
-    assert_equal 'text', Language['FORTRAN'].ace_mode
+    assert_equal 'fortran', Language['FORTRAN'].ace_mode
   end
 
   def test_codemirror_mode


### PR DESCRIPTION
# Description
This pull-request adds missing CodeMirror and ACE editor modes to languages that aren't using them.

There were two additions I had to leave out:

1.	**Unix Assembly's CodeMirror mode**  
	<del>~~This is an [upstream issue](https://github.com/codemirror/codemirror5/issues/7134) that I'll probably submit a patch for. If all goes well, expect a follow-up to this PR with the following changes:~~</del>  
**UPDATE:** Already fixed in [`codemirror/codemirror5@98e86d1a`](https://github.com/codemirror/codemirror5/commit/98e86d1ae3fc8b6353e511bf25cf7adac7b03482). However, I'll hold off on adding `text/x-gas` for the same reasons as those discussed in [item 2](#item-2) (release cycles and what-have-you).

	```diff
	diff --git a/lib/linguist/languages.yml b/lib/linguist/languages.yml
	index 70c9fd3a..10edf36f 100644
	--- a/lib/linguist/languages.yml
	+++ b/lib/linguist/languages.yml
	@@ -7844,6 +7844,8 @@ Unix Assembly:
	   - unix asm
	   tm_scope: source.x86
	   ace_mode: assembly_x86
	+  codemirror_mode: gas
	+  codemirror_mime_type: text/x-gas
	   language_id: 120
	 Uno:
	   type: programming
	```

2.	<a name="item-2"></a>**Clue's ACE mode**  
	I've only omitted this because support for Clue was added [very recently](https://github.com/ajaxorg/ace/pull/5823) to the Ace project itself, and the odds are that Linguist will need to update whatever Ace editor version it uses before I can include the following addition too:

	```diff
	diff --git a/lib/linguist/languages.yml b/lib/linguist/languages.yml
	index 66c4324c..39f044f6 100644
	--- a/lib/linguist/languages.yml
	+++ b/lib/linguist/languages.yml
	@@ -1241,7 +1241,7 @@ Clue:
	   extensions:
	   - ".clue"
	   tm_scope: source.clue
	-  ace_mode: text
	+  ace_mode: clue
	   language_id: 163763508
	 CoNLL-U:
	   type: data
	```
*(Checklist removed as it doesn't apply)*
