### PR TITLE
Add aliases to glimmer-js and glimmer-ts

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2662,6 +2662,8 @@ Glimmer JS:
   language_id: 5523150
 Glimmer TS:
   type: programming
+  aliases:
+  - gts
   extensions:
   - ".gts"
   ace_mode: typescript


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

Patches #6630 and #6680.

While the terms "Glimmer JS" and "Glimmer TS" do currently appear in public repos in the context of parsers, I think these terms are technical and not what Ember developers would colloquially refer to files with `<template>` tags. Rather, we refer to `gjs` and `gts`, respectively.

Example: [Ember's official tutorial](https://guides.emberjs.com/release/tutorial/part-1/orientation/) doesn't mention "Glimmer JS" or "Glimmer TS."

<img width="1728" height="951" alt="" src="https://github.com/user-attachments/assets/dd7b8625-de5e-4de9-84a4-9d795224f2af" />

Examples of more technical documentations:

- https://github.com/ember-cli/ember-template-imports/tree/v4.4.0-ember-template-imports?tab=readme-ov-file#using-template-tags-and-gjsgts-files
- https://rfcs.emberjs.com/id/1046-template-tag-in-routes/

I added the `aliases` key to these 2 languages, in particular, to ease writing code blocks on GitHub. Once this pull request is approved and released, developers would be able to write the following:

````diff
- ```glimmer-js
+ ```gjs
const Hello = <template>
  <div>Hello, {{@name}}!</div>
</template>;

export default Hello;
```
````

````diff
- ```glimmer-ts
+ ```gts
interface HelloSignature {
  Args: {
    name: string;
  }
}

const Hello: HelloSignature = <template>
  <div>Hello, {{@name}}!</div>
</template>;

export default Hello;
```
````


## Checklist:

- [x] **I am adding new or changing current functionality**
  <!-- This includes modifying the vendor, documentation, and generated lists. -->
  - [ ] I have added or updated the tests for the new or changed functionality.
