### PR TITLE
Cyber+ scripting language support

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -864,11 +864,12 @@ C++:
   language_id: 43
 Cyber+:
   type: programming
-  color: "#00E5FF"
+  color: "#00CFFF"
   extensions:
     - ".cybp"
   tm_scope: source.cyberplus
   ace_mode: text
+
 C-ObjDump:
   type: data
   extensions:


### PR DESCRIPTION
Add Cyber+ language support with .cpu extension
I want Cyber+ programming language Alpha ( a powerful programming language for Cyber security ) be added in language support.
Here is the github resp for it -- https://github.com/TanmayCzax/Cyber-Programming-language-Alpha