### PR TITLE
Add Avocado programming language

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -528,6 +528,14 @@ Awk:
   tm_scope: source.awk
   ace_mode: text
   language_id: 28
+Avocado:
+  type: programming
+  color: "#6BBA62"
+  extensions:
+  - ".avo"
+  tm_scope: source.avocado
+  ace_mode: text
+  language_id: 1000000001
 B4X:
   type: programming
   color: "#00e4ff"

--- a/samples/Avocado/hello.avo
+++ b/samples/Avocado/hello.avo
@@ -1,0 +1,6 @@
+// Hello World in Avocado DSL
+// The canonical first program in Avocado
+
+fn main() {
+    println("Hello from Avocado! 🥑");
+}


### PR DESCRIPTION
Avocado is a statically typed systems programming language I engineered specifically for cybersecurity operations, designed from first principles to give security professionals the precision and control modern tooling lacks. It combines Rust grade memory safety, gostyle ergonomics, and direct low level access through a native c backend hopefully enabling high performance execution for pentesting, exploit development, digital forensics, and network level security engineering. For cybersecurity purposes only.

The language ships with a comprehensive security-oriented standard library including cryptographic primitives, packet inspection, socket tooling, stateful firewall construction, vulnerability scanning modules, and architecture-aware exploit templates. Avocado’s compiler pipeline ( aka lexer → parser → type checker → C codegen → GCC / Clang) is designed for clarity, auditability, and determinism, ensuring predictable behavior in high risk security environments.

Designed to be both expressive and operationally reliable, Avocado provides a purpose-built environment for professionals who need to write secure tooling with the speed of a scripting language and the performance of native code.

Hope that helps