### PR TITLE
Add `.bxl` to Starlark

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7313,6 +7313,7 @@ Starlark:
   color: "#76d275"
   extensions:
   - ".bzl"
+  - ".bxl"
   - ".star"
   filenames:
   - BUCK

--- a/samples/Starlark/part2.bxl
+++ b/samples/Starlark/part2.bxl
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+def _main(ctx: bxl.Context):
+    universe = ctx.target_universe(ctx.cli_args.target)
+    all_targets = universe.universe_target_set()
+    nodes = ctx.cquery().kind("^(binary|library)$", all_targets)
+    analysis_res_dict = ctx.analysis(nodes)
+    index_outputs = []
+    for _, analysis_res in analysis_res_dict.items():
+        default_info = analysis_res.as_dependency()[DefaultInfo]
+        index_sub_target_provider = default_info.sub_targets["index"]
+        index_outputs.extend(index_sub_target_provider[DefaultInfo].default_outputs)
+    ctx.output.print(pstr(index_outputs))
+
+main = bxl_main(
+    impl = _main,
+    cli_args = {
+        "target": cli_args.target_label(),
+    },
+)


### PR DESCRIPTION
https://buck2.build/docs/bxl/

<!--- Briefly describe your changes in the field above. -->

## Description

Buck2 has PACKAGE files which do directory specific configuration. I am not familiar enough with Bazel to draw a comparison to WORKSPACE, but I think the Buck2 equivalent is a combo of buckconfig and PACKAGE. BXL is the Buck eXtension language and it lets you write programs in Starlark which query your build graph.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.bxl
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/facebook/buck2/blob/c779e6f75b80779a4951f99774040a324ff32f2e/examples/bxl_tutorial/part2.bxl
    - Sample license(s): Apache 2 & MIT
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.