### PR TITLE
Update C# color

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -819,7 +819,7 @@ C#:
   codemirror_mode: clike
   codemirror_mime_type: text/x-csharp
   tm_scope: source.cs
-  color: "#178600"
+  color: "#E6E6FA"
   aliases:
   - csharp
   - cake


### PR DESCRIPTION
## Description

This pull request proposes updating the color associated with **C#** in GitHub Linguist from green to a lavender tone.

The current green color closely overlaps with several other widely used languages, which can make repositories with mixed language usage harder to visually distinguish at a glance in the language bar. A lavender color provides clearer differentiation while remaining readable and neutral in both light and dark themes.

The proposed color was selected to:
- Improve visual distinction from other green-coded languages
- Maintain sufficient contrast in GitHub’s UI
- Avoid clashing with existing dominant language colors

This change is intended to gather feedback from maintainers and the wider C# community before any final decision.

## Checklist

- [x] **I am changing the color associated with a language**
- [ ] I have obtained agreement from the wider language community on this color change
