### PR TITLE
Add Baz programming language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -581,6 +581,13 @@ Batchfile:
   ace_mode: batchfile
   color: "#C1F12E"
   language_id: 29
+Baz:
+  type: programming
+  extensions:
+    - ".baz"
+  tm_scope: source.baz
+  tree_sitter:
+    grammar: calint/tree-sitter-baz
 Beef:
   type: programming
   color: "#a52f4e"


### PR DESCRIPTION
Add support for Baz language (calint/tree-sitter-baz)

## Description

## Checklist:
- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      -  https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.baz+language
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/calint/compiler-2/blob/master/prog.baz
    - Sample license(s): Free
  - [x] I have included a syntax highlighting grammar: [[URL to grammar repo](https://github.com/calint/tree-sitter-baz)]
  - [x] I have added a color
    - Hex value: `#2B9DC6`
    - Rationale: Pleasant color
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
