### PR TITLE
Add ApexForge NightScript language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ test/fixtures/ace_modes.json
 linguist-grammars*
 .venv
 Brewfile.lock.json
+
+# bundler vendor dir
+/vendor/bundle/
+
+# bundler local config
+/.bundle/

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -384,6 +384,15 @@ Apex:
   codemirror_mode: clike
   codemirror_mime_type: text/x-java
   language_id: 17
+ApexForge NightScript:
+  type: programming
+  color: "#F59E0B"
+  extensions:
+  - ".afns"
+  - ".afml"
+  tm_scope: none
+  ace_mode: text
+  language_id: 246039967
 Apollo Guidance Computer:
   type: programming
   color: "#0B3D91"
@@ -583,8 +592,8 @@ Batchfile:
   - ".bat"
   - ".cmd"
   filenames:
-  - "gradlew.bat"
-  - "mvnw.cmd"
+  - gradlew.bat
+  - mvnw.cmd
   tm_scope: source.batchfile
   ace_mode: batchfile
   color: "#C1F12E"

--- a/samples/ApexForge NightScript/api.afml
+++ b/samples/ApexForge NightScript/api.afml
@@ -1,0 +1,4 @@
+# AFML sample for Linguist detection
+title: "Hello AFML"
+body:
+  - "This is a sample .afml file."

--- a/samples/ApexForge NightScript/hello.afns
+++ b/samples/ApexForge NightScript/hello.afns
@@ -1,0 +1,17 @@
+package demo;
+
+import forge.log as log;
+
+fun apex()::Option<Result> {
+  let name::String = "ApexForge";
+  let age::i32 = 2;
+
+  log.info(q"Hello $name, age=$age");
+
+  check age {
+    0..=10 => log.info("young");
+    _ => log.info("unknown");
+  }
+
+  Some(Ok())
+}


### PR DESCRIPTION
## Description

This pull request adds support for the **ApexForge NightScript (AFNS)** programming language to GitHub Linguist.

It includes:
- New language entry for **ApexForge NightScript**
- File extensions: `.afns` and `.afml`
- Sample files for accurate detection
- Verified with `bundle exec rake test` (all tests passing)

## Details

ApexForge NightScript is a modern systems and application programming language developed as part of the ApexForge platform.

This PR enables:
- Correct language detection on GitHub
- Syntax classification for `.afns` and `.afml` files
- Repository language statistics

## Checklist

- [x] I am adding a new language
- [x] I have added sample files
- [x] All tests pass locally (`bundle exec rake test`)
- [x] The language entry is sorted correctly
