### PR TITLE
Add Kotodama language grammar and samples

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -770,6 +770,9 @@
 [submodule "vendor/grammars/language-kotlin"]
 	path = vendor/grammars/language-kotlin
 	url = https://github.com/nishtahir/language-kotlin
+[submodule "vendor/grammars/language-kotodama"]
+	path = vendor/grammars/language-kotodama
+	url = https://github.com/takemiyamakoto/language-kotodama.git
 [submodule "vendor/grammars/language-langium"]
 	path = vendor/grammars/language-langium
 	url = https://github.com/eclipse-langium/language-langium.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -718,6 +718,8 @@ vendor/grammars/language-kickstart:
 - source.kickstart
 vendor/grammars/language-kotlin:
 - source.kotlin
+vendor/grammars/language-kotodama:
+- source.kotodama
 vendor/grammars/language-langium:
 - source.langium
 vendor/grammars/language-less:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -4012,6 +4012,14 @@ Koka:
   color: "#215166"
   tm_scope: source.koka
   language_id: 597930447
+Kotodama:
+  type: programming
+  color: "#C26E2D"
+  extensions:
+  - ".ko"
+  tm_scope: source.kotodama
+  ace_mode: text
+  language_id: 426932494
 Kotlin:
   type: programming
   color: "#A97BFF"

--- a/samples/Kotodama/irohaswap.ko
+++ b/samples/Kotodama/irohaswap.ko
@@ -1,0 +1,153 @@
+// Constant-product (XYK) DEX sample with basic pool lifecycle.
+// Pools are keyed by a caller-provided `Name` so multiple pairs can coexist.
+seiyaku IrohaSwap {
+  // Pool metadata
+  state PoolAssetA: Map<Name, AssetDefinitionId>;
+  state PoolAssetB: Map<Name, AssetDefinitionId>;
+  state PoolAccount: Map<Name, AccountId>;
+  state PoolLpAsset: Map<Name, AssetDefinitionId>;
+
+  // Pool accounting (reserves and LP supply)
+  state ReserveA: Map<Name, int>;
+  state ReserveB: Map<Name, int>;
+  state LpSupply: Map<Name, int>;
+
+  fn min(a: int, b: int) -> int {
+    if (a < b) { return a; } else { return b; }
+  }
+
+  fn ensure_pool(pool: Name) {
+    assert(contains(PoolAssetA, pool), "unknown pool");
+  }
+
+  // Create a new pool with caller-chosen LP asset and pool account.
+  #[access(read="*", write="*")]
+	  kotoage fn init_pool(pool: Name,
+	                       asset_a: AssetDefinitionId,
+	                       asset_b: AssetDefinitionId,
+	                       pool_account: AccountId,
+	                       lp_asset: AssetDefinitionId) permission(Admin) {
+    assert(asset_a != asset_b, "identical assets");
+    // Refuse re-init.
+    assert(!contains(PoolAssetA, pool), "pool exists");
+    PoolAssetA[pool] = asset_a;
+    PoolAssetB[pool] = asset_b;
+    PoolAccount[pool] = pool_account;
+    PoolLpAsset[pool] = lp_asset;
+    ReserveA[pool] = 0;
+    ReserveB[pool] = 0;
+    LpSupply[pool] = 0;
+    info("pool_initialized");
+  }
+
+  // Provide liquidity; mints LP proportional to contribution.
+  #[access(read="*", write="*")]
+	  kotoage fn deposit_liquidity(provider: AccountId,
+	                               pool: Name,
+	                               amount_a: int,
+	                               amount_b: int) permission(Admin) {
+    assert(amount_a > 0, "invalid amount_a");
+    assert(amount_b > 0, "invalid amount_b");
+    ensure_pool(pool);
+
+    let asset_a = PoolAssetA[pool];
+    let asset_b = PoolAssetB[pool];
+    let pool_account = PoolAccount[pool];
+    let lp_asset = PoolLpAsset[pool];
+
+    let reserve_a = get_or_insert_default(ReserveA, pool, 0);
+    let reserve_b = get_or_insert_default(ReserveB, pool, 0);
+    let total_lp = get_or_insert_default(LpSupply, pool, 0);
+
+    let minted = (total_lp == 0) ? isqrt(amount_a * amount_b) : min((amount_a * total_lp) / reserve_a,
+                                                                   (amount_b * total_lp) / reserve_b);
+
+    assert(minted > 0, "zero lp");
+
+    // Move tokens into the pool account.
+    transfer_asset(provider, pool_account, asset_a, amount_a);
+    transfer_asset(provider, pool_account, asset_b, amount_b);
+    // Mint LP tokens to the provider.
+    mint_asset(provider, lp_asset, minted);
+
+    ReserveA[pool] = reserve_a + amount_a;
+    ReserveB[pool] = reserve_b + amount_b;
+    LpSupply[pool] = total_lp + minted;
+  }
+
+  // Withdraw liquidity; burns LP and returns proportional reserves.
+  #[access(read="*", write="*")]
+	  kotoage fn withdraw_liquidity(provider: AccountId,
+	                                pool: Name,
+	                                lp_amount: int) permission(Admin) {
+    assert(lp_amount > 0, "invalid lp");
+    ensure_pool(pool);
+
+    let asset_a = PoolAssetA[pool];
+    let asset_b = PoolAssetB[pool];
+    let pool_account = PoolAccount[pool];
+    let lp_asset = PoolLpAsset[pool];
+
+    let reserve_a = get_or_insert_default(ReserveA, pool, 0);
+    let reserve_b = get_or_insert_default(ReserveB, pool, 0);
+    let total_lp = get_or_insert_default(LpSupply, pool, 0);
+    assert(total_lp > 0, "empty pool");
+
+    let amount_a = (lp_amount * reserve_a) / total_lp;
+    let amount_b = (lp_amount * reserve_b) / total_lp;
+    assert(amount_a > 0, "zero out a");
+    assert(amount_b > 0, "zero out b");
+
+    burn_asset(provider, lp_asset, lp_amount);
+    transfer_asset(pool_account, provider, asset_a, amount_a);
+    transfer_asset(pool_account, provider, asset_b, amount_b);
+
+    ReserveA[pool] = reserve_a - amount_a;
+    ReserveB[pool] = reserve_b - amount_b;
+    LpSupply[pool] = total_lp - lp_amount;
+  }
+
+  // Swap with 0.3% fee (997/1000).
+  #[access(read="*", write="*")]
+	  kotoage fn swap(trader: AccountId,
+	                  pool: Name,
+	                  input_asset: AssetDefinitionId,
+	                  amount_in: int,
+	                  min_output: int) -> int permission(Admin) {
+    assert(amount_in > 0, "invalid amount");
+    ensure_pool(pool);
+
+    let asset_a = PoolAssetA[pool];
+    let asset_b = PoolAssetB[pool];
+    let pool_account = PoolAccount[pool];
+
+    let reserve_a = get_or_insert_default(ReserveA, pool, 0);
+    let reserve_b = get_or_insert_default(ReserveB, pool, 0);
+
+    let is_a_in = input_asset == asset_a;
+    let is_b_in = input_asset == asset_b;
+    assert(is_a_in || is_b_in, "asset not in pool");
+
+    let reserve_in = (is_a_in) ? reserve_a : reserve_b;
+    let reserve_out = (is_a_in) ? reserve_b : reserve_a;
+
+    let effective = (amount_in * 997) / 1000;
+    let out = (reserve_out * effective) / (reserve_in + effective);
+    assert(out >= min_output, "slippage");
+    assert(out > 0, "insufficient output");
+
+    if (is_a_in) {
+      ReserveA[pool] = reserve_in + amount_in;
+      ReserveB[pool] = reserve_out - out;
+      transfer_asset(trader, pool_account, asset_a, amount_in);
+      transfer_asset(pool_account, trader, asset_b, out);
+    } else {
+      ReserveB[pool] = reserve_in + amount_in;
+      ReserveA[pool] = reserve_out - out;
+      transfer_asset(trader, pool_account, asset_b, amount_in);
+      transfer_asset(pool_account, trader, asset_a, out);
+    }
+
+    return out;
+  }
+}

--- a/samples/Kotodama/mint_rose_trigger.ko
+++ b/samples/Kotodama/mint_rose_trigger.ko
@@ -1,0 +1,8 @@
+// Mint `62Fk4FPcMuLvW5QjDGNF2a4jAmjM` (canonical asset-definition address below) for the trigger authority.
+// Amount is taken from trigger args (MintRoseArgs.val) when available.
+seiyaku MintRoseTrigger {
+  kotoage fn run() permission(Admin) {
+    // Mint using typed arguments: authority and explicit asset; amount from trigger args when 0
+    mint_asset(authority(), asset_definition!("66owaQmAQMuHxPzxUN3bqZ6FJfDa"), 0);
+  }
+}

--- a/samples/Kotodama/zk_vote_and_unshield.ko
+++ b/samples/Kotodama/zk_vote_and_unshield.ko
@@ -1,0 +1,75 @@
+// Demonstrates the intended flow for shielded voting and unshield operations
+// using Kotodama ZK intrinsics followed by the vendor bridge to enqueue ISIs.
+//
+// These intrinsics lower to IVM syscalls with strict pointer‑ABI:
+//   - `zk_vote_verify_ballot(norito_bytes(...))` → ZK_VOTE_VERIFY_BALLOT (0x62)
+//   - `zk_verify_unshield(norito_bytes(...))` → ZK_VERIFY_UNSHIELD (0x61)
+//   - `execute_instruction(<Blob NoritoBytes InstructionBox>)` → SMARTCONTRACT_EXECUTE_INSTRUCTION (0xA0)
+//
+// Note: This sample uses string literals and inline builders to construct
+// Blob/NoritoBytes pointers for illustration. Real clients should prepare
+// proper Norito TLVs (envelopes and InstructionBox bytes) and may preload them
+// into INPUT.
+seiyaku ZkVoteAndUnshield {
+  meta {
+    abi_version: 1,
+    features: ["zk"],
+    max_cycles: 0,
+  }
+
+  // Verify a ballot proof, then enqueue a prebuilt SubmitBallot instruction via the vendor bridge.
+  #[access(read="*", write="*")]
+  fn verify_and_submit_ballot(proof_env: Blob, submit: Blob) {
+    // 1) Verify the ballot using ZK_VOTE_VERIFY_BALLOT.
+    //    `proof_env` must be a Norito-encoded OpenVerifyEnvelope in a NoritoBytes TLV.
+    zk_vote_verify_ballot(proof_env);
+
+    // 2) Enqueue the prebuilt SubmitBallot InstructionBox.
+    // Generic entry point: lowers to SMARTCONTRACT_EXECUTE_INSTRUCTION (0xA0)
+    execute_instruction(submit);
+  }
+
+  // Verify an unshield proof, then enqueue a prebuilt Unshield instruction via the vendor bridge.
+  #[access(read="*", write="*")]
+  fn verify_and_unshield(proof_env: Blob, unshield: Blob) {
+    // 1) Verify the unshield using ZK_VERIFY_UNSHIELD (0x61).
+    zk_verify_unshield(proof_env);
+
+    // 2) Enqueue the prebuilt Unshield instruction.
+    execute_instruction(unshield);
+  }
+
+  // Optional demo entrypoint: verifies and enqueues both operations using literal data.
+  #[access(read="*", write="*")]
+  kotoage fn demo() {
+    // Mock envelope bytes (opaque here); in practice, pass a Norito-encoded OpenVerifyEnvelope.
+    let env_ballot = norito_bytes("ENV-BALLOT");
+    let env_unshield = norito_bytes("ENV-UNSHIELD");
+    let nullifier = blob!("0123456789abcdef0123456789abcdef");
+    let proof = blob!("proof-bytes");
+    let vk = blob!("vk-bytes");
+
+    // Inline builders require literal inputs; for runtime data, prebuild
+    // the Norito InstructionBox and pass it as a Blob/NoritoBytes pointer.
+    let submit = build_submit_ballot_inline(
+      "election-1",
+      blob!("ciphertext"),
+      nullifier,
+      "halo2/ipa",
+      proof,
+      vk
+    );
+    verify_and_submit_ballot(env_ballot, submit);
+
+    let unshield = build_unshield_inline(
+      asset_definition!("62Fk4FPcMuLvW5QjDGNF2a4jAmjM"),
+      authority(),
+      1,
+      nullifier,
+      "halo2/ipa",
+      proof,
+      vk
+    );
+    verify_and_unshield(env_unshield, unshield);
+  }
+}

--- a/vendor/licenses/git_submodule/language-kotodama.dep.yml
+++ b/vendor/licenses/git_submodule/language-kotodama.dep.yml
@@ -1,0 +1,187 @@
+---
+name: language-kotodama
+version: 9629832d8eed7de2645ef2e9aeaeed3a9ea77de2
+type: git_submodule
+homepage: https://github.com/takemiyamakoto/language-kotodama.git
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+notices: []


### PR DESCRIPTION
## Description
Add `Kotodama` as a first-class language in Linguist, mapping `.ko` files to the TextMate scope `source.kotodama`.

This PR includes:
- a syntax-highlighting grammar sourced from `https://github.com/takemiyamakoto/language-kotodama`
- a new `Kotodama` entry in `lib/linguist/languages.yml`
- real `.ko` samples from the public Hyperledger Iroha repository

This is opened as a draft because the current public usage counts appear to be below Linguist's usual threshold for new languages. I wanted to provide a concrete implementation for maintainers to evaluate, but I am explicitly not claiming that the adoption bar has been met.

## Checklist:
- [ ] **I am adding a new extension to a language.**

- [x] **I am adding a new language.**
  - [ ] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+extension%3Ako+seiyaku
      - https://github.com/search?type=code&q=NOT+is%3Afork+extension%3Ako+kotoage
      - https://github.com/search?type=code&q=NOT+is%3Afork+extension%3Ako+%22register_trigger%22
    - Authenticated API counts observed while preparing this draft on 2026-03-31:
      - `extension:ko seiyaku NOT is:fork` -> `67`
      - `extension:ko kotoage NOT is:fork` -> `62`
      - `extension:ko "register_trigger" NOT is:fork` -> `2`
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/hyperledger-iroha/iroha/blob/main/crates/kotodama_lang/src/samples/irohaswap.ko
      - https://github.com/hyperledger-iroha/iroha/blob/main/crates/kotodama_lang/src/samples/mint_rose_trigger.ko
      - https://github.com/hyperledger-iroha/iroha/blob/main/crates/kotodama_lang/src/samples/zk_vote_and_unshield.ko
    - Sample license(s):
      - Apache-2.0
  - [x] I have included a syntax highlighting grammar: https://github.com/takemiyamakoto/language-kotodama
  - [x] I have added a color
    - Hex value: `#C26E2D`
    - Rationale: chosen to give Kotodama a distinct warm tone rather than reusing Kotlin/Rust-adjacent colors
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

- [ ] **I am fixing a misclassified language**

- [ ] **I am changing the source of a syntax highlighting grammar**

- [ ] **I am updating a grammar submodule**

- [x] **I am adding new or changing current functionality**
  - [ ] I have added or updated the tests for the new or changed functionality.
    - Manual validation run locally instead:
      - `bundle _2.7.2_ exec ruby -Ilib -e 'require "linguist"; ["samples/Kotodama/irohaswap.ko","samples/Kotodama/mint_rose_trigger.ko","samples/Kotodama/zk_vote_and_unshield.ko"].each { |p| blob = Linguist::FileBlob.new(p); puts "#{p}: #{blob.language&.name}" }'`
      - all three sample files classified as `Kotodama`

- [ ] **I am changing the color associated with a language**
