### PR TITLE
Add support for the Sophia programming language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1524,6 +1524,9 @@
 [submodule "vendor/grammars/vscode-slice"]
 	path = vendor/grammars/vscode-slice
 	url = https://github.com/zeroc-ice/vscode-slice
+[submodule "vendor/grammars/vscode-sophia"]
+	path = vendor/grammars/vscode-sophia
+	url = https://github.com/mradkov/vscode-sophia.git
 [submodule "vendor/grammars/vscode-teal"]
 	path = vendor/grammars/vscode-teal
 	url = https://github.com/teal-language/vscode-teal.git

--- a/grammars.yml
+++ b/grammars.yml
@@ -1366,6 +1366,8 @@ vendor/grammars/vscode-singularity:
 vendor/grammars/vscode-slice:
 - source.ice
 - source.slice
+vendor/grammars/vscode-sophia:
+- source.sophia
 vendor/grammars/vscode-teal:
 - source.teal
 vendor/grammars/vscode-tmdl:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -7439,6 +7439,14 @@ Soong:
   filenames:
   - Android.bp
   language_id: 222900098
+Sophia:
+  type: programming
+  color: "#5319E7"
+  ace_mode: text
+  tm_scope: source.sophia
+  extensions:
+  - ".aes"
+  language_id: 751572298
 SourcePawn:
   type: programming
   color: "#f69e1d"

--- a/samples/Sophia/FundMe.aes
+++ b/samples/Sophia/FundMe.aes
@@ -1,0 +1,65 @@
+/*
+ * A simple crowd-funding example
+ * License: MIT — source: https://github.com/mradkov/vscode-sophia (examples/FundMe.aes)
+ */
+@compiler >= 4
+
+payable contract FundMe =
+
+  record spend_args = { recipient : address
+                      , amount    : int }
+
+  record state = { contributions : map(address, int)
+                 , total         : int
+                 , beneficiary   : address
+                 , deadline      : int
+                 , goal          : int }
+
+  stateful function spend(args : spend_args) =
+    Chain.spend(args.recipient, args.amount)
+
+  entrypoint init(beneficiary, deadline, goal) : state =
+    { contributions = {},
+      beneficiary   = beneficiary,
+      deadline      = deadline,
+      total         = 0,
+      goal          = goal }
+
+  function is_contributor(addr) =
+    Map.member(addr, state.contributions)
+
+  stateful entrypoint contribute() : bool =
+    if(Chain.block_height >= state.deadline)
+      spend({ recipient = Call.caller, amount = Call.value }) // Refund money
+      false
+    else
+      let amount =
+        switch(Map.lookup(Call.caller, state.contributions))
+          None    => Call.value
+          Some(n) => n + Call.value
+      put(state{ contributions[Call.caller] = amount,
+                 total @ tot = tot + Call.value })
+      true
+
+  stateful entrypoint withdraw() : unit =
+    if(Chain.block_height < state.deadline)
+      abort("Cannot withdraw before deadline")
+    if(Call.caller == state.beneficiary)
+      withdraw_beneficiary()
+    elif(is_contributor(Call.caller))
+      withdraw_contributor()
+    else
+      abort("Not a contributor or beneficiary")
+
+  stateful function withdraw_beneficiary() : unit =
+    require(state.total >= state.goal, "Project was not funded")
+    spend({recipient = state.beneficiary,
+           amount    = Contract.balance })
+
+  stateful function withdraw_contributor() : unit =
+    if(state.total >= state.goal)
+      abort("Project was funded")
+    let to = Call.caller
+    spend({recipient = to,
+           amount    = state.contributions[to]})
+    put(state{ contributions @ c = Map.delete(to, c) })

--- a/samples/Sophia/NamespaceExample.aes
+++ b/samples/Sophia/NamespaceExample.aes
@@ -1,0 +1,20 @@
+// License: MIT — source: https://github.com/mradkov/vscode-sophia (examples/Example.aes)
+
+namespace Nsp =
+  function f() = ()
+
+contract interface I =
+  entrypoint f : () => int
+
+contract C =
+  using Nsp
+  using Nsp as N
+  using Nsp for [f]
+  using Nsp hiding [f]
+  using Nsp as N for [f]
+  using Nsp as N hiding [f]
+
+  entrypoint init() = ()
+
+main contract Main =
+  entrypoint init() = ()

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -597,6 +597,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **Snakemake:** [MagicStack/MagicPython](https://github.com/MagicStack/MagicPython)
 - **Solidity:** [davidhq/SublimeEthereum](https://github.com/davidhq/SublimeEthereum)
 - **Soong:** [flimberger/android-system-tools](https://github.com/flimberger/android-system-tools)
+- **Sophia:** [mradkov/vscode-sophia](https://github.com/mradkov/vscode-sophia)
 - **SourcePawn:** [Sarrus1/sourcepawn-vscode](https://github.com/Sarrus1/sourcepawn-vscode)
 - **Spline Font Database:** [Alhadis/language-fontforge](https://github.com/Alhadis/language-fontforge)
 - **Squirrel:** [mathewmariani/squirrel-language](https://github.com/mathewmariani/squirrel-language)

--- a/vendor/licenses/git_submodule/vscode-sophia.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-sophia.dep.yml
@@ -1,0 +1,31 @@
+---
+name: vscode-sophia
+version: bf21a6360dee8b3a39856fb04270cb9590e33862
+type: git_submodule
+homepage: https://github.com/mradkov/vscode-sophia.git
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2019 Milen Radkov
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []


### PR DESCRIPTION
Add Sophia (`.aes`) language support

- Introduced new submodule for vscode-sophia and updated `.gitmodules`
- Added Sophia language definition in `languages.yml`
- Updated `grammars.yml` to include Sophia grammar (`source.sophia`)
- Added sample contracts in `samples/Sophia/`
- Updated `vendor/README.md` to document Sophia support
- Added `vendor/licenses/git_submodule/vscode-sophia.dep.yml` for the grammar submodule (MIT)

## Description

This pull request adds **[Sophia](https://sophia-language.com/)** (æternity smart contract language) to Linguist with the primary extension **`.aes`**.

**Detection:** `languages.yml` registers Sophia as a programming language with `tm_scope: source.sophia`, `ace_mode: text`, and color `#5319E7`.

**Syntax highlighting:** The TextMate-compatible grammar comes from the MIT-licensed VS Code extension repository [mradkov/vscode-sophia](https://github.com/mradkov/vscode-sophia), added as `vendor/grammars/vscode-sophia` via `script/add-grammar` (and recorded in `grammars.yml`).

**Samples:** Two representative `.aes` files live under `samples/Sophia/`. They are adapted from the upstream extension’s `examples/` tree (MIT); paths and license lines in the samples point to the original sources.

**Heuristics:** `.aes` is not currently mapped to any other language in Linguist, so no new heuristic was added.

**Note for reviewers:** Please confirm [usage on GitHub Code Search](https://docs.github.com/en/search-github/github-code-search/about-github-code-search) meets the thresholds in [CONTRIBUTING.md](https://github.com/github-linguist/linguist/blob/master/CONTRIBUTING.md#language-extension-and-filename-usage-requirements) (e.g. indexed file counts and spread across repos). If the search query below should be refined (e.g. additional Sophia-specific tokens), maintainer feedback is welcome.

## Checklist:

- [ ] **I am adding a new extension to a language.**

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com. _(Per [CONTRIBUTING.md](https://github.com/github-linguist/linguist/blob/master/CONTRIBUTING.md#language-extension-and-filename-usage-requirements), maintainers expect **~2000+** indexed `.aes` files in the last year, excluding forks, with reasonable spread across repos—please verify the search link below before merge.)_
    - Search results for each extension:
      - https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.aes+%28entrypoint+OR+contract+OR+%40compiler%29
      - _(Optional refinement: add more Sophia-specific tokens if results are too noisy.)_
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - https://github.com/mradkov/vscode-sophia/blob/master/examples/FundMe.aes (`samples/Sophia/FundMe.aes`)
      - https://github.com/mradkov/vscode-sophia/blob/master/examples/Example.aes (`samples/Sophia/NamespaceExample.aes`, derived from Example.aes)
    - Sample license(s): **MIT** — [vscode-sophia LICENSE](https://github.com/mradkov/vscode-sophia/blob/master/LICENSE)
  - [x] I have included a syntax highlighting grammar: https://github.com/mradkov/vscode-sophia
  - [x] I have added a color
    - Hex value: `#5319E7`
    - Rationale: Distinct purple on the language graph; chosen to read well on light and dark UI; not tied to an official Sophia brand sheet—happy to adjust if maintainers or the æternity/Sophia community prefer a documented brand color.
  - [x] I have updated the heuristics to distinguish my language from others using the same extension. **N/A** — `.aes` is not shared with another Linguist language today; no heuristic change.

- [ ] **I am fixing a misclassified language**

- [ ] **I am changing the source of a syntax highlighting grammar**

- [ ] **I am updating a grammar submodule**

- [ ] **I am adding new or changing current functionality**

- [ ] **I am changing the color associated with a language**
