### PR TITLE
This PR adds official Linguist support for the Vitte programming language.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -9210,14 +9210,5 @@ xBase:
   tm_scope: source.harbour
   ace_mode: text
   language_id: 421
-  Vitte:
-  type: programming
-  extensions:
-    - ".vitte"
-    - ".vit"
-    - ".vitx"
-  tm_scope: source.vitte
-  ace_mode: text
-  color: "#FF6600"
-  language_id: 999999999
+  
 


### PR DESCRIPTION

Changes:
- Define the "Vitte" language in lib/linguist/languages.yml
  - type: programming
  - extensions: .vitte, .vit
  - tm_scope: source.vitte
  - aliases: vitte, vit
  - color: "#3B82F6"






Notes:
- Extensions are intentionally limited to .vitte and .vit.