### PR TITLE
Add Premake language definition

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9151,3 +9151,13 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
+Premake:
+  type: programming
+  extensions:
+    - .lua
+  filenames:
+    - premake5.lua
+    - premake4.lua
+  ace_mode: lua
+  color: "#e67e22"
+  tm_scope: source.lua


### PR DESCRIPTION
## Description
Adding support for Premake files (`premake5.lua` and `premake4.lua`) as a distinct language in GitHub Linguist. These files are Lua-based but have a specific structure and usage, so we distinguish them from generic Lua.

Official Premake links:  
- Repository: https://github.com/premake/premake-core  
- Website: https://premake.github.io/

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.lua+premake5.lua
    - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.lua+premake4.lua
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      ```lua
      workspace "MyProject"
          architecture "x64"
          location "build"

          configurations{
              "Debug",
              "Release"
          }

      include "vendor/premake5.lua"

      project "App"
          location "build"
          kind "ConsoleApp"
          language "C++"
          cppdialect "C++20"

          targetdir("build/%{cfg.buildcfg}")
          objdir("build/obj/%{cfg.buildcfg}")

          files {
              "App/**.h", 
              "App/**.hpp", 
              "App/**.cpp"
          }

          includedirs{
              "App/",
          }
      ```
    - Sample license(s): BSD License (Premake)
  - [x] I have added a color
    - Hex value: `#e67e22`
    - Rationale: Premake’s official branding uses orange.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
