### PR TITLE
Add `.bi` extension to QuickBASIC

### DIFF
--- a/lib/linguist/heuristics.yml
+++ b/lib/linguist/heuristics.yml
@@ -139,6 +139,8 @@ disambiguations:
     and:
     - pattern: '(?i)^[ \t]*return '
     - negative_pattern: '(?i)[ \t]*gosub '
+  - language: QuickBASIC
+    named_pattern: quickbasic
 - extensions: ['.bs']
   rules:
   - language: Bikeshed

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6131,6 +6131,7 @@ QuickBASIC:
   color: "#008080"
   extensions:
   - ".bas"
+  - ".bi"
   tm_scope: source.QB64
   aliases:
   - qb

--- a/samples/QuickBASIC/InForm.bi
+++ b/samples/QuickBASIC/InForm.bi
@@ -1,0 +1,118 @@
+'-----------------------------------------------------------------------------------------------------------------------
+' InForm-PE GUI engine for QB64-PE
+' Copyright (c) 2025 Samuel Gomes
+' Copyright (c) 2023 George McGinn
+' Copyright (c) 2022 Fellippe Heitor
+'-----------------------------------------------------------------------------------------------------------------------
+
+$INCLUDEONCE
+
+$LET INFORM_BI = TRUE
+
+$SCREENHIDE
+_ALLOWFULLSCREEN OFF
+_CONTROLCHR OFF
+
+'$INCLUDE:'InFormCommon.bi'
+
+'Control types: -----------------------------------------------
+__UI_Type(__UI_Type_Form).Name = "Form"
+
+__UI_Type(__UI_Type_Frame).Name = "Frame"
+__UI_Type(__UI_Type_Frame).DefaultWidth = 230
+__UI_Type(__UI_Type_Frame).DefaultHeight = 150
+
+__UI_Type(__UI_Type_Button).Name = "Button"
+__UI_Type(__UI_Type_Button).DefaultWidth = 80
+__UI_Type(__UI_Type_Button).DefaultHeight = 23
+
+__UI_Type(__UI_Type_Label).Name = "Label"
+__UI_Type(__UI_Type_Label).DefaultWidth = 150
+__UI_Type(__UI_Type_Label).DefaultHeight = 23
+
+__UI_Type(__UI_Type_CheckBox).Name = "CheckBox"
+__UI_Type(__UI_Type_CheckBox).DefaultWidth = 150
+__UI_Type(__UI_Type_CheckBox).DefaultHeight = 23
+__UI_Type(__UI_Type_CheckBox).TurnsInto = __UI_Type_ToggleSwitch
+
+__UI_Type(__UI_Type_RadioButton).Name = "RadioButton"
+__UI_Type(__UI_Type_RadioButton).DefaultWidth = 150
+__UI_Type(__UI_Type_RadioButton).DefaultHeight = 23
+
+__UI_Type(__UI_Type_TextBox).Name = "TextBox"
+__UI_Type(__UI_Type_TextBox).DefaultWidth = 120
+__UI_Type(__UI_Type_TextBox).DefaultHeight = 23
+
+__UI_Type(__UI_Type_ProgressBar).Name = "ProgressBar"
+__UI_Type(__UI_Type_ProgressBar).DefaultWidth = 300
+__UI_Type(__UI_Type_ProgressBar).DefaultHeight = 23
+
+__UI_Type(__UI_Type_ListBox).Name = "ListBox"
+__UI_Type(__UI_Type_ListBox).DefaultWidth = 200
+__UI_Type(__UI_Type_ListBox).DefaultHeight = 200
+__UI_Type(__UI_Type_ListBox).TurnsInto = __UI_Type_DropdownList
+
+__UI_Type(__UI_Type_DropdownList).Name = "DropdownList"
+__UI_Type(__UI_Type_DropdownList).DefaultWidth = 200
+__UI_Type(__UI_Type_DropdownList).DefaultHeight = 23
+__UI_Type(__UI_Type_DropdownList).TurnsInto = __UI_Type_ListBox
+
+__UI_Type(__UI_Type_MenuBar).Name = "MenuBar"
+__UI_Type(__UI_Type_MenuBar).TurnsInto = __UI_Type_ContextMenu
+__UI_Type(__UI_Type_MenuBar).RestrictResize = __UI_CantResizeV
+
+__UI_Type(__UI_Type_MenuItem).Name = "MenuItem"
+__UI_Type(__UI_Type_MenuItem).RestrictResize = __UI_CantResizeV
+
+__UI_Type(__UI_Type_MenuPanel).Name = "MenuPanel"
+
+__UI_Type(__UI_Type_PictureBox).Name = "PictureBox"
+__UI_Type(__UI_Type_PictureBox).DefaultWidth = 230
+__UI_Type(__UI_Type_PictureBox).DefaultHeight = 150
+
+__UI_Type(__UI_Type_TrackBar).Name = "TrackBar"
+__UI_Type(__UI_Type_TrackBar).DefaultWidth = 300
+__UI_Type(__UI_Type_TrackBar).DefaultHeight = 40
+__UI_Type(__UI_Type_TrackBar).MinimumHeight = 30
+__UI_Type(__UI_Type_TrackBar).RestrictResize = __UI_CantResizeV
+
+__UI_Type(__UI_Type_ContextMenu).Name = "ContextMenu"
+__UI_Type(__UI_Type_ContextMenu).TurnsInto = __UI_Type_MenuBar
+__UI_Type(__UI_Type_ContextMenu).RestrictResize = __UI_CantResize
+__UI_Type(__UI_Type_ContextMenu).DefaultWidth = 22
+__UI_Type(__UI_Type_ContextMenu).DefaultHeight = 22
+
+__UI_Type(__UI_Type_Font).Name = "Font"
+
+__UI_Type(__UI_Type_ToggleSwitch).Name = "ToggleSwitch"
+__UI_Type(__UI_Type_ToggleSwitch).DefaultWidth = 40
+__UI_Type(__UI_Type_ToggleSwitch).DefaultHeight = 17
+__UI_Type(__UI_Type_ToggleSwitch).TurnsInto = __UI_Type_CheckBox
+__UI_Type(__UI_Type_ToggleSwitch).RestrictResize = __UI_CantResize
+'--------------------------------------------------------------
+
+__UI_RestoreFKeys
+
+__UI_SubMenuDelay = .4
+__UI_SnapDistance = 5
+__UI_SnapDistanceFromForm = 10
+__UI_MaxBorderSize = 10
+__UI_Font8Offset = 5
+__UI_Font16Offset = 3
+__UI_ClipboardCheck$ = "InForm" + STRING$(2, 10) + "BEGIN CONTROL DATA" + CHR$(10) + STRING$(60, 45) + CHR$(10)
+
+__UI_ThemeSetup
+__UI_InternalMenus
+__UI_LoadForm
+
+__UI_Init
+
+'Main loop
+DO
+    _LIMIT 1
+LOOP
+
+SYSTEM
+
+__UI_ErrorHandler:
+RESUME NEXT


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

This PR adds the `.bi` extension which can be interpreted as "BASIC include" file used inside certain versions of BASIC like in this case for QuickBASIC (and FreeBASIC).

~~Note that the estimation of the number of files is a little difficult here because the heurisitcs we used for QuickBASIC are case-sensitive, but GitHub search is case-insensitive. For that reason, I've included an upper and lower bound for the estimation of the number of files. The upper bound might include FreeBASIC files that would normally not be detected as QuickBASIC since they don't have the right casing, but it's hard to tell by how much.~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      - [2k files](https://github.com/search?q=path%3A*.bi+NOT+is%3Afork+%2F%28%3F-i%3A%5E%5B+%5D*%28CONST%7CDIM%7CREDIM%7CDEFINT%7CPRINT%7CDECLARE+%28SUB%7CFUNCTION%29%7CFUNCTION%7CSUB%29+%29%7C%28%28%23%7C%24%29lang%3A%3F%5Cs*%22%3Fqb%22%3F%29%7C%28%3Fi%29%28%27%5C%24INCLUDE%3A%7C%5E%5B+%5D*CLS%5B+%5D*%28%27%27%7C%3A%7C%5Cr%7C%5Cn%29%7C%5E%5B+%5D*OPTION+_EXPLICIT%7C%5E%5B+%5D*DIM+SHARED+%7C%5E%5B+%5D*PRINT+%22%7C+As+_%28Byte%7COffset%7CMEM%29%7C%5E%5B+%5D*_%28DISPLAY%7CDEST%7CCONSOLE%7CSOURCE%7CFREEIMAGE%7CPALETTECOLOR%7CPRINTSTRING%7CLOADFONT%7CPUTIMAGE%29%7C%5E%5B+%5D*_%28TITLE%7CPLAYMOD%29+%22%7C%5E%5B+%5D*_%28LIMIT%7CSCREEN%7CDELAY%29+%5C.%3F%5Cd%2B%7C%5Cb_%28MOUSEBUTTON%7CNEWIMAGE%7CKEYDOWN%7CWIDTH%7CHEIGHT%29%5C%28%7C%5E%5B+%5D*%5C%24%28CONSOLE%7CCHECKING%29%3A%7C%5E%5B+%5D*%5C%24%28FULLSCREEN%7CRESIZE%7CSTATIC%7CDYNAMIC%7CNOPREFIX%7CSCREENSHOW%7CSCREENHIDE%7CEXEICON%29%5Cb%29%2F&type=code) 
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/FellippeHeitor/InForm/blob/3820134c76970c004376cc8f92433065643966a3/InForm/InForm.bi
    - Sample license(s): [MIT](https://github.com/FellippeHeitor/InForm/blob/development/LICENSE.md)
  - [x] I have included a change to the heuristics to distinguish my language from others using the same extension.
