### PR TITLE
Add Rey programming language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -6267,6 +6267,11 @@ REXX:
   tm_scope: source.rexx
   ace_mode: text
   language_id: 311
+Rey:
+  type: programming
+  extensions:
+    - ".rey"
+  color: "#ff9361"
 RMarkdown:
   type: prose
   color: "#198ce7"


### PR DESCRIPTION
Adds support for the Rey programming language with the .rey extension.

## Checklist:

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.rey+language
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/rey-language/rey
    - Sample license(s):
      - MIT
  - [ ] I have included a syntax highlighting grammar: [URL to grammar repo]
  - [x] I have added a color
    - Hex value: `#ff9361`
    - Rationale: Selected for high contrast and clear visual distinction in GitHub’s language statistics.
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.
