### PR TITLE
Add PklProject filename to Pkl

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -5845,6 +5845,8 @@ Pkl:
   color: "#6b9543"
   extensions:
   - ".pkl"
+  filenames:
+  - PklProject
   interpreters:
   - pkl
   tm_scope: source.pkl

--- a/samples/Pkl/filenames/PklProject
+++ b/samples/Pkl/filenames/PklProject
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+amends "pkl:Project"
+
+package {
+  name = "pkl.swift"
+  baseUri = "package://pkg.pkl-lang.org/pkl-swift/\(name)"
+  packageZipUrl =
+    "https://github.com/apple/pkl-swift/releases/download/\(name)@\(version)/\(name)@\(version).zip"
+  version = read("../../VERSION.txt").text.trim()
+  authors {
+    "The Pkl Authors <pkl-oss@group.apple.com>"
+  }
+  sourceCodeUrlScheme =
+    "https://github.com/apple/pkl-swift/blob/\(version)/codegen/src%{path}#L%{line}-L%{endLine}"
+  sourceCode = "https://github.com/apple/pkl-swift"
+  description = "Pkl bindings for the Swift programming language"
+  license = "Apache-2.0"
+  exclude {
+    "tests"
+    "tests/**"
+  }
+}
+
+tests {
+  for (key, _ in import*("tests/*.pkl")) {
+    key
+  }
+}


### PR DESCRIPTION
Add `PklProject` to Pkl's `filenames`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding a new extension to a language.**
  - [x] The new extension is used in hundreds of repositories on GitHub.com
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT%20is%3Afork%20path%3A*PklProject%20amends
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/apple/pkl-swift/blob/4ef24e1ffac624de9bd6909a5a830f08f48fe38a/codegen/src/PklProject
    - Sample license(s):
      - Apache-2.0
  - [ ] I have included a change to the heuristics to distinguish my language from others using the same extension.
