### PR TITLE
Add Effekt language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -485,6 +485,9 @@
 [submodule "vendor/grammars/edgedb-editor-plugin"]
 	path = vendor/grammars/edgedb-editor-plugin
 	url = https://github.com/edgedb/edgedb-editor-plugin.git
+[submodule "vendor/grammars/effekt-vscode"]
+	path = vendor/grammars/effekt-vscode
+	url = https://github.com/effekt-lang/effekt-vscode.git
 [submodule "vendor/grammars/eiffel.tmbundle"]
 	path = vendor/grammars/eiffel.tmbundle
 	url = https://github.com/textmate/eiffel.tmbundle

--- a/grammars.yml
+++ b/grammars.yml
@@ -392,6 +392,9 @@ vendor/grammars/edgedb-editor-plugin:
 - js.inline.edgeql
 - res.inline.edgeql
 - source.edgeql
+vendor/grammars/effekt-vscode:
+- source.effekt
+- source.literateeffekt
 vendor/grammars/eiffel.tmbundle:
 - source.eiffel
 vendor/grammars/ejs-tmbundle:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -1979,6 +1979,17 @@ Edje Data Collection:
   codemirror_mode: clike
   codemirror_mime_type: text/x-c++src
   language_id: 342840478
+Effekt:
+  type: programming
+  color: "#83488d"
+  extensions:
+  - ".effekt"
+  interpreters:
+  - effekt
+  tm_scope: source.effekt
+  ace_mode: effekt
+  codemirror_mode: clike
+  language_id: 983145650
 Eiffel:
   type: programming
   color: "#4d6977"
@@ -4283,6 +4294,17 @@ Literate CoffeeScript:
   - ".litcoffee"
   - ".coffee.md"
   language_id: 206
+Literate Effekt:
+  type: programming
+  color: "#83488d"
+  extensions:
+  - ".effekt.md"
+  interpreters:
+  - effekt
+  group: Effekt
+  tm_scope: source.literateeffekt
+  ace_mode: text
+  language_id: 479921086
 Literate Haskell:
   type: programming
   color: "#5e5086"

--- a/samples/Effekt/inference.effekt
+++ b/samples/Effekt/inference.effekt
@@ -1,0 +1,640 @@
+/*
+ * Copyright (c) 2026 Jonathan Brachthäuser and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// This case study shows how we can perform inference over probabilistic
+// models with the help of effects.
+
+import exception
+
+// We need some effects to perform probabilistic operations:
+
+type Distribution {
+  Gaussian(mean: Double, variance: Double)
+  Uniform(lower: Double, upper: Double)
+  Beta(mean: Double, sampleSize: Double)
+}
+type Probability = Double
+effect sample(dist: Distribution): Double
+effect observe(value: Double, dist: Distribution): Unit
+effect random(): Double
+effect weight(prob: Probability): Unit
+
+// With the effect `sample`, we can sample from a given distribution, and
+// with the effect `observe` we can determine how probable it is to observe
+// a given value under a given distribution (probability density function
+// (PDF)).
+
+// Currently, we support models with Gaussian, Uniform or Beta
+// distributions. Thus, we need a way to draw from these distributions and
+// to compute the probability density.
+
+def draw(dist: Distribution): Double / random = {
+  dist match {
+    case Gaussian(mean, variance) =>
+      val u1 = do random();
+      val u2 = do random();
+      val sigma = variance
+      // box-muller transform
+      val mag = sigma * sqrt(-2.0 * log(u1))
+      val z0 = mag * cos(2.0 * PI * u2)
+      return z0 + mean
+
+    case Uniform(lower, upper) =>
+      val x = do random()
+      return (lower + x * upper)
+
+    case Beta(mean, sampleSize) =>
+      val alpha = mean * sampleSize
+      return draw(Gaussian(0.5, 1.0 / (4.0 * (2.0 * alpha + 1.0))))
+  }
+}
+
+// For the Beta distribution, we need to approximate the Gamma function
+
+def gamma(z0: Double): Double = {
+  var z = z0
+  // g is a small integer and p is a list of coeficients dependent on g
+  val g = 7.0
+  val p = [0.99999999999980993,
+    676.5203681218851,
+    -1259.1392167224028,
+    771.32342877765313,
+    -176.61502916214059,
+    12.507343278686905,
+    -0.13857109526572012,
+    9.9843695780195716 * pow(10.0, 0.0 - 6.0),
+    1.5056327351493116 * pow(10.0, 0.0 - 7.0)]
+
+  // lanczos approximation
+  if (z < 0.5) {
+    val y = PI / (sin(PI * z) * gamma(1.0 - z))
+    return y
+  } else {
+    with on[OutOfBounds].panic
+    z = z - 1.0
+    var x = p.get(0)
+    var i = 1
+    while (i <= 8) {
+      x = x + (p.get(i) / (z + i.toDouble - 1.0))
+      i = i + 1
+    }
+    val t = z + g + 0.5
+    val y = sqrt(2.0 * PI) * pow(t, (z + 0.5)) * exp(0.0 - t) * x
+    return y
+  }
+}
+
+// and then can compute the probability density function at a given value
+// for the aforementioned distributions.
+
+def density(value: Double, dist: Distribution): Double = {
+  dist match {
+    case Gaussian(mean, variance) =>
+      val density = 1.0 / (sqrt(variance) * (sqrt(2.0 * PI))) * exp((0.0 - 1.0 / 2.0) * (square(value - mean) / variance))
+      return density
+
+    case Uniform(lower, upper) =>
+      if (lower < value && value < upper) { 1.0 / (upper - lower) }
+      else { 0.0 }
+
+    case Beta(mean, sampleSize) =>
+      val alpha = mean * sampleSize
+      val beta = (1.0 - mean) * sampleSize
+      val density = (gamma(alpha + beta) / (gamma(alpha) * gamma(beta))) * pow(value, (alpha - 1.0)) * pow((1.0 - value), (beta - 1.0))
+      return density
+  }
+}
+
+// Next, we define default handlers for all effects:
+
+def handleSample[R] { program: () => R / sample }: R / random = {
+  try { program() }
+  with sample { dist => resume(draw(dist)) }
+}
+def handleObserve[R] { program: () => R / observe }: R / weight = {
+  try { program() }
+  with observe { (value, dist) => do weight(density(value, dist)); resume(()) }
+}
+def handleWeight[R] { program: () => R / weight }: (R, Double)  = {
+  var current = 1.0
+  try { (program(), current) }
+  with weight { (prob) =>
+    current = current * prob;
+    resume(())
+  }
+}
+
+// For generating random numbers, we either use the `random` function from
+// stdlib
+
+def handleRandom[R] { program: () => R / random }: R =
+  try { program() }
+  with random { () => resume(random()) }
+
+// or a pseudo random number generator using a linear congruential
+// generator:
+
+def linearCongruentialGenerator[R](seed: Int) { prog: => R / random } : R = {
+  // parameters from Numerical Recipes (https://en.wikipedia.org/wiki/Linear_congruential_generator)
+  val a = 1664525
+  val c = 1013904223
+  val m = 1073741824
+  var x: Int = seed;
+  def next() = { x = mod((a * x + c), m); x }
+  try { prog() }
+  with random {
+    resume(next().toDouble / m.toDouble)
+  }
+}
+
+// With the effect `emit` it is also possible to limit infinite loops. This
+// allows for flexible numbers of steps to be performed with any algorithm
+// that uses the effect `emit`.
+
+def onEmit[A] { handler: A => Unit } { program: => Unit / emit[A] }: Unit =
+  try { program(); () }
+  with emit[A] {
+    def emit(element) = { handler(element); resume(()) }
+  }
+
+// === Rejection Sampling ===
+
+// The effect `weight` is the basis of the rejection sampling
+// algorithm (https://en.wikipedia.org/wiki/Rejection_sampling) is given
+// by the following handler:
+
+def handleRejection[R] { program: () => R / weight }: R / random = {
+  try { program() }
+  with weight { (prob) =>
+    if (do random() < prob) { resume(()) }
+    else { handleRejection {program} }
+  }
+}
+
+// Intuitively, invoking `do weight(p)` in some program `prog` assigns this
+// path the probability of `p` such that `prog` is non-deterministically
+// repeated until it is accepted by the underlying proposal distribution.
+
+// region _ {
+//   with linearCongruentialGenerator(1)
+//   with handleSample
+//   with handleRejection
+//   val N = Gaussian(0.0, 1.0)
+//   val sample = do sample(N)
+//   println(show(round(sample, 2)))
+//   do weight(0.01)
+//   println("accepted")
+// }
+
+// For easier usage, we define a wrapper to be used for rejection sampling:
+
+def rejectionSampling[R] { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  def loop(): Unit / emit[R] = {
+    with handleSample
+    with handleRejection
+    with handleObserve
+    do emit(program())
+    loop()
+  }
+  loop()
+}
+
+// === Slice Sampling ===
+
+// The following function is implementing a form of slice sampling — a
+// Markov Chain Monte Carlo (MCMC) algorithm often used in probabilistic
+// programming for sampling from a distribution. This algorithm iteratively
+// samples from a distribution and adjusts weights or probabilities to
+// ensure that the samples align with the target distribution.
+
+def sliceSamplingAlgo[R]() { program: () => R / weight } = {
+  val (result, prob) = handleSample { handleWeight { program() }}
+
+  def step(result0: R, prob0: Probability) = handleRejection {
+    val (result1, prob1) = handleWeight { program() }
+    if (prob1 < prob0) { do weight(prob1 / prob0) }
+    (result1, prob1)
+  }
+  def loop(result: R, prob: Probability): Unit / emit[R] = {
+    do emit(result)
+    val (result1, prob1) = step(result, prob)
+    loop(result1, prob1)
+  }
+  loop(result, prob)
+}
+
+// First, we get an initial sample `result` with its associated probability
+// `prob`. `step` is then used to generate new samples based on the
+// previous result and probability. If the new sample has a lower
+// probability (prob1 \< prob0), the sample is down-weighted by adjusting
+// the weight using `do weight(prob1 / prob0)`. This ensures that samples
+// with lower probabilities are less likely to be accepted. Finally, using
+// `loop` and `emit`, we emit the sampling results.
+
+// === Metropolis-Hastings ===
+
+// A trace records past samples used by an algorithm. The trace also
+// controls where the algorithm draws samples from in the next iterations.
+// Constructing traces is possible by handling the effect `sample`, not
+// with the default handler, but with one that draws new samples and
+// records them in a trace.
+
+type Trace = List[Probability]
+
+def handleTracing[R] { program: () => R / sample }: (R, Trace) / sample = {
+  var trace = []
+  val result = try { program() }
+  with sample { (dist) =>
+    val d = do sample(dist);
+    trace = Cons(d, trace)
+    resume(d)
+  }
+  (result, trace.reverse)
+}
+def handleReusingTrace[R](trace0: Trace) { program: () => R / sample } = handleObserve {
+  var trace = trace0
+  try { program() }
+  with sample { (dist) =>
+    trace match {
+      case Nil() => panic("empty trace")
+      case Cons(t, ts) =>
+        do observe(t, dist)
+        trace = ts; resume(t)
+    }
+  }
+}
+
+// How the candidates of this algorithm are proposed can vary between
+// different implementations of the algorithm and thus creating inference
+// of the Metropolis-Hastings algorithm. The Metropolis-Hastings algorithm
+// proposes a new trace based on the old trace, by recursively adding noise
+// to the samples in the old trace and thus creating a new trace.
+
+def propose(trace: Trace): Trace / sample = {
+  trace match {
+    case Nil() => []
+    case Cons(t, ts) =>
+      val noise = do sample(Gaussian(0.0, 1.0))
+      val proposal = t + noise
+      Cons(proposal, propose(ts))
+  }
+}
+
+// The algorithm is implemented with a helper function
+
+def metropolisStep[A](prob0: Probability, trace0: Trace) { program: Trace => (A, Probability) } = {
+  val trace1 = propose(trace0)
+  val (result1, prob1) = program(trace1)
+  if (prob1 < prob0) {
+    do weight(prob1 / prob0)
+  }
+  ((result1, trace1), prob1)
+}
+
+// `metropolisStep` is then called in the algorithm implementation
+
+def metropolisHastingsAlgo[A] { program: () => A / { sample, weight } } = {
+  val ((result0, trace0), prob0) = handleWeight {
+    with handleSample
+    with handleTracing
+    program()
+  }
+  def loop(result: A, trace: Trace, prob: Probability): Unit / emit[A] = {
+    do emit(result)
+    val ((result1, trace1), prob1) =
+    handleSample {
+      with handleRejection
+      metropolisStep(prob, trace) { trace =>
+        with handleWeight
+        with handleReusingTrace(trace)
+        program()
+      }
+    }
+    loop(result1, trace1, prob1)
+  }
+  loop(result0, trace0, prob0)
+}
+
+// To perform inference over the Metropolis-Hastings algorithm, and for
+// creating the single-site Metropolis-Hastings algorithm, we just need to
+// alter the implementation of the `propose` function. In this
+// implementation, the noise is added to only one random sample in the
+// trace and the other samples are reused.
+
+def proposeSingleSite(trace: Trace): Trace / sample = {
+  val tsize = toDouble(size(trace))
+  val rand = do sample(Uniform(0.0, tsize))
+  def putAti(i: Int, p0: List[Double]): List[Double] = {
+    p0 match {
+      case Nil() => []
+      case Cons(p, ps) =>
+        if (i == 0) {
+          val noise = do sample(Gaussian(0.0, 1.0))
+          Cons(p + noise, ps)
+        }
+        else {
+          Cons(p, putAti(i - 1, ps))
+        }
+    }
+  }
+  putAti(floor(rand), trace)
+}
+
+// The single-site Metropolis-Hastings algorithm is implemented like the
+// Metropolis-Hastings algorithm above.
+
+def metropolisStepSingleSite[A](prob0: Probability, trace0: Trace) { program: Trace => (A, Probability) } = {
+  val trace1 = proposeSingleSite(trace0)
+  val (result1, prob1) = program(trace1)
+  if (prob1 < prob0) {
+    do weight(prob1 / prob0)
+  }
+  ((result1, trace1), prob1)
+}
+def metropolisHastingsSingleSiteAlgo[A] {program: () => A / { sample, weight } } = {
+  val ((result0, trace0), prob0) = handleWeight {
+    with handleSample
+    with handleTracing
+    program()
+  }
+  def loop(result: A, trace: Trace, prob: Probability): Unit / emit[A] = {
+    do emit(result)
+    val ((result1, trace1), prob1) = handleSample {
+      with handleRejection
+      metropolisStepSingleSite(prob, trace) { trace =>
+        with handleWeight
+        with handleReusingTrace(trace)
+        program()
+      }
+    }
+    loop(result1, trace1, prob1)
+  }
+  loop(result0, trace0, prob0)
+}
+
+// === Wrappers ===
+
+// In order to make it easier to use these algorithms without having to
+// call the various effect handlers, we constructed wrappers for the
+// algorithms implemented previously.
+
+def sliceSampling[R](n: Int) { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  with handleSample
+  with sliceSamplingAlgo[R]
+  with handleObserve
+  program()
+}
+def metropolisHastings[R](n: Int) { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  with metropolisHastingsAlgo[R]
+  with handleObserve
+  program()
+}
+def metropolisHastingsSingleSite[R](n: Int) { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  with metropolisHastingsSingleSiteAlgo[R]
+  with handleObserve
+  program()
+}
+
+// === Examples ===
+
+record Point(x: Double, y: Double)
+
+record State(x: Double, y: Double, vx: Double, vy: Double)
+type Measurement = Double
+type Path = List[State]
+
+record Population(susceptible: Double, infected: Double, recovered: Double)
+
+def main() = {
+
+  // As a short example of how the effects `sample` and `observe` can be used
+  // in a model, we construct a linear regression model.
+
+  def linearRegression(observations: List[Point]) = {
+    val m = do sample(Gaussian(0.0, 3.0))
+    val c = do sample(Gaussian(0.0, 2.0))
+    observations.foreach {
+      case Point(x, y) => do observe(y, Gaussian(m * x + c, 1.0))
+    }
+    return Point(m, c)
+  }
+
+  // Remember from earlier that `handleObserve` uses the `weight` effect
+  // operation. Therefore, the call `do observe(y, Gaussian(m * x + c, 1.0))`
+  // can be understood as `P(Y | C)` where `Y` are the observations and `C`
+  // are the parameters sampled from a Gaussian given by `m ~ N(0, 3)` and
+  // `c ~ N(0, 2)`. If the chosen parameters do not explain the observations
+  // well, it is likely it will be rejected and new parameters will be
+  // sampled. Conversely, if the model fits well, it is unlikely it will be
+  // rejected.
+
+  linearCongruentialGenerator(1) {
+    with onEmit[Point] { s => println(s.show) };
+
+    limit[Point](5) {
+      with rejectionSampling[Point]
+
+      linearRegression([
+        Point(5.0, 5.0),
+        Point(1.0, 1.0),
+        Point(-2.0, -2.0),
+        Point(3.0, 3.0),
+        Point(20.0, 20.0),
+        Point(5.0, 5.0)
+      ])
+    }
+  }.show.println()
+
+  // It is also possible to construct bigger examples on which we can apply
+  // these algorithms. In this example, the movements of a robot on a
+  // 2D-plane are observed. In the center of this plane, at the coordinates
+  // (0, 0), there is a radar station that can measure the distance to the
+  // robot at any point in time. We try to predict the state of the robot
+  // while taking into account the measurements. The current state of the
+  // robot consists of the position and velocity.
+
+  // For simulating the movement of the robot at a given state, we sample
+  // accelerations `xa`, `ya` along the x and y axis from a Gaussian
+  // distribution. By applying the laws of motion and assuming that the
+  // difference between each time step is one, we can derive the update
+  // equations given the sampled acceleration for the velocity and the
+  // position.
+
+  def move(s: State): State / sample =
+    s match {
+      case State(x0, y0, vx0, vy0) =>
+        val xa1 = do sample(Gaussian(0.0, 1.0))
+        val ya1 = do sample(Gaussian(0.0, 1.0))
+        val (x1, y1) = (x0 + vx0 + xa1, y0 + vy0 + ya1)
+        val (vx1, vy1) = (vx0 + xa1, vy0 + ya1)
+        return State(x1, y1, vx1, vy1)
+    }
+
+  // After predicting the next state of the robot, we get a distance
+  // measurement from the radar station. We then compute the probabilistic
+  // distance given the predicted state using the Euclidean distance. Next,
+  // we try to reconcile our model with the given measurement by applying the
+  // `obeserve` effect operation. Similar to linear regression example, we
+  // reject our prediction if the observation is unlikely given our
+  // previously predicted acceleration.
+
+  def measure(s: State, m: Measurement): Unit / observe = {
+    s match {
+      case State(x, y, vx, vy) =>
+        val dist = sqrt(square(x) + square(y))
+        do observe(m, Gaussian(dist, 0.4))
+    }
+  }
+
+  // Putting it all together, we first call `move` for predicting the
+  // acceleration and then reconcile it with a given measurement. If the
+  // predicted state is unlikely to have produced the measurement, we predict
+  // another state. Finally, we return the first state that is not rejected.
+
+  def step(s0: State, m1: Measurement): State / { sample, observe } = {
+    val s1 = move(s0)
+    measure(s1, m1)
+    return s1
+  }
+
+  // We can now put our model to the test by running the following simple
+  // example:
+
+  linearCongruentialGenerator(1) {
+    with onEmit[State] { s => println(s.show) }
+
+    limit[State](5) {
+      with sliceSampling[State](5)
+
+      val init = State(0.0, 3.0, 2.0, 0.0)
+      step(init, 5.0)
+    }
+  }.show.println()
+
+  // As a more complex example, we now also probabilisticly augment the
+  // distance measurements by applying Gaussian noise to it instead of
+  // keeping constant. More importantly, we now predict five different
+  // possible paths consisting of five states each.
+
+  linearCongruentialGenerator(1) {
+    with onEmit[Path] { path => println(path.show) }
+
+    limit[Path](5) {
+      with sliceSampling[Path](1);
+
+      var nextState = State(0.0, 3.0, 2.0, 0.0)
+      var nextdis = 5.0
+      var m = 5
+      var path = [nextState]
+      while (m > 0) {
+        nextState = step(nextState, nextdis)
+        val noise = do sample(Gaussian(0.0, 1.0))
+        nextdis = nextdis + noise
+        path = append(path, [nextState])
+        m = m - 1
+      }
+      path
+    }
+  }.show.println()
+
+  // This example simulates a population experiencing an epidemic outbreak
+  // with the SIR model. The SIR model divides the population into
+  // susceptible **S**, infected **I** and recovered **R**.
+
+  // we now try to predict the population state at the next time step:
+
+  def progression(p: Population): Population / sample = {
+    p match {
+      case Population(s, i, r) =>
+        val noise = do sample(Gaussian(0.0, 0.01))
+        val s1 = 0.5 * s - noise
+        val i1 = 0.3 * i + 0.5 * s + 0.1 * r + noise
+        val r1 =  0.9 * r + 0.7 * i
+        return Population(s1, i1, r1)
+    }
+  }
+
+  // Next, given a population and a positive-rate of COVID-like test, we
+  // gauge how likely it is that the positive-rate was observed assuming the
+  // test result is distributed according to a Beta distribution. Formally,
+  // we compute $\text{Beta}(pr \mid I, 100)$ where $I$ is the number of
+  // infected individuals in the predicted population. If it is unlikely, the
+  // predicted population will be rejected and another one will be proposed.
+
+  def test(p: Population, pr: Double): Unit / observe = {
+    p match {
+      case Population(s, i, r) =>
+        val mean = i
+        val sampleSize = 100.0
+        do observe(pr, Beta(mean, sampleSize))
+    }
+  }
+
+  // Like in the previous examples, we combine these two functions into a
+  // `step` function:
+
+  // approximate next state of population based on current state
+  def step(p0: Population, pr1: Double): Population / { sample, observe } = {
+    val p1 = progression(p0)
+    test(p1, pr1)
+    return p1
+  }
+
+  // Testing it on a simple example, is similar as we have seen previously
+  // with the robot movement predictions:
+
+  linearCongruentialGenerator(1) {
+    with onEmit[Population] { p => println(p.show) }
+
+    limit[Population](5) {
+      with metropolisHastings[Population](5)
+
+      val init = Population(0.7, 0.2, 0.1)
+      step(init, 0.8)
+    }
+  }.show.println()
+
+  // We again can also predict multiple different scenarios where the disease
+  // spreads differently throughout a population:
+
+  linearCongruentialGenerator(1) {
+    with onEmit[List[Population]] { ps => println(ps.show) }
+
+    limit[List[Population]](1) {
+      with metropolisHastings[List[Population]](1)
+
+      var nextPop = Population(0.7, 0.2, 0.1)
+      var nextpr = 0.8
+      var m = 5
+      var path : List[Population] = [nextPop]
+      while (m > 0) {
+        nextPop = step(nextPop, nextpr)
+        val noise = do sample(Gaussian(0.0, 0.01))
+        var nextpr1 = nextpr + noise
+        if (not(nextpr1 < 0.0 || nextpr1 > 1.0)) { nextpr = nextpr1 }
+        path = append(path, [nextPop])
+        m = m - 1
+      }
+      path
+    }
+  }.show.println()
+}

--- a/samples/Effekt/parser.effekt
+++ b/samples/Effekt/parser.effekt
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2026 Jonathan Brachthäuser and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// In this case study, we show how to implement a *pull-based* lexer
+// in terms of effect handlers.
+// Afterwards, we show how to implement a parser using the lexer.
+
+import regex
+
+// == Tokens and Positions ==
+
+// First we define the datatypes to represent lexemes (tokens) and
+// positions in the input stream:
+
+record Position(line: Int, col: Int, index: Int)
+
+type TokenKind { Number(); Ident(); Punct(); Space() }
+
+def infixEq(t1: TokenKind, t2: TokenKind): Bool =
+  (t1, t2) match {
+    case (Number(), Number()) => true
+    case (Ident(), Ident()) => true
+    case (Punct(), Punct()) => true
+    case (Space(), Space()) => true
+    case _ => false
+  }
+
+record Token(kind: TokenKind, text: String, position: Position)
+
+// Tokens simply are tagged with a token type (distinguishing numbers,
+// identifiers, and punctuation), the original text of the token and its
+// position.
+
+// === The Lexer Effect ===
+
+// Next, we define the interface to the lexer as an effect signature.
+
+interface Lexer {
+  def peek(): Option[Token]
+  def next(): Token
+}
+
+// it consists of two effect operations, one to inspect the next token
+// without consuming it (`peek`) and one operation to advance in the stream
+// of tokens. This describes the interface of a *pull-based* lexer as a
+// stream of tokens. Lexemes are only processed on demand. An example
+// program using the lexer effect is:
+
+def example1() = {
+  val t1 = do next();
+  val t2 = do next();
+  val t3 = do next();
+  (t1, t2, t3)
+}
+
+// === Handling the Lexer Effect with a given List ===
+
+// A dummy lexer reading lexemes from a given list can be implemented as a
+// handler for the `Lexer` effect. The definition uses the effect
+// `LexerError` to signal the end of the input stream:
+
+effect LexerError(msg: String, pos: Position): Nothing
+val dummyPosition = Position(0, 0, 0)
+
+def lexerFromList[R](l: List[Token]) { program: => R / Lexer }: R / LexerError = {
+  var in = l;
+  try { program() } with Lexer {
+    def peek() = in match {
+      case Nil() => resume(None())
+      case Cons(tok, _) => resume(Some(tok))
+    }
+    def next() = in match {
+      case Nil() => do LexerError("Unexpected end of input", dummyPosition)
+      case Cons(tok, _) => resume(tok)
+    }
+  }
+}
+
+// We define a separate handler to report lexer errors to the console:
+
+def report { prog: => Unit / LexerError }: Unit =
+  try { prog() } with LexerError { (msg, pos) =>
+    println(pos.line.show ++ ":" ++ pos.col.show ++ " " ++ msg)
+  }
+
+// === Handling the Lexer Effect by Processing a String ===
+
+// Of course, we can also implement a handler for our `Lexer` effect that
+// *actually* processes an input and computes the tokens contained therein.
+//
+// This time, we use a number of different regular expressions to recognize
+// lexemes. First, we define the different token types as a list of pairs
+// of regular expressions and token types.
+
+record TokenRx(kind: TokenKind, rx: Regex)
+
+val tokenDesriptors = [
+  TokenRx(Number(), "^[0-9]+".regex),
+  TokenRx(Ident(),  "^[a-zA-Z]+".regex),
+  TokenRx(Punct(),  "^[=,.()\\[\\]{}:]".regex),
+  TokenRx(Space(),  "^[ \t\n]+".regex)
+]
+
+// Now, we can define the function `lexer` which receives a string as input
+// as well as a computation `prog` for which it handles the `Lexer` effect:
+
+def lexer[R](in: String) { prog: => R / Lexer } : R / LexerError = {
+  // Additionally, we keep track of the current position in the input stream, by maintaining
+  // three mutable variables for the zero based index, and one-based column and line position.
+  var index = 0
+  var col = 1
+  var line = 1
+  // A few local helper functions ease the handling of the input stream.
+  // At the same time, we need to keep track of the line information.
+  def position() = Position(line, col, index)
+  def input() = in.substring(index)
+  def consume(text: String): Unit = {
+    with ignore[MissingValue]
+    val lines = text.split("\n")
+    val offset = lines.last.length
+    // compute new positions
+    index = index + text.length
+    line = line + lines.size - 1
+    if (lines.size == 1) { col = col + text.length } else { col = offset }
+  }
+  def eos(): Bool = index >= in.length
+  // The function `tryMatch` applies a given token description to the current position of
+  // the input stream, without advancing it. Its companion `tryMatchAll` returns the first token
+  // matched by any of the matches in the given description list.
+  def tryMatch(desc: TokenRx): Option[Token] =
+      desc.rx.exec(input()).map { m => Token(desc.kind, m.matched, position()) }
+
+  def tryMatchAll(descs: List[TokenRx]): Option[Token] = descs match {
+    case Nil() => None()
+    case Cons(desc, descs) => tryMatch(desc).orElse { tryMatchAll(descs) }
+  }
+  // Now defining the lexer is trivial. We just need to use `tryMatchAll` and either consume
+  // the input, or not.
+  try { prog() } with Lexer {
+    def peek() = resume(tryMatchAll(tokenDesriptors))
+    def next() =
+      if (eos())
+        do LexerError("Unexpected EOS", position())
+      else {
+        val tok = tryMatchAll(tokenDesriptors).getOrElse {
+          do LexerError("Cannot tokenize input", position())
+        }
+        consume(tok.text)
+        resume(tok)
+      }
+  }
+}
+
+// === Whitespace Skipping ===
+
+// Interestingly, a whitespace skipping lexer can be implemented as a
+// *effect transformer*. That is, a handler that (partially) re-raises
+// effect operations.
+
+def skipSpaces(): Unit / Lexer = do peek() match {
+  case None() => ()
+  case Some(Token(Space(), _, _)) => do next(); skipSpaces()
+  case _ => ()
+}
+
+// The handler `skipWhitespace` simply skips all spaces by using the
+// `Lexer` effect itself.
+
+def skipWhitespace[R] { prog: => R / Lexer }: R / Lexer =
+  try { prog() } with Lexer {
+    def peek() = { skipSpaces(); resume(do peek()) }
+    def next() = { skipSpaces(); resume(do next()) }
+  }
+
+// === Parsing ===
+
+// Parsers can be expressed by using the lexer effect and process the token
+// stream. To model different alternatives in the grammar, we use the
+// following effect for non-determinism:
+
+interface Nondet {
+  def alt(): Bool
+  def fail(msg: String): Nothing
+}
+
+effect Parser = { Nondet, Lexer }
+
+// === Parser Combinators ===
+
+// Given these two effects, we can readily define a host of (imperative)
+// parser combinators. We start by the simplest one, which applies a
+// predicate to the next element in the input stream and fails, if it does
+// not match.
+
+def accept { p: Token => Bool } : Token / Parser = {
+  val got = do next();
+  if (p(got)) got
+  else do fail("Unexpected token " ++ show(got))
+}
+
+// Using `accept`, we can define parsers for the different token types.
+
+def any() = accept { t => true }
+def accept(exp: TokenKind) = accept { t => t.kind == exp }
+def ident() = accept(Ident()).text
+def number() = accept(Number()).text
+def punct(p: String) = {
+  val tok = accept(Punct())
+  if (tok.text == p) ()
+  else do fail("Expected " ++ p ++ " but got " ++ tok.text)
+}
+def kw(exp: String): Unit / Parser = {
+  val got = ident();
+  if (got == exp) ()
+  else do fail("Expected keyword " ++ exp ++ " but got " ++ got)
+}
+
+// Using the effect for non-deterministic choice `alt`, we can model
+// alternatives, optional matches and various repetitions:
+
+def or[R] { p: => R } { q: => R } =
+  if (do alt()) { p() } else { q() }
+
+def opt[R] { p: => R }: Option[R] / Parser =
+  or { Some(p()) } { None() }
+
+def many { p: => Unit }: Unit / Parser =
+  or { some { p() } } { () }
+
+def some { p: => Unit }: Unit / Parser =
+  { p(); many { p() } }
+
+
+// === Example: A Simple Expression Language ===
+
+// We illustrate the usage of the above parser combinators by parsing a
+// simple expressions language.
+
+type Tree {
+  Lit(value: Int)
+  Var(name: String)
+  Let(name: String, binding: Tree, body: Tree)
+  App(name: String, arg: Tree)
+}
+
+// Let us start by defining the parser for numeric literals.
+
+def parseNum(): Tree / Parser = {
+  val numText = number();
+  attempt { Lit(numText.toInt) } { do fail("Expected number, but cannot convert input to integer: " ++ numText) }
+}
+
+
+// We simply call the parser for `number()` and try to convert the
+// resulting string to an intenger.
+
+
+def parseVar(): Tree / Parser =
+  Var(ident())
+
+def parseAtom() = or { parseVar() } { parseNum() }
+
+// Parsing variables is simply a matter of reusing the `ident` parser and
+// changing the result. Users of monadic parser combinator libraries might
+// be delighted to see, that we do not need to use `map` or something
+// similar to transform the result. The parser is simply written in direct
+// style, still offering great flexibility in modifying the semantics of
+// effects.
+
+// Similarly, we can write parsers for let bindings, by sequentially
+// composing our existing parsers:
+
+def parseLet(): Tree / Parser = {
+  kw("let");
+  val name = ident();
+  punct("=");
+  val binding = parseExpr();
+  kw("in");
+  val body = parseExpr();
+  Let(name, binding, body)
+}
+
+def parseGroup() = or { parseAtom() } {
+  punct("(");
+  val res = parseExpr();
+  punct(")");
+  res
+}
+
+def parseApp(): Tree / Parser = {
+  val funName = ident();
+  punct("(");
+  val arg = parseExpr();
+  punct(")");
+  App(funName, arg)
+}
+
+def parseExpr(): Tree / Parser =
+  or { parseLet() } { or { parseApp() } { parseGroup() } }
+
+// Again, note how naturally the result can be composed from the individual
+// results, much like manually writing a recursive descent parser. Compared
+// to handcrafted parsers, the imperative parser combinators presented here
+// offer a similar flexibility. At the same time, the semantics of `alt`
+// and `fail` is still left open, offering flexibility in the
+// implementation of the actual underlying parsing algorithm.
+
+// === Example: Combining Parsers and Local Mutable State ===
+
+// It is possible to combine the imperative parser combinators with local
+// mutable state. The implementation of local variables in Effekt is
+// designed to interact well with continuation capture and multiple
+// resumptions. This is important for use cases like the parser example
+// where the continuation is potentially called multiple times.
+//
+// The following example implements an example
+//
+// ```
+// <EXPR> ::= <NUMBER> | <IDENT> `(` <EXPR> (`,` <EXPR>)*  `)`
+// ```
+//
+// It uses local (mutable) variables to count the number of leafs as
+// semantic action.
+
+def parseCalls(): Int / Parser =
+  or { number(); 1 } {
+    var count = 1;
+    ident();
+    punct("(");
+    count = count + parseCalls();
+    many {
+        punct(",");
+        count = count + parseCalls()
+    };
+    punct(")");
+    count
+  }
+
+// Notice how the user defined combinator `many` feels like a built-in
+// control operator `while`.
+
+// === Backtracking Parsers ===
+
+// As mentioned above, so far we used the non-determinism effects, but did
+// not specify what they mean. We could implement depth-first parsing
+// corresponding to recursive descent. Alternatively, we also could
+// implement breadth-first parsing. Further, in case of ambiguities, we
+// have the choice whether we want to recognize only the first result or
+// compute all possible alternative ways to recognize the input.
+
+// For this case study, we implement a depth-first parser, computing the
+// first successful result. Results are represented by the `ParseResult`
+// datatype. The parsing algorithm is simply implemented as a handler for
+// `Parser`.
+
+type ParseResult[R] {
+  ParseSuccess(t: R);
+  ParseFailure(msg: String)
+}
+
+def parse[R](input: String) { p: => R / Parser }: ParseResult[R] = try {
+  lexer(input) { skipWhitespace { ParseSuccess(p()) } }
+} with Nondet {
+  def alt() = resume(true) match {
+    case ParseFailure(msg) => resume(false)
+    case ParseSuccess(res) => ParseSuccess(res)
+  }
+  def fail(msg) = ParseFailure(msg)
+} with LexerError { (msg, pos) =>
+  ParseFailure(msg)
+}
+
+// The handler reuses the lexer implementation of the lexer. The lexer
+// raises a `LexerError` in case of an unexpected enf of the input stream
+// or if it cannot recognize a token. Those lexer errors are simply
+// converted into failures, which the parser can backtrack. To establish
+// the backtracking behavior, it is important that the lexer is executed
+// *under* the parser handler and not the other way around. Only this way
+// the lexer positions will be restored when calling the continuation a
+// second time with `resume(false)`.
+
+// === Running the Examples ===
+
+// Having implemented a handler for the `Parser` effect, we can run our
+// example “grammars” on some inputs.
+
+def main() = {
+  println(parse("42") { parseCalls() }.show)
+  println(parse("foo(1)") { parseCalls() }.show)
+  println(parse("foo(1, 2)") { parseCalls() }.show)
+  println(parse("foo(1, 2, 3, 4)") { parseCalls() }.show)
+  println(parse("foo(1, 2, bar(4, 5))") { parseCalls() }.show)
+  println(parse("foo(1, 2,\nbar(4, 5))") { parseCalls() }.show)
+
+  println(parse("}42") { parseExpr() }.show)
+  println(parse("42") { parseExpr() }.show)
+  println(parse("let x = 4 in 42") { parseExpr() }.show)
+  println(parse("let x = let y = 2 in 1 in 42") { parseExpr() }.show)
+  println(parse("let x = (let y = 2 in 1) in 42") { parseExpr() }.show)
+  println(parse("let x = (let y = f(42) in 1) in 42") { parseExpr() }.show)
+  println(parse("let x = (let y = f(let z = 1 in z) in 1) in 42") { parseExpr() }.show)
+}

--- a/samples/Literate Effekt/inference.effekt.md
+++ b/samples/Literate Effekt/inference.effekt.md
@@ -1,0 +1,663 @@
+```
+/*
+ * Copyright (c) 2026 Jonathan Brachthäuser and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+```
+
+# Probabilistic Inference
+
+This case study shows how we can perform inference over probabilistic models with the help of effects.
+
+---
+
+We require some imports:
+
+```
+import exception
+```
+
+We need some effects to perform probabilistic operations:
+
+```
+type Distribution {
+  Gaussian(mean: Double, variance: Double)
+  Uniform(lower: Double, upper: Double)
+  Beta(mean: Double, sampleSize: Double)
+}
+type Probability = Double
+effect sample(dist: Distribution): Double
+effect observe(value: Double, dist: Distribution): Unit
+effect random(): Double
+effect weight(prob: Probability): Unit
+```
+
+With the effect `sample`, we can sample from a given distribution, and with the effect `observe` we can determine how probable it is to observe a given value under a given distribution (probability density function (PDF)).
+
+Currently, we support models with Gaussian, Uniform or Beta distributions. Thus, we need a way to draw from these distributions and to compute the probability density.
+
+```
+def draw(dist: Distribution): Double / random = {
+  dist match {
+    case Gaussian(mean, variance) =>
+      val u1 = do random();
+      val u2 = do random();
+      val sigma = variance
+      // box-muller transform
+      val mag = sigma * sqrt(-2.0 * log(u1))
+      val z0 = mag * cos(2.0 * PI * u2)
+      return z0 + mean
+
+    case Uniform(lower, upper) =>
+      val x = do random()
+      return (lower + x * upper)
+
+    case Beta(mean, sampleSize) =>
+      val alpha = mean * sampleSize
+      return draw(Gaussian(0.5, 1.0 / (4.0 * (2.0 * alpha + 1.0))))
+  }
+}
+```
+
+For the Beta distribution, we need to approximate the Gamma function
+
+```
+def gamma(z0: Double): Double = {
+  var z = z0
+  // g is a small integer and p is a list of coeficients dependent on g
+  val g = 7.0
+  val p = [0.99999999999980993,
+    676.5203681218851,
+    -1259.1392167224028,
+    771.32342877765313,
+    -176.61502916214059,
+    12.507343278686905,
+    -0.13857109526572012,
+    9.9843695780195716 * pow(10.0, 0.0 - 6.0),
+    1.5056327351493116 * pow(10.0, 0.0 - 7.0)]
+
+  // lanczos approximation
+  if (z < 0.5) {
+    val y = PI / (sin(PI * z) * gamma(1.0 - z))
+    return y
+  } else {
+    with on[OutOfBounds].panic
+    z = z - 1.0
+    var x = p.get(0)
+    var i = 1
+    while (i <= 8) {
+      x = x + (p.get(i) / (z + i.toDouble - 1.0))
+      i = i + 1
+    }
+    val t = z + g + 0.5
+    val y = sqrt(2.0 * PI) * pow(t, (z + 0.5)) * exp(0.0 - t) * x
+    return y
+  }
+}
+```
+
+and then can compute the probability density function at a given value for the aforementioned distributions.
+
+```
+def density(value: Double, dist: Distribution): Double = {
+  dist match {
+    case Gaussian(mean, variance) =>
+      val density = 1.0 / (sqrt(variance) * (sqrt(2.0 * PI))) * exp((0.0 - 1.0 / 2.0) * (square(value - mean) / variance))
+      return density
+
+    case Uniform(lower, upper) =>
+      if (lower < value && value < upper) { 1.0 / (upper - lower) }
+      else { 0.0 }
+
+    case Beta(mean, sampleSize) =>
+      val alpha = mean * sampleSize
+      val beta = (1.0 - mean) * sampleSize
+      val density = (gamma(alpha + beta) / (gamma(alpha) * gamma(beta))) * pow(value, (alpha - 1.0)) * pow((1.0 - value), (beta - 1.0))
+      return density
+  }
+}
+```
+
+Next, we define default handlers for all effects:
+
+```
+def handleSample[R] { program: () => R / sample }: R / random = {
+  try { program() }
+  with sample { dist => resume(draw(dist)) }
+}
+def handleObserve[R] { program: () => R / observe }: R / weight = {
+  try { program() }
+  with observe { (value, dist) => do weight(density(value, dist)); resume(()) }
+}
+def handleWeight[R] { program: () => R / weight }: (R, Double)  = {
+  var current = 1.0
+  try { (program(), current) }
+  with weight { (prob) =>
+    current = current * prob;
+    resume(())
+  }
+}
+```
+
+For generating random numbers, we either use the `random` function from stdlib
+
+```
+def handleRandom[R] { program: () => R / random }: R =
+  try { program() }
+  with random { () => resume(random()) }
+```
+
+or a pseudo random number generator using a linear congruential generator:
+
+```
+def linearCongruentialGenerator[R](seed: Int) { prog: => R / random } : R = {
+  // parameters from Numerical Recipes (https://en.wikipedia.org/wiki/Linear_congruential_generator)
+  val a = 1664525
+  val c = 1013904223
+  val m = 1073741824
+  var x: Int = seed;
+  def next() = { x = mod((a * x + c), m); x }
+  try { prog() }
+  with random {
+    resume(next().toDouble / m.toDouble)
+  }
+}
+```
+
+With the effect `emit` it is also possible to limit infinite loops. This allows for flexible numbers of steps to be performed with any algorithm that uses the effect `emit`.
+
+```
+def onEmit[A] { handler: A => Unit } { program: => Unit / emit[A] }: Unit =
+  try { program(); () }
+  with emit[A] {
+    def emit(element) = { handler(element); resume(()) }
+  }
+```
+
+## Rejection Sampling
+
+The effect `weight` is the basis of the [rejection sampling algorithm](https://en.wikipedia.org/wiki/Rejection_sampling#) is given by the following handler:
+
+```
+def handleRejection[R] { program: () => R / weight }: R / random = {
+  try { program() }
+  with weight { (prob) =>
+    if (do random() < prob) { resume(()) }
+    else { handleRejection {program} }
+  }
+}
+```
+
+Intuitively, invoking `do weight(p)` in some program `prog` assigns this path the probability of `p` such that `prog` is non-deterministically repeated until it is accepted by the underlying proposal distribution.
+
+```effekt:repl
+region _ {
+  with linearCongruentialGenerator(1)
+  with handleSample
+  with handleRejection
+  val N = Gaussian(0.0, 1.0)
+  val sample = do sample(N)
+  println(show(round(sample, 2)))
+  do weight(0.01)
+  println("accepted")
+}
+```
+
+For easier usage, we define a wrapper to be used for rejection sampling:
+
+```
+def rejectionSampling[R] { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  def loop(): Unit / emit[R] = {
+    with handleSample
+    with handleRejection
+    with handleObserve
+    do emit(program())
+    loop()
+  }
+  loop()
+}
+```
+
+## Slice Sampling
+
+The following function is implementing a form of slice sampling — a Markov Chain Monte Carlo (MCMC) algorithm often used in probabilistic programming for sampling from a distribution.
+This algorithm iteratively samples from a distribution and adjusts weights or probabilities to ensure that the samples align with the target distribution.
+
+```
+def sliceSamplingAlgo[R]() { program: () => R / weight } = {
+  val (result, prob) = handleSample { handleWeight { program() }}
+
+  def step(result0: R, prob0: Probability) = handleRejection {
+    val (result1, prob1) = handleWeight { program() }
+    if (prob1 < prob0) { do weight(prob1 / prob0) }
+    (result1, prob1)
+  }
+  def loop(result: R, prob: Probability): Unit / emit[R] = {
+    do emit(result)
+    val (result1, prob1) = step(result, prob)
+    loop(result1, prob1)
+  }
+  loop(result, prob)
+}
+```
+
+First, we get an initial sample `result` with its associated probability `prob`. `step` is then used to generate new samples based on the previous result and probability.
+If the new sample has a lower probability (prob1 < prob0), the sample is down-weighted by adjusting the weight using `do weight(prob1 / prob0)`. This ensures that samples with lower probabilities are less likely to be accepted. Finally, using `loop` and `emit`, we emit the sampling results.
+
+## Metropolis-Hastings
+
+### Tracing
+
+A trace records past samples used by an algorithm. The trace also controls where the algorithm draws samples from in the next iterations.
+Constructing traces is possible by handling the effect `sample`, not with the default handler, but with one that draws new samples and records them in a trace.
+
+```
+type Trace = List[Probability]
+
+def handleTracing[R] { program: () => R / sample }: (R, Trace) / sample = {
+  var trace = []
+  val result = try { program() }
+  with sample { (dist) =>
+    val d = do sample(dist);
+    trace = Cons(d, trace)
+    resume(d)
+  }
+  (result, trace.reverse)
+}
+def handleReusingTrace[R](trace0: Trace) { program: () => R / sample } = handleObserve {
+  var trace = trace0
+  try { program() }
+  with sample { (dist) =>
+    trace match {
+      case Nil() => panic("empty trace")
+      case Cons(t, ts) =>
+        do observe(t, dist)
+        trace = ts; resume(t)
+    }
+  }
+}
+```
+
+### Proposing samples
+
+How the candidates of this algorithm are proposed can vary between different implementations of the algorithm and thus creating inference of the Metropolis-Hastings algorithm.
+The Metropolis-Hastings algorithm proposes a new trace based on the old trace, by recursively adding noise to the samples in the old trace and thus creating a new trace.
+
+```
+def propose(trace: Trace): Trace / sample = {
+  trace match {
+    case Nil() => []
+    case Cons(t, ts) =>
+      val noise = do sample(Gaussian(0.0, 1.0))
+      val proposal = t + noise
+      Cons(proposal, propose(ts))
+  }
+}
+```
+
+### Metropolis-Hastings algorithm
+
+The algorithm is implemented with a helper function
+
+```
+def metropolisStep[A](prob0: Probability, trace0: Trace) { program: Trace => (A, Probability) } = {
+  val trace1 = propose(trace0)
+  val (result1, prob1) = program(trace1)
+  if (prob1 < prob0) {
+    do weight(prob1 / prob0)
+  }
+  ((result1, trace1), prob1)
+}
+```
+
+`metropolisStep` is then called in the algorithm implementation
+
+```
+def metropolisHastingsAlgo[A] { program: () => A / { sample, weight } } = {
+  val ((result0, trace0), prob0) = handleWeight {
+    with handleSample
+    with handleTracing
+    program()
+  }
+  def loop(result: A, trace: Trace, prob: Probability): Unit / emit[A] = {
+    do emit(result)
+    val ((result1, trace1), prob1) =
+    handleSample {
+      with handleRejection
+      metropolisStep(prob, trace) { trace =>
+        with handleWeight
+        with handleReusingTrace(trace)
+        program()
+      }
+    }
+    loop(result1, trace1, prob1)
+  }
+  loop(result0, trace0, prob0)
+}
+```
+
+### Single-Site Metropolis-Hastings
+
+To perform inference over the Metropolis-Hastings algorithm, and for creating the single-site Metropolis-Hastings algorithm, we just need to alter the implementation of the `propose` function.
+In this implementation, the noise is added to only one random sample in the trace and the other samples are reused.
+
+```
+def proposeSingleSite(trace: Trace): Trace / sample = {
+  val tsize = toDouble(size(trace))
+  val rand = do sample(Uniform(0.0, tsize))
+  def putAti(i: Int, p0: List[Double]): List[Double] = {
+    p0 match {
+      case Nil() => []
+      case Cons(p, ps) =>
+        if (i == 0) {
+          val noise = do sample(Gaussian(0.0, 1.0))
+          Cons(p + noise, ps)
+        }
+        else {
+          Cons(p, putAti(i - 1, ps))
+        }
+    }
+  }
+  putAti(floor(rand), trace)
+}
+```
+
+The single-site Metropolis-Hastings algorithm is implemented like the Metropolis-Hastings algorithm above.
+
+```
+def metropolisStepSingleSite[A](prob0: Probability, trace0: Trace) { program: Trace => (A, Probability) } = {
+  val trace1 = proposeSingleSite(trace0)
+  val (result1, prob1) = program(trace1)
+  if (prob1 < prob0) {
+    do weight(prob1 / prob0)
+  }
+  ((result1, trace1), prob1)
+}
+def metropolisHastingsSingleSiteAlgo[A] {program: () => A / { sample, weight } } = {
+  val ((result0, trace0), prob0) = handleWeight {
+    with handleSample
+    with handleTracing
+    program()
+  }
+  def loop(result: A, trace: Trace, prob: Probability): Unit / emit[A] = {
+    do emit(result)
+    val ((result1, trace1), prob1) = handleSample {
+      with handleRejection
+      metropolisStepSingleSite(prob, trace) { trace =>
+        with handleWeight
+        with handleReusingTrace(trace)
+        program()
+      }
+    }
+    loop(result1, trace1, prob1)
+  }
+  loop(result0, trace0, prob0)
+}
+```
+
+## Wrappers
+
+In order to make it easier to use these algorithms without having to call the various effect handlers, we constructed wrappers for the algorithms implemented previously.
+
+```
+def sliceSampling[R](n: Int) { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  with handleSample
+  with sliceSamplingAlgo[R]
+  with handleObserve
+  program()
+}
+def metropolisHastings[R](n: Int) { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  with metropolisHastingsAlgo[R]
+  with handleObserve
+  program()
+}
+def metropolisHastingsSingleSite[R](n: Int) { program: () => R / { sample, observe } }: Unit / { random, emit[R] } = {
+  with metropolisHastingsSingleSiteAlgo[R]
+  with handleObserve
+  program()
+}
+```
+
+## Examples
+
+### Linear Regression
+
+As a short example of how the effects `sample` and `observe` can be used in a model, we construct a linear regression model.
+
+```
+record Point(x: Double, y: Double)
+
+def linearRegression(observations: List[Point]) = {
+  val m = do sample(Gaussian(0.0, 3.0))
+  val c = do sample(Gaussian(0.0, 2.0))
+  observations.foreach {
+    case Point(x, y) => do observe(y, Gaussian(m * x + c, 1.0))
+  }
+  return Point(m, c)
+}
+```
+
+Remember from earlier that `handleObserve` uses the `weight` effect operation.
+Therefore, the call `do observe(y, Gaussian(m * x + c, 1.0))` can be understood as `P(Y | C)` where `Y` are the observations and `C` are the parameters sampled from a Gaussian given by `m ~ N(0, 3)` and `c ~ N(0, 2)`.
+If the chosen parameters do not explain the observations well, it is likely it will be rejected and new parameters will be sampled. Conversely, if the model fits well, it is unlikely it will be rejected.
+
+```effekt:repl
+with linearCongruentialGenerator(1)
+with onEmit[Point] { s => println(s.show) };
+
+limit[Point](5) {
+  with rejectionSampling[Point]
+
+  linearRegression([
+    Point(5.0, 5.0),
+    Point(1.0, 1.0),
+    Point(-2.0, -2.0),
+    Point(3.0, 3.0),
+    Point(20.0, 20.0),
+    Point(5.0, 5.0)
+  ])
+}
+```
+
+### Robot Movements
+
+It is also possible to construct bigger examples on which we can apply these algorithms.
+In this example, the movements of a robot on a 2D-plane are observed. In the center of this plane, at the coordinates (0, 0), there is a radar station that can measure the distance to the robot at any point in time. We try to predict the state of the robot while taking into account the measurements.
+The current state of the robot consists of the position and velocity.
+
+```
+record State(x: Double, y: Double, vx: Double, vy: Double)
+```
+
+In this example, we also define a type alias for `Measurement`:
+
+```
+type Measurement = Double
+type Path = List[State]
+```
+
+For simulating the movement of the robot at a given state, we sample accelerations `xa`, `ya` along the x and y axis from a Gaussian distribution.
+By applying the laws of motion and assuming that the difference between each time step is one, we can derive the update equations given the sampled acceleration for the velocity and the position.
+
+```
+def move(s: State): State / sample =
+  s match {
+    case State(x0, y0, vx0, vy0) =>
+      val xa1 = do sample(Gaussian(0.0, 1.0))
+      val ya1 = do sample(Gaussian(0.0, 1.0))
+      val (x1, y1) = (x0 + vx0 + xa1, y0 + vy0 + ya1)
+      val (vx1, vy1) = (vx0 + xa1, vy0 + ya1)
+      return State(x1, y1, vx1, vy1)
+  }
+```
+
+After predicting the next state of the robot, we get a distance measurement from the radar station.
+We then compute the probabilistic distance given the predicted state using the Euclidean distance.
+Next, we try to reconcile our model with the given measurement by applying the `obeserve` effect operation.
+Similar to linear regression example, we reject our prediction if the observation is unlikely given our previously predicted acceleration.
+
+```
+def measure(s: State, m: Measurement): Unit / observe = {
+  s match {
+    case State(x, y, vx, vy) =>
+      val dist = sqrt(square(x) + square(y))
+      do observe(m, Gaussian(dist, 0.4))
+  }
+}
+```
+
+Putting it all together, we first call `move` for predicting the acceleration and then reconcile it with a given measurement. If the predicted state is unlikely to have produced the measurement, we predict another state. Finally, we return the first state that is not rejected.
+
+```
+def step(s0: State, m1: Measurement): State / { sample, observe } = {
+  val s1 = move(s0)
+  measure(s1, m1)
+  return s1
+}
+```
+
+We can now put our model to the test by running the following simple example:
+
+```effekt:repl
+with linearCongruentialGenerator(1)
+with onEmit[State] { s => println(s.show) };
+
+limit[State](5) {
+  with sliceSampling[State](5)
+
+  val init = State(0.0, 3.0, 2.0, 0.0)
+  step(init, 5.0)
+}
+```
+
+As a more complex example, we now also probabilisticly augment the distance measurements by applying Gaussian noise to it instead of keeping constant.
+More importantly, we now predict five different possible paths consisting of five states each.
+
+```effekt:repl
+with linearCongruentialGenerator(1)
+with onEmit[Path] { path => println(path.show) };
+
+limit[Path](5) {
+  with sliceSampling[Path](1);
+
+  var nextState = State(0.0, 3.0, 2.0, 0.0)
+  var nextdis = 5.0
+  var m = 5
+  var path = [nextState]
+  while (m > 0) {
+    nextState = step(nextState, nextdis)
+    val noise = do sample(Gaussian(0.0, 1.0))
+    nextdis = nextdis + noise
+    path = append(path, [nextState])
+    m = m - 1
+  }
+  path
+}
+```
+
+### Epidemic Spreading
+
+This example simulates a population experiencing an epidemic outbreak with the SIR model. The SIR model divides the population into susceptible **S**, infected **I** and recovered **R**.
+
+```
+record Population(susceptible: Double, infected: Double, recovered: Double)
+```
+
+Having defined our population state, we now try to predict the population state at the next time step:
+
+```
+def progression(p: Population): Population / sample = {
+  p match {
+    case Population(s, i, r) =>
+      val noise = do sample(Gaussian(0.0, 0.01))
+      val s1 = 0.5 * s - noise
+      val i1 = 0.3 * i + 0.5 * s + 0.1 * r + noise
+      val r1 =  0.9 * r + 0.7 * i
+      return Population(s1, i1, r1)
+  }
+}
+```
+
+Next, given a population and a positive-rate of COVID-like test, we gauge how likely it is that the positive-rate was observed assuming the test result is distributed according to a Beta distribution.
+Formally, we compute $\text{Beta}(pr \mid I, 100)$ where $I$ is the number of infected individuals in the predicted population.
+If it is unlikely, the predicted population will be rejected and another one will be proposed.
+
+```
+def test(p: Population, pr: Double): Unit / observe = {
+  p match {
+    case Population(s, i, r) =>
+      val mean = i
+      val sampleSize = 100.0
+      do observe(pr, Beta(mean, sampleSize))
+  }
+}
+```
+
+Like in the previous examples, we combine these two functions into a `step` function:
+
+```
+// approximate next state of population based on current state
+def step(p0: Population, pr1: Double): Population / { sample, observe } = {
+  val p1 = progression(p0)
+  test(p1, pr1)
+  return p1
+}
+```
+
+Testing it on a simple example, is similar as we have seen previously with the robot movement predictions:
+
+```effekt:repl
+with linearCongruentialGenerator(1)
+with onEmit[Population] { p => println(p.show) };
+
+limit[Population](5) {
+  with metropolisHastings[Population](5)
+
+  val init = Population(0.7, 0.2, 0.1)
+  step(init, 0.8)
+}
+```
+
+We again can also predict multiple different scenarios where the disease spreads differently throughout a population:
+
+```effekt:repl
+with linearCongruentialGenerator(1)
+with onEmit[List[Population]] { ps => println(ps.show) }
+
+limit[List[Population]](1) {
+  with metropolisHastings[List[Population]](1)
+
+  var nextPop = Population(0.7, 0.2, 0.1)
+  var nextpr = 0.8
+  var m = 5
+  var path : List[Population] = [nextPop]
+  while (m > 0) {
+    nextPop = step(nextPop, nextpr)
+    val noise = do sample(Gaussian(0.0, 0.01))
+    var nextpr1 = nextpr + noise
+    if (not(nextpr1 < 0.0 || nextpr1 > 1.0)) { nextpr = nextpr1 }
+    path = append(path, [nextPop])
+    m = m - 1
+  }
+  path
+}
+```
+
+The other algorithms of this library can be called used similar as shown in the previous examples.

--- a/samples/Literate Effekt/parser.effekt.md
+++ b/samples/Literate Effekt/parser.effekt.md
@@ -1,0 +1,452 @@
+```
+/*
+ * Copyright (c) 2026 Jonathan Brachthäuser and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+```
+
+# Pull-based Lexing
+In this case study, we show how to implement a _pull-based_ lexer
+in terms of effect handlers.
+
+```effekt:prelude
+import regex
+```
+
+## Tokens and Positions
+First we define the datatypes to represent lexemes (tokens) and positions in the input stream:
+```
+record Position(line: Int, col: Int, index: Int)
+
+type TokenKind { Number(); Ident(); Punct(); Space() }
+
+def infixEq(t1: TokenKind, t2: TokenKind): Bool =
+  (t1, t2) match {
+    case (Number(), Number()) => true
+    case (Ident(), Ident()) => true
+    case (Punct(), Punct()) => true
+    case (Space(), Space()) => true
+    case _ => false
+  }
+
+record Token(kind: TokenKind, text: String, position: Position)
+```
+Tokens simply are tagged with a token type (distinguishing numbers, identifiers, and punctuation),
+the original text of the token and its position.
+
+## The Lexer Effect
+Next, we define the interface to the lexer as an effect signature.
+```
+interface Lexer {
+  def peek(): Option[Token]
+  def next(): Token
+}
+```
+it consists of two effect operations, one to inspect the next token without consuming it (`peek`)
+and one operation to advance in the stream of tokens. This describes the interface of a _pull-based_ lexer as a stream of tokens. Lexemes are only processed on demand.
+An example program using the lexer effect is:
+
+```
+def example1() = {
+  val t1 = do next();
+  val t2 = do next();
+  val t3 = do next();
+  (t1, t2, t3)
+}
+```
+
+## Handling the Lexer Effect with a given List
+A dummy lexer reading lexemes from a given list can be implemented as a handler for the `Lexer` effect. The definition uses the effect `LexerError` to signal the end of the input stream:
+```
+effect LexerError(msg: String, pos: Position): Nothing
+val dummyPosition = Position(0, 0, 0)
+
+def lexerFromList[R](l: List[Token]) { program: => R / Lexer }: R / LexerError = {
+  var in = l;
+  try { program() } with Lexer {
+    def peek() = in match {
+      case Nil() => resume(None())
+      case Cons(tok, _) => resume(Some(tok))
+    }
+    def next() = in match {
+      case Nil() => do LexerError("Unexpected end of input", dummyPosition)
+      case Cons(tok, _) => resume(tok)
+    }
+  }
+}
+```
+We define a separate handler to report lexer errors to the console:
+```
+def report { prog: => Unit / LexerError }: Unit =
+  try { prog() } with LexerError { (msg, pos) =>
+    println(pos.line.show ++ ":" ++ pos.col.show ++ " " ++ msg)
+  }
+```
+Given a list of example tokens
+```
+val exampleTokens = [
+  Token(Ident(), "foo", dummyPosition),
+  Token(Punct(), "(", dummyPosition),
+  Token(Punct(), ")", dummyPosition)
+]
+```
+we can compose the two handlers to run our example consumer:
+```effekt:repl
+report {
+  exampleTokens.lexerFromList {
+    println(example1().show)
+  }
+}
+```
+
+## Handling the Lexer Effect by Processing a String
+Of course, we can also implement a handler for our `Lexer` effect that _actually_
+processes an input and computes the tokens contained therein.
+
+This time, we use a number of different regular expressions to recognize lexemes.
+First, we define the different token types as a list of pairs of regular expressions and token types.
+
+```
+record TokenRx(kind: TokenKind, rx: Regex)
+
+val tokenDesriptors = [
+  TokenRx(Number(), "^[0-9]+".regex),
+  TokenRx(Ident(),  "^[a-zA-Z]+".regex),
+  TokenRx(Punct(),  "^[=,.()\\[\\]{}:]".regex),
+  TokenRx(Space(),  "^[ \t\n]+".regex)
+]
+```
+
+Now, we can define the function `lexer` which receives a string as input as well as a computation `prog` for which it handles the `Lexer` effect:
+
+```
+def lexer[R](in: String) { prog: => R / Lexer } : R / LexerError = {
+  // Additionally, we keep track of the current position in the input stream, by maintaining
+  // three mutable variables for the zero based index, and one-based column and line position.
+  var index = 0
+  var col = 1
+  var line = 1
+  // A few local helper functions ease the handling of the input stream.
+  // At the same time, we need to keep track of the line information.
+  def position() = Position(line, col, index)
+  def input() = in.substring(index)
+  def consume(text: String): Unit = {
+    with ignore[MissingValue]
+    val lines = text.split("\n")
+    val offset = lines.last.length
+    // compute new positions
+    index = index + text.length
+    line = line + lines.size - 1
+    if (lines.size == 1) { col = col + text.length } else { col = offset }
+  }
+  def eos(): Bool = index >= in.length
+  // The function `tryMatch` applies a given token description to the current position of
+  // the input stream, without advancing it. Its companion `tryMatchAll` returns the first token
+  // matched by any of the matches in the given description list.
+  def tryMatch(desc: TokenRx): Option[Token] =
+      desc.rx.exec(input()).map { m => Token(desc.kind, m.matched, position()) }
+
+  def tryMatchAll(descs: List[TokenRx]): Option[Token] = descs match {
+    case Nil() => None()
+    case Cons(desc, descs) => tryMatch(desc).orElse { tryMatchAll(descs) }
+  }
+  // Now defining the lexer is trivial. We just need to use `tryMatchAll` and either consume
+  // the input, or not.
+  try { prog() } with Lexer {
+    def peek() = resume(tryMatchAll(tokenDesriptors))
+    def next() =
+      if (eos())
+        do LexerError("Unexpected EOS", position())
+      else {
+        val tok = tryMatchAll(tokenDesriptors).getOrElse {
+          do LexerError("Cannot tokenize input", position())
+        }
+        consume(tok.text)
+        resume(tok)
+      }
+  }
+}
+```
+Running our above consumer with the string `"foo()"`:
+```effekt:repl
+  report {
+    lexer("foo()") {
+      println(example1().show)
+    }
+  }
+```
+
+## Whitespace Skipping
+Interestingly, a whitespace skipping lexer can be implemented as a _effect transformer_. That is, a handler that (partially) re-raises effect operations.
+
+```
+def skipSpaces(): Unit / Lexer = do peek() match {
+  case None() => ()
+  case Some(Token(Space(), _, _)) => do next(); skipSpaces()
+  case _ => ()
+}
+
+def skipWhitespace[R] { prog: => R / Lexer }: R / Lexer =
+  try { prog() } with Lexer {
+    def peek() = { skipSpaces(); resume(do peek()) }
+    def next() = { skipSpaces(); resume(do next()) }
+  }
+```
+The handler `skipWhitespace` simply skips all spaces by using the `Lexer` effect itself.
+
+```effekt:repl
+  report {
+    lexer("foo (   \n  )") {
+      skipWhitespace {
+        println(example1().show)
+      }
+    }
+  }
+```
+
+---
+layout: docs
+title: Parser
+permalink: docs/casestudies/parser
+redirect_to: docs/casestudies/frontend#parsing
+---
+
+# Parsing
+In this case study, we show how to implement a parser, using the lexer from the
+[Lexer case study](lexer).
+
+---
+
+Parsers can be expressed by using the lexer effect and process the token stream. To model different alternatives in the grammar, we use the following effect for non-determinism:
+
+```
+interface Nondet {
+  def alt(): Bool
+  def fail(msg: String): Nothing
+}
+
+effect Parser = { Nondet, Lexer }
+```
+
+## Parser Combinators
+Given these two effects, we can readily define a host of (imperative) parser combinators.
+We start by the simplest one, which applies a predicate to the next element in the
+input stream and fails, if it does not match.
+
+```
+def accept { p: Token => Bool } : Token / Parser = {
+  val got = do next();
+  if (p(got)) got
+  else do fail("Unexpected token " ++ show(got))
+}
+```
+
+Using `accept`, we can define parsers for the different token types.
+```
+def any() = accept { t => true }
+def accept(exp: TokenKind) = accept { t => t.kind == exp }
+def ident() = accept(Ident()).text
+def number() = accept(Number()).text
+def punct(p: String) = {
+  val tok = accept(Punct())
+  if (tok.text == p) ()
+  else do fail("Expected " ++ p ++ " but got " ++ tok.text)
+}
+def kw(exp: String): Unit / Parser = {
+  val got = ident();
+  if (got == exp) ()
+  else do fail("Expected keyword " ++ exp ++ " but got " ++ got)
+}
+```
+Using the effect for non-deterministic choice `alt`, we can model alternatives, optional matches and various repetitions:
+```
+def or[R] { p: => R } { q: => R } =
+  if (do alt()) { p() } else { q() }
+
+def opt[R] { p: => R }: Option[R] / Parser =
+  or { Some(p()) } { None() }
+
+def many { p: => Unit }: Unit / Parser =
+  or { some { p() } } { () }
+
+def some { p: => Unit }: Unit / Parser =
+  { p(); many { p() } }
+```
+
+## Example: A Simple Expression Language
+We illustrate the usage of the above parser combinators by parsing a simple
+expressions language.
+
+```
+type Tree {
+  Lit(value: Int)
+  Var(name: String)
+  Let(name: String, binding: Tree, body: Tree)
+  App(name: String, arg: Tree)
+}
+```
+
+Let us start by defining the parser for numeric literals.
+```
+def parseNum(): Tree / Parser = {
+  val numText = number();
+  attempt { Lit(numText.toInt) } { do fail("Expected number, but cannot convert input to integer: " ++ numText) }
+}
+```
+We simply call the parser for `number()` and try to convert the
+resulting string to an intenger.
+
+```
+def parseVar(): Tree / Parser =
+  Var(ident())
+
+def parseAtom() = or { parseVar() } { parseNum() }
+```
+Parsing variables is simply a matter of reusing the `ident` parser and changing the
+result. Users of monadic parser combinator libraries might be delighted to see, that we
+do not need to use `map` or something similar to transform the result. The parser is
+simply written in direct style, still offering great flexibility in modifying the
+semantics of effects.
+
+Similarly, we can write parsers for let bindings, by sequentially composing
+our existing parsers:
+
+```
+def parseLet(): Tree / Parser = {
+  kw("let");
+  val name = ident();
+  punct("=");
+  val binding = parseExpr();
+  kw("in");
+  val body = parseExpr();
+  Let(name, binding, body)
+}
+
+def parseGroup() = or { parseAtom() } {
+  punct("(");
+  val res = parseExpr();
+  punct(")");
+  res
+}
+
+def parseApp(): Tree / Parser = {
+  val funName = ident();
+  punct("(");
+  val arg = parseExpr();
+  punct(")");
+  App(funName, arg)
+}
+
+def parseExpr(): Tree / Parser =
+  or { parseLet() } { or { parseApp() } { parseGroup() } }
+
+```
+
+Again, note how naturally the result can be composed from the individual results, much like
+manually writing a recursive descent parser. Compared to handcrafted parsers, the imperative
+parser combinators presented here offer a similar flexibility. At the same time, the semantics
+of `alt` and `fail` is still left open, offering flexibility in the implementation of the actual underlying parsing algorithm.
+
+## Example: Combining Parsers and Local Mutable State
+It is possible to combine the imperative parser combinators with
+local mutable state. The implementation of local variables in Effekt is
+designed to interact well with continuation capture and multiple resumptions.
+This is important for use cases like the parser example where the continuation is
+potentially called multiple times.
+
+The following example implements an example
+```raw
+<EXPR> ::= <NUMBER> | <IDENT> `(` <EXPR> (`,` <EXPR>)*  `)`
+```
+It uses local (mutable) variables to count the number of leafs as semantic action.
+```
+def parseCalls(): Int / Parser =
+  or { number(); 1 } {
+    var count = 1;
+    ident();
+    punct("(");
+    count = count + parseCalls();
+    many {
+        punct(",");
+        count = count + parseCalls()
+    };
+    punct(")");
+    count
+  }
+```
+Notice how the user defined combinator `many` feels like a built-in control operator
+`while`.
+
+## Backtracking Parsers
+As mentioned above, so far we used the non-determinism effects, but did not specify
+what they mean. We could implement depth-first parsing corresponding to recursive descent.
+Alternatively, we also could implement breadth-first parsing. Further, in case of
+ambiguities, we have the choice whether we want to recognize only the first result
+or compute all possible alternative ways to recognize the input.
+
+For this case study, we implement a depth-first parser, computing the first
+successful result. Results are represented by the `ParseResult` datatype.
+The parsing algorithm is simply implemented as a handler for `Parser`.
+
+```
+type ParseResult[R] {
+  ParseSuccess(t: R);
+  ParseFailure(msg: String)
+}
+
+def parse[R](input: String) { p: => R / Parser }: ParseResult[R] = try {
+  lexer(input) { skipWhitespace { ParseSuccess(p()) } }
+} with Nondet {
+  def alt() = resume(true) match {
+    case ParseFailure(msg) => resume(false)
+    case ParseSuccess(res) => ParseSuccess(res)
+  }
+  def fail(msg) = ParseFailure(msg)
+} with LexerError { (msg, pos) =>
+  ParseFailure(msg)
+}
+```
+The handler reuses the lexer implementation of the Lexer case study. The lexer
+raises a `LexerError` in case of an unexpected enf of the input stream or if it cannot
+recognize a token. Those lexer errors are simply converted into failures, which the
+parser can backtrack. To establish the backtracking behavior, it is important that the
+lexer is executed _under_ the parser handler and not the other way around. Only this way
+the lexer positions will be restored when calling the continuation a second time with `resume(false)`.
+
+
+## Running the Examples
+Having implemented a handler for the `Parser` effect, we can run our example "grammars" on some inputs.
+
+```effekt:repl
+println(parse("42") { parseCalls() }.show)
+println(parse("foo(1)") { parseCalls() }.show)
+println(parse("foo(1, 2)") { parseCalls() }.show)
+println(parse("foo(1, 2, 3, 4)") { parseCalls() }.show)
+println(parse("foo(1, 2, bar(4, 5))") { parseCalls() }.show)
+println(parse("foo(1, 2,\nbar(4, 5))") { parseCalls() }.show)
+
+println(parse("}42") { parseExpr() }.show)
+println(parse("42") { parseExpr() }.show)
+println(parse("let x = 4 in 42") { parseExpr() }.show)
+println(parse("let x = let y = 2 in 1 in 42") { parseExpr() }.show)
+println(parse("let x = (let y = 2 in 1) in 42") { parseExpr() }.show)
+println(parse("let x = (let y = f(42) in 1) in 42") { parseExpr() }.show)
+println(parse("let x = (let y = f(let z = 1 in z) in 1) in 42") { parseExpr() }.show)
+```

--- a/vendor/licenses/git_submodule/effekt-vscode.dep.yml
+++ b/vendor/licenses/git_submodule/effekt-vscode.dep.yml
@@ -1,0 +1,30 @@
+---
+name: effekt-vscode
+version: e65ba3bd0a07955f0bb1dceef00ab827151a1801
+type: git_submodule
+homepage: https://github.com/effekt-lang/effekt-vscode.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: This project is licensed under the MIT license. See [LICENSE](LICENSE) for
+    details.
+notices: []


### PR DESCRIPTION
Add Effekt language support with `.effekt` extension and its literate variant with the `.effekt.md` extension.

## Description

This PR adds support for Effekt as a new programming language in Linguist. [Effekt](https://effekt-lang.org/) is a research language with lexical effect handlers and lightweight effect polymorphism. Being in active development since over 5 years, by now it amounted to considerable [research contributions](https://effekt-lang.org/publications.html) as well as adoption in projects experimenting with effects and handlers.

I believe that the current interest in the language as well as its adoption is enough to meet Linguist's requirements. Literate Effekt via `.effekt.md` of course does not match the adoption of `.effekt`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Please remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.effekt
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.effekt.md
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - `inference.effekt`: [probabilistic inference](https://github.com/effekt-lang/effekt/blob/main/examples/casestudies/inference.effekt.md)
      - `parser.effekt`: [lexer](https://github.com/effekt-lang/effekt/blob/main/examples/casestudies/lexer.effekt.md) + [parser](https://github.com/effekt-lang/effekt/blob/main/examples/casestudies/parser.effekt.md)
    - Sample license(s): [MIT](https://github.com/effekt-lang/effekt/blob/main/examples/casestudies/lexer.effekt.md)
  - [x] I have included a syntax highlighting grammar: https://github.com/effekt-lang/effekt-vscode
      <!-- Setting a color is strongly recommended, but optional: `#cccccc` is used by default -->
  - [x] I have added a color
    - Hex value: `#83488d`
    - Rationale: It is used in the color scheme on https://effekt-lang.org/
  - [x] I have updated the heuristics to distinguish my language from others using the same extension.
    - Effekt uses `.effekt` exclusively.
