### PR TITLE
Add .env.template as Dotenv filename

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1729,6 +1729,7 @@ Dotenv:
   - ".env.production"
   - ".env.sample"
   - ".env.staging"
+  - ".env.template"
   - ".env.test"
   - ".env.testing"
   tm_scope: source.dotenv

--- a/samples/Dotenv/filenames/.env.template
+++ b/samples/Dotenv/filenames/.env.template
@@ -1,0 +1,17 @@
+NEXT_PUBLIC_SUPABASE_URL=https://YOURSUPABASE.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=YYY
+PRIVATE_SUPABASE_SERVICE_KEY=XXX
+NEXT_PUBLIC_PRODUCTNAME=BasicSass
+NEXT_PUBLIC_SSO_PROVIDERS=github,google,facebook,apple
+
+
+NEXT_PUBLIC_GOOGLE_TAG=G-GOOGLETAG
+NEXT_PUBLIC_THEME=theme-sass
+
+
+NEXT_PUBLIC_TIERS_NAMES=Basic,Growth,Max
+NEXT_PUBLIC_TIERS_PRICES=99,199,299
+NEXT_PUBLIC_TIERS_DESCRIPTIONS=Perfect for getting started,Best for growing teams,For enterprise-grade needs
+NEXT_PUBLIC_TIERS_FEATURES=14 day free trial|30 PDF files,14 day free trial|1000 PDF files,14 day free trial|Unlimited PDF files
+NEXT_PUBLIC_POPULAR_TIER=Growth
+NEXT_PUBLIC_COMMON_FEATURES=SSL security,unlimited updates,premium support


### PR DESCRIPTION
adds `.env.template` as a filename for the Dotenv language
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.env.template
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/Razikus/supabase-nextjs-template/blob/e57b1756be3c26674ed15955d3162acbec1d399f/nextjs/.env.template
    - Sample license(s):
      - Apache License 2.0
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
