### PR TITLE
Delete `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Fix syntax highlighting for devcontainer files
-.devcontainer/*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
## Description

The only entry was an override that is no longer needed in newer versions of Linguist.

See https://github.com/github-linguist/linguist/pull/7600#discussion_r2418975679

## Checklist:

N/A