### PR TITLE
Standardise usage requirements and assessment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ If there are official branding guidelines to support the colour choice, please l
 
 In order to a new language extension or filename to be accepted in Linguist, we require that there is sufficient wide-spread usage on public GitHub repositories.
 This means we do not accept PRs for very new or hobby languages, and will close any such PRs that attempt to add them.
-We use GitHub's Search to assess popularity. The search query we ask you to provide in the PR template is required to support evidence of your language's usage in the wild. The better your search query, the more likely your PR will be accepted.
+We use GitHub's Search to assess popularity. The search query we ask you to provide in the PR template is required to support evidence of your language's usage in the wild.
 Note that there are [limitations][search-limitations] imposed on what results are indexed by GitHub Search.
 
 The usage requirements are:


### PR DESCRIPTION
<!--- Briefly describe your changes in the field above. -->

## Description

We've been using the "temporary" usage requirements and assessment approach detailed in https://github.com/github-linguist/linguist/issues/5756 since GitHub changed its Search.

Nothing better has come about since then so I think it's time we solidify these in the CONTRIBUTING.md file and make them easily referencable.

I've also taken the opportunity to use GitHub markdown alerts to bring attention to some of our important points.

Closes https://github.com/github-linguist/linguist/issues/5756
