### PR TITLE
Adds Mercury (some language i made)

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -735,6 +735,13 @@ Boo:
   ace_mode: text
   tm_scope: source.boo
   language_id: 37
+Mercury:
+  type: programming
+  color: "#D100D1"
+  extensions:
+  - ".merc"
+  tm_scope: source.merc
+  ace_mode: text
 Boogie:
   type: programming
   color: "#c80fa0"


### PR DESCRIPTION
# Adding Mercury Language

## Description
Adds Mercury programming language to `languages.yml` with the `.merc` extension.

## Checklist:

- [ ] **I am adding a new extension to a language.**
  - [ ] N/A

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for `.merc` extension:  
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.merc+mercury
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/Epicinver/MercuryLang
    - Sample license(s):
      - MIT
  - [x] I have included a syntax highlighting grammar: 
      - https://github.com/Epicinver/mercury-vscode
  - [x] I have added a color
    - Hex value: `#D100D1`
    - Rationale: Mercury’s theme color is purple, consistent with its branding.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**
  - N/A

- [ ] **I am changing the source of a syntax highlighting grammar**
  - N/A

- [ ] **I am updating a grammar submodule**
  - N/A

- [ ] **I am adding new or changing current functionality**
  - N/A

- [ ] **I am changing the color associated with a language**
  - N/A
