### PR TITLE
Add Luajit interpreter to Lua

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4274,6 +4274,7 @@ Lua:
   - ".luacheckrc"
   interpreters:
   - lua
+  - luajit
   language_id: 213
 Luau:
   type: programming


### PR DESCRIPTION
Luajit is popular interpreter for Lua. Right now shebangs like `#!/usr/bin/env luajit` do not enable syntax highlight on GitHub

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->

## Checklist:
- [x] **I am adding new or changing current functionality**
  - [ ] I have added or updated the tests for the new or changed functionality.