### PR TITLE
Add support for `xinitrc` and `xsession` filenames

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7079,6 +7079,8 @@ Shell:
   - ".login"
   - ".profile"
   - ".tmux.conf"
+  - ".xinitrc"
+  - ".xsession"
   - ".zlogin"
   - ".zlogout"
   - ".zprofile"
@@ -7097,6 +7099,8 @@ Shell:
   - man
   - profile
   - tmux.conf
+  - xinitrc
+  - xsession
   - zlogin
   - zlogout
   - zprofile

--- a/samples/Shell/filenames/.xinitrc
+++ b/samples/Shell/filenames/.xinitrc
@@ -1,0 +1,18 @@
+dwmstatus &
+xfce4-screensaver &
+st -e irssi &
+st -e vim ~/TODO &
+chromium &
+mbsync -a &
+st -e neomutt &
+redshift -O3500; xset r rate 300 50; exec startdwm
+
+
+### startdwm
+while true; do
+    # Log stderror to a file
+    dwm 2> ~/.dwm.log
+    # No error logging
+    #dwm >/dev/null 2>&1
+done
+

--- a/samples/Shell/filenames/.xsession
+++ b/samples/Shell/filenames/.xsession
@@ -1,0 +1,10 @@
+# bcallah@ ~/.xsession
+
+xset b off &
+mixerctl outputs.master=180,180 &
+ls ~/.startup/o*.wav | shuf -n 1 | xargs aucat -i &
+ls ~/.wallpaper/*.jpg | shuf -n 1 | xargs feh --bg-fill --no-fehbg &
+xcompmgr -Ff &
+xrdb ~/.Xresources &
+tint2 &
+exec cwm

--- a/samples/Shell/filenames/xinitrc
+++ b/samples/Shell/filenames/xinitrc
@@ -1,0 +1,13 @@
+xbindkeys &
+dunst &
+synclient TouchPadOff=1
+#wmname LG3D
+xscreensaver -no-splash &
+(conky -c ~/.conky.conf |while read LINE; do xsetroot -name "$LINE"; done) &
+xset b 50 440 50
+xrdb -merge .Xdefaults
+#
+# dwm
+#
+dwm; exit
+

--- a/samples/Shell/filenames/xsession
+++ b/samples/Shell/filenames/xsession
@@ -1,0 +1,26 @@
+# use UTF-8 everywhere
+export LANG=en_US.UTF-8
+
+# specify location of kshrc
+export ENV=$HOME/.kshrc
+
+export PATH HOME TERM
+export ENV=$HOME/.kshrc
+export PATH=$PATH:$HOME/.local/bin
+export PATH=$PATH:$HOME/.yarn/bin
+export PATH=$PATH:$HOME/.npm-packages
+
+NPM_PACKAGES=$HOME/.npm-packages
+NODE_PATH="$NPM_PACKAGES/lib/modules:$NODE_PATH"
+export PATH=$NPM_PACKAGES/bin:$PATH
+
+# load Xresources file
+xrdb -merge $HOME/.Xresources &
+
+# disable system beep
+xset b off &
+
+# set your background color
+xsetroot -solid gray40 &
+
+exec ck-launch-session startxfce4


### PR DESCRIPTION
## Description
This pull-request adds the undotted and dotted forms of two X11-related filenames, [`xinitrc`](https://wiki.archlinux.org/title/Xinit) and [`xsession`](https://unix.stackexchange.com/q/47359), to the list of filenames recognised by Linguist as shell-script syntax.

## Checklist
-	[x] **I am adding new filenames to a language.**
	-	[x] **The new filenames are used in hundreds of repositories:**  
		These are configuration files that are frequently found in dotfile repositories, and many users include hashbangs that mark them as shell files. In the interests of fairness, I thought to include a count of those files that would benefit from the changes being made by this pull-request compared to those that wouldn't:
		<details open><summary><b>All results</b></summary>
		
		- `.xinitrc`:  [~8.7k files](https://github.com/search?q=path%3A**%2F.xinitrc&type=code&p=1)
		- `.xsession`: [~1.2k files](https://github.com/search?q=path%3A**%2F.xsession&type=code&p=1)
		- `xinitrc`:   [~3k files](https://github.com/search?q=path%3A**%2Fxinitrc&type=code&p=1)
		- `xsession`:  [~790 files](https://github.com/search?q=path%3A**%2Fxsession&type=code&p=1)
		</details><details><summary><b>Results without shell hashbangs</b></summary>
		
		- `.xinitrc`:  [~3.6k files](https://github.com/search?q=path%3A**%2F.xinitrc+NOT+language%3Ashell&type=code&p=1)
		- `.xsession`: [~486 files](https://github.com/search?q=path%3A**%2F.xsession+NOT+language%3Ashell&type=code&p=1)
		- `xinitrc`:   [~960 files](https://github.com/search?q=path%3A**%2Fxinitrc+NOT+language%3Ashell&type=code&p=1)
		- `xsession`:  [~168 files](https://github.com/search?q=path%3A**%2Fxsession+NOT+language%3Ashell&type=code&p=1)
		</details>
	-	[x] **I have included real-world usage samples for each filename added by this PR:**
		- `.xinitrc`:  [Source][5] ([MIT-licensed][6])
		- `.xsession`: [Source][7] ([ISC-licensed][8])
		- `xinitrc`:   [Source][3] ([MIT-licensed][4])
		- `xsession`:  [Source][1] ([MIT-licensed][2])
	-	[ ] **I have included a change to the heuristics.**

[1]: https://github.com/cyril2day/OpenBSD-Environment/blob/8e2e2556f33a1eb936e245b8500b4a8b294eb53d/config/home/xsession
[2]: https://github.com/cyril2day/OpenBSD-Environment/blob/40eb928768c2ea8ee7dfb9247ddeeda138541bf8/LICENSE
[3]: https://github.com/neilhwatson/nustuff/blob/b7bd4a6553ea3669071e7bae2156ad38bdbe1a95/X/xinitrc
[4]: https://github.com/neilhwatson/nustuff/blob/90d7619fb6205373e0b02d60f0eefcc8bb737e26/LICENSE
[5]: https://github.com/imlauera/dwm/blob/c0a6e66e4c821683867672ec612c24cb2f58535f/.xinitrc
[6]: https://github.com/imlauera/dwm/blob/3054dea12d5e3ddeebf450e3d9a2fc0fa5106177/LICENSE
[7]: https://github.com/ibara/dotfiles/blob/6b8a41efe8b81c1587e9cbb67fc35fea14ad6a06/.xsession
[8]: https://github.com/ibara/dotfiles/blob/f01223f2aff52cff568ef3d7fb622a5a7b738510/LICENSE
