### PR TITLE
Add HLX language support

### DIFF
--- a/grammars.yml
+++ b/grammars.yml
@@ -45,6 +45,8 @@ vendor/grammars/GeneroFgl.tmbundle:
 - source.genero-per
 vendor/grammars/Handlebars:
 - text.html.handlebars
+vendor/grammars/hlx-language:
+- source.hlx
 vendor/grammars/IDL-Syntax:
 - source.webidl
 vendor/grammars/Isabelle.tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2938,6 +2938,18 @@ HLSL:
   ace_mode: text
   tm_scope: source.hlsl
   language_id: 145
+HLX:
+  type: programming
+  color: "#9d4edd"
+  aliases:
+  - hlx
+  extensions:
+  - ".hlxa"
+  - ".hlxc"
+  tm_scope: source.hlx
+  ace_mode: text
+  interpreters:
+  - hlx
 HOCON:
   type: data
   color: "#9ff8ee"

--- a/samples/HLX/sample.hlxa
+++ b/samples/HLX/sample.hlxa
@@ -1,0 +1,31 @@
+// Sample HLX program demonstrating language syntax
+
+program fibonacci {
+    fn fib(n) -> int {
+        if n <= 1 {
+            return n;
+        }
+        return fib(n - 1) + fib(n - 2);
+    }
+
+    fn factorial(n) -> int {
+        if n <= 1 {
+            return 1;
+        }
+        return n * factorial(n - 1);
+    }
+
+    fn main() {
+        // Compute fibonacci numbers
+        let fib_result = fib(10);
+        print("Fibonacci(10):");
+        print(fib_result);
+
+        // Compute factorial
+        let fact_result = factorial(5);
+        print("Factorial(5):");
+        print(fact_result);
+
+        return 0;
+    }
+}

--- a/vendor/grammars/hlx-language/hlx.tmLanguage.json
+++ b/vendor/grammars/hlx-language/hlx.tmLanguage.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "HLX",
+  "scopeName": "source.hlx",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#keywords" },
+    { "include": "#types" },
+    { "include": "#strings" },
+    { "include": "#numbers" },
+    { "include": "#operators" },
+    { "include": "#functions" },
+    { "include": "#variables" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.hlx",
+          "match": "//.*$"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.hlx",
+          "match": "\\b(if|else|loop|break|continue|return)\\b"
+        },
+        {
+          "name": "keyword.other.hlx",
+          "match": "\\b(fn|let|program)\\b"
+        },
+        {
+          "name": "constant.language.hlx",
+          "match": "\\b(true|false)\\b"
+        },
+        {
+          "name": "keyword.operator.logical.hlx",
+          "match": "\\b(and|or|not)\\b"
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "name": "storage.type.hlx",
+          "match": "\\b(bool|int|float|string|object)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.hlx",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.hlx",
+              "match": "\\\\(n|r|t|\\\\|\")"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hlx",
+          "match": "\\b\\d+\\.\\d+\\b"
+        },
+        {
+          "name": "constant.numeric.hlx",
+          "match": "\\b\\d+\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.comparison.hlx",
+          "match": "(==|!=|<=|>=|<|>)"
+        },
+        {
+          "name": "keyword.operator.arithmetic.hlx",
+          "match": "(\\+|-|\\*|/|%)"
+        },
+        {
+          "name": "keyword.operator.assignment.hlx",
+          "match": "="
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "name": "entity.name.function.hlx",
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()"
+        },
+        {
+          "name": "support.function.builtin.hlx",
+          "match": "\\b(print|len|ord|chr|push|pop|type)\\b"
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "name": "variable.other.hlx",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Add HLX language support

This PR adds support for HLX (Helix Language), a self-hosting deterministic programming language designed for human-AI collaboration.

## Language Information

- **Extensions**: `.hlxa` (ASCII source), `.hlxc` (compiled/canonical)
- **Type**: Programming language
- **Repository**: https://github.com/latentcollapse/hlx-compiler
- **License**: Apache 2.0
- **Status**: Self-hosting compiler with bootstrap verification

## Changes

- Added HLX to `lib/linguist/languages.yml`
- Added TextMate grammar to `vendor/grammars/hlx-language/`
- Added grammar reference to `grammars.yml`
- Added sample code to `samples/HLX/`

## Language Features

HLX is a tensor-native programming language with:
- Self-hosting compiler (compiles itself)
- Deterministic output (same input → same output, verified)
- First-class tensor operations
- Focus on human-AI collaboration

## Verification

The compiler achieves "Ouroboros" - a 3-stage bootstrap where:
1. Rust compiler compiles HLX source (Stage 1)
2. Stage 1 compiles itself (Stage 2)
3. Stage 2 compiles itself (Stage 3)
4. Stage 2 == Stage 3 (bytewise identical)

This proves the compiler is fully self-hosting and deterministic.

## Sample Code

```hlx
program fibonacci {
    fn fib(n) -> int {
        if n <= 1 {
            return n;
        }
        return fib(n - 1) + fib(n - 2);
    }

    fn main() {
        let result = fib(10);
        print(result);
        return 0;
    }
}
```

## Testing

All files added follow Linguist conventions:
- Grammar uses TextMate format
- Sample code demonstrates key syntax features
- Language definition includes proper metadata

Ready for review.
