### PR TITLE
Add ApexForge NightScript language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ test/fixtures/ace_modes.json
 linguist-grammars*
 .venv
 Brewfile.lock.json
+
+# bundler vendor dir
+/vendor/bundle/
+
+# bundler local config
+/.bundle/

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -384,6 +384,15 @@ Apex:
   codemirror_mode: clike
   codemirror_mime_type: text/x-java
   language_id: 17
+ApexForge NightScript:
+  type: programming
+  color: "#F59E0B"
+  extensions:
+  - ".afns"
+  - ".afml"
+  tm_scope: none
+  ace_mode: text
+  language_id: 246039967
 Apollo Guidance Computer:
   type: programming
   color: "#0B3D91"
@@ -583,8 +592,8 @@ Batchfile:
   - ".bat"
   - ".cmd"
   filenames:
-  - "gradlew.bat"
-  - "mvnw.cmd"
+  - gradlew.bat
+  - mvnw.cmd
   tm_scope: source.batchfile
   ace_mode: batchfile
   color: "#C1F12E"

--- a/samples/ApexForge NightScript/api.afml
+++ b/samples/ApexForge NightScript/api.afml
@@ -1,0 +1,4 @@
+# AFML sample for Linguist detection
+title: "Hello AFML"
+body:
+  - "This is a sample .afml file."

--- a/samples/ApexForge NightScript/hello.afns
+++ b/samples/ApexForge NightScript/hello.afns
@@ -1,0 +1,17 @@
+package demo;
+
+import forge.log as log;
+
+fun apex()::Option<Result> {
+  let name::String = "ApexForge";
+  let age::i32 = 2;
+
+  log.info(q"Hello $name, age=$age");
+
+  check age {
+    0..=10 => log.info("young");
+    _ => log.info("unknown");
+  }
+
+  Some(Ok())
+}


### PR DESCRIPTION
## Description

This pull request adds support for a new programming language called **ApexForge NightScript (AFNS)**.

It includes:
- Language definition in `languages.yml`
- File extensions `.afns` and `.afml`
- Sample files for Linguist detection
- Updated samples database
- All tests passing

This allows GitHub Linguist to correctly detect and classify ApexForge NightScript repositories.

---

## Checklist

- [x] I am adding a new extension to a language
- [x] The new extension is used in real repositories on GitHub
- [x] I have added sample files under `samples/`
- [x] I have run `bundle exec rake test`
- [x] All tests pass

---

## About the language

**ApexForge NightScript** is a systems and application programming language developed for the ApexForge platform.  
It is used for operating system development, application scripting, and tooling inside the ApexForge ecosystem.

The language is actively used in:
- ApexForge Phoenix Night OS
- ApexForge NightScript SDK
- ApexForge GUI and Android tooling

It is already published and used in public GitHub repositories.

---

## Extensions

- `.afns` — ApexForge NightScript source
- `.afml` — ApexForge Markup Language
